### PR TITLE
security(isolation): audit the PR's own head; stop admitting unrelated deletions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,10 @@
 # Authentication & session machinery.
 /checkin-app/src/lib/auth.ts                      @dkaygithub @jee7s @thpr
 /checkin-app/src/lib/auth-options.ts              @dkaygithub @jee7s @thpr
+# The site-wide org-login/access gate. security-boundary-isolation.yml's
+# is_boundary() already treats this as a boundary file; without the entry here
+# the isolation check and the review requirement disagree about what it is.
+/checkin-app/src/middleware.ts                    @dkaygithub @jee7s @thpr
 
 # Contract tests that enforce the policy in CI.
 /checkin-app/tests/security/                      @dkaygithub @jee7s @thpr

--- a/.github/workflows/security-boundary-isolation.yml
+++ b/.github/workflows/security-boundary-isolation.yml
@@ -170,6 +170,7 @@ jobs:
             if [ -z "$RETIER" ] && [ "${#BOUNDARY_FILES[@]}" -gt 0 ] &&
                node checkin-app/scripts/check-boundary-decommission.js \
                  --base "$BASE_SHA" \
+                 --head "$HEAD_SHA" \
                  --boundary "${BOUNDARY_FILES[@]}" \
                  -- "${VIOLATIONS[@]}"; then
               echo "Decommission exception: boundary diff is whole-entry removals of dropped"

--- a/.github/workflows/security-boundary-isolation.yml
+++ b/.github/workflows/security-boundary-isolation.yml
@@ -36,7 +36,14 @@ name: Security boundary isolation
 # to its migration (#1446). When check-boundary-decommission.js certifies
 # that shape — byte-strict, fail-closed: partial edits, additions, re-tiers,
 # reorders, and engine-file changes never qualify — the PR may also carry
-# prisma/migrations/** and file deletions, nothing else.
+# prisma/migrations/** and the route files of the removed entries, nothing else.
+#
+# Known fail-closed corner: the certifier requires each removed route entry's
+# derived file to export the verb AT BASE (otherwise absence at head proves
+# nothing). Removing an ALREADY-INERT entry therefore fails certification. That
+# is only visible on a PR that also carries a violation — a bindings drop plus
+# its migration, say — since a boundary-only PR never reaches the certifier.
+# Split the inert-entry removal into its own PR.
 on:
   pull_request:
     # rel/** stays in the trigger even though enforcement is main-only:
@@ -86,7 +93,16 @@ jobs:
           # merge ref (= base.sha and head.sha) local, so no fetch is needed;
           # if either SHA is unreachable the diff below fails loud, never a
           # silent unaudited pass.
-          if ! CHANGED_RAW=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA"); then
+          # --no-renames: with rename detection on, `git diff --name-only`
+          # reports ONLY the destination, so renaming a boundary file never puts
+          # its name in CHANGED, is_boundary never fires, and the step exits
+          # green. Next.js runs only src/middleware.ts, so a rename disables the
+          # site-wide gate exactly as thoroughly as deleting it — and nothing
+          # imports it, so tsc and the build stay green too. D+A surfaces both
+          # names. (The certifier's own --name-status diff deliberately keeps the
+          # destination only; detection needs the source, the deletion rule does
+          # not.)
+          if ! CHANGED_RAW=$(git diff --no-renames --name-only "$BASE_SHA"..."$HEAD_SHA"); then
             echo "::error::Could not diff $BASE_SHA...$HEAD_SHA — a SHA is unreachable. Failing rather than passing this PR unaudited."
             exit 1
           fi
@@ -185,6 +201,12 @@ jobs:
             echo "to a separate PR (registry-first for new routes — an unused"
             echo "defineRoute is inert):"
             printf '  %s\n' "${VIOLATIONS[@]}"
+            # Guarded: a re-tier-only failure has no boundary files, and an
+            # empty array still prints one blank bullet.
+            if [ "${#BOUNDARY_FILES[@]}" -gt 0 ]; then
+              echo "Triggered by these boundary files:"
+              printf '  %s\n' "${BOUNDARY_FILES[@]}"
+            fi
             exit 1
           fi
           echo "Boundary change is properly isolated (companions: tests/docs/schema only)."

--- a/checkin-app/scripts/__tests__/boundary-decommission.test.ts
+++ b/checkin-app/scripts/__tests__/boundary-decommission.test.ts
@@ -116,17 +116,19 @@ const bindingsWithoutFeePayment = dropLines(
 describe('parseArgs', () => {
     // The shell → argv → lib wire is now the sole carrier of the boundary set;
     // pin its slicing so a workflow invocation-line edit can't silently drift.
-    it('splits --base / --boundary / -- into the certifier inputs', () => {
-        expect(parseArgs(['--base', 'X', '--boundary', 'a', 'b', '--', 'v'])).toEqual({
+    it('splits --base / --head / --boundary / -- into the certifier inputs', () => {
+        expect(parseArgs(['--base', 'X', '--head', 'Y', '--boundary', 'a', 'b', '--', 'v'])).toEqual({
             baseSha: 'X',
+            headSha: 'Y',
             boundaryChanged: ['a', 'b'],
             violations: ['v'],
         });
     });
 
     it('yields an empty boundary set when --boundary is omitted', () => {
-        expect(parseArgs(['--base', 'X', '--', 'v'])).toEqual({
+        expect(parseArgs(['--base', 'X', '--head', 'Y', '--', 'v'])).toEqual({
             baseSha: 'X',
+            headSha: 'Y',
             boundaryChanged: [],
             violations: ['v'],
         });
@@ -147,12 +149,19 @@ describe('main argument validation', () => {
     afterEach(() => err.mockRestore());
 
     it('rejects a missing --base', () => {
-        expect(main(['--boundary', 'a', '--', 'v'])).toBe(1);
+        expect(main(['--head', 'Y', '--boundary', 'a', '--', 'v'])).toBe(1);
+    });
+
+    // The PR head sha, never the checked-out HEAD: on a pull_request run that is
+    // refs/pull/N/merge, which folds in main's advance and audits a tree the PR
+    // does not propose. Requiring the flag makes the wrong ref unreachable.
+    it('rejects a missing --head', () => {
+        expect(main(['--base', 'X', '--boundary', 'a', '--', 'v'])).toBe(1);
     });
 
     it('rejects a flag-like token misordered into the --boundary slice', () => {
         // `--boundary a --base sha -- v` slurps --base/sha into the boundary set.
-        expect(main(['--boundary', 'a', '--base', 'sha', '--', 'v'])).toBe(1);
+        expect(main(['--boundary', 'a', '--base', 'sha', '--head', 'sha2', '--', 'v'])).toBe(1);
         expect(err).toHaveBeenCalledWith(expect.stringContaining('--base'));
     });
 });
@@ -330,6 +339,8 @@ describe('certifyDecommission', () => {
         const start = lineOf(REGISTRY_BASE, "// Payments history");
         const registryWithoutFees = dropLines(REGISTRY_BASE, [start - 1, start + 9]);
 
+        const ROUTE_BASE = 'export async function GET() {}';
+
         const attempt = (routeHead: string | null, status: 'M' | 'D') =>
             certifyDecommission({
                 changed: [
@@ -338,15 +349,38 @@ describe('certifyDecommission', () => {
                 ],
                 boundaryChanged: [REGISTRY],
                 violations: [ROUTE_FILE],
-                readBase: files({}),
+                readBase: files({ [ROUTE_FILE]: ROUTE_BASE }),
                 readHead: files({ [REGISTRY]: registryWithoutFees, [ROUTE_FILE]: routeHead }),
             });
 
-        expect(attempt('export async function GET() {}', 'M').ok).toBe(false);
+        expect(attempt(ROUTE_BASE, 'M').ok).toBe(false);
         const killed = attempt(null, 'D');
         expect(killed.reasons).toEqual([]);
         expect(killed.ok).toBe(true);
         expect(killed.removedEndpoints).toEqual(['GET /api/fees/payments']);
+    });
+
+    it('rejects a route kill whose derived path never served the verb at base', () => {
+        const REGISTRY = 'checkin-app/src/security/registry.ts';
+        const ROUTE_FILE = 'checkin-app/src/app/api/fees/payments/route.ts';
+        const start = lineOf(REGISTRY_BASE, "// Payments history");
+        const registryWithoutFees = dropLines(REGISTRY_BASE, [start - 1, start + 9]);
+
+        // A route group, catch-all or `route.tsx` puts the real handler somewhere
+        // the derived path does not name. Absent at head then proves nothing, so
+        // the certifier must refuse rather than bless a still-live endpoint.
+        const r = certifyDecommission({
+            changed: [{ status: 'M', path: REGISTRY }],
+            boundaryChanged: [REGISTRY],
+            violations: [],
+            readBase: files({ [ROUTE_FILE]: null }),
+            readHead: files({ [REGISTRY]: registryWithoutFees, [ROUTE_FILE]: null }),
+        });
+
+        expect(r.ok).toBe(false);
+        expect(r.reasons).toEqual([
+            'GET /api/fees/payments: checkin-app/src/app/api/fees/payments/route.ts does not export GET at base — endpoint-to-file mapping unverified',
+        ]);
     });
 
     it('rejects outbound-surface removals', () => {
@@ -382,7 +416,7 @@ describe('certifyDecommission', () => {
         expect(r.reasons.join()).toContain('middleware.ts');
     });
 
-    it('rejects modified app code riding along, while allowing deletions and migrations', () => {
+    it('rejects riding-along app code, modified or deleted — only the migration is free', () => {
         const r = certifyDecommission({
             changed: [
                 { status: 'M', path: BINDINGS },
@@ -397,7 +431,35 @@ describe('certifyDecommission', () => {
             readHead: files({ [BINDINGS]: bindingsWithoutFeePayment, [SCHEMA]: SCHEMA_DROPPED }),
         });
         expect(r.ok).toBe(false);
+        // fees.ts is a deletion, but this PR removed no route entry, so nothing
+        // implies it. A file nothing imports can still be a security control.
+        expect(r.reasons.map(x => x.split(':')[0])).toEqual([
+            'checkin-app/src/lib/fees.ts',
+            'checkin-app/src/lib/membership.ts',
+        ]);
+        expect(r.reasons[0]).toContain('not a route file of a removed registry entry');
+    });
+
+    it('admits the deleted route file of a removed entry, and only that one', () => {
+        const REGISTRY = 'checkin-app/src/security/registry.ts';
+        const ROUTE_FILE = 'checkin-app/src/app/api/fees/payments/route.ts';
+        const start = lineOf(REGISTRY_BASE, "// Payments history");
+        const registryWithoutFees = dropLines(REGISTRY_BASE, [start - 1, start + 9]);
+
+        const r = certifyDecommission({
+            changed: [
+                { status: 'M', path: REGISTRY },
+                { status: 'D', path: ROUTE_FILE },
+                { status: 'D', path: 'checkin-app/src/lib/fees.ts' },
+            ],
+            boundaryChanged: [REGISTRY],
+            violations: [ROUTE_FILE, 'checkin-app/src/lib/fees.ts'],
+            readBase: files({ [ROUTE_FILE]: 'export async function GET() {}' }),
+            readHead: files({ [REGISTRY]: registryWithoutFees, [ROUTE_FILE]: null }),
+        });
+
+        expect(r.ok).toBe(false);
         expect(r.reasons).toHaveLength(1);
-        expect(r.reasons[0]).toContain('membership.ts');
+        expect(r.reasons[0]).toContain('checkin-app/src/lib/fees.ts');
     });
 });

--- a/checkin-app/scripts/__tests__/boundary-decommission.test.ts
+++ b/checkin-app/scripts/__tests__/boundary-decommission.test.ts
@@ -269,6 +269,8 @@ describe('certifyDecommission', () => {
     };
 
     const BINDINGS = 'checkin-app/src/security/scopeBindings.ts';
+    const REGISTRY = 'checkin-app/src/security/registry.ts';
+    const ROUTE_FILE = 'checkin-app/src/app/api/fees/payments/route.ts';
     const SCHEMA = 'checkin-app/prisma/schema.prisma';
     const MIGRATION = 'checkin-app/prisma/migrations/20260803000000_drop_fee/migration.sql';
 
@@ -334,8 +336,6 @@ describe('certifyDecommission', () => {
     });
 
     it('certifies a route kill only once the verb stops being served', () => {
-        const REGISTRY = 'checkin-app/src/security/registry.ts';
-        const ROUTE_FILE = 'checkin-app/src/app/api/fees/payments/route.ts';
         const start = lineOf(REGISTRY_BASE, "// Payments history");
         const registryWithoutFees = dropLines(REGISTRY_BASE, [start - 1, start + 9]);
 
@@ -361,8 +361,6 @@ describe('certifyDecommission', () => {
     });
 
     it('rejects a route kill whose derived path never served the verb at base', () => {
-        const REGISTRY = 'checkin-app/src/security/registry.ts';
-        const ROUTE_FILE = 'checkin-app/src/app/api/fees/payments/route.ts';
         const start = lineOf(REGISTRY_BASE, "// Payments history");
         const registryWithoutFees = dropLines(REGISTRY_BASE, [start - 1, start + 9]);
 
@@ -384,7 +382,6 @@ describe('certifyDecommission', () => {
     });
 
     it('rejects outbound-surface removals', () => {
-        const REGISTRY = 'checkin-app/src/security/registry.ts';
         const start = lineOf(REGISTRY_BASE, 'defineOutbound({');
         const head = dropLines(REGISTRY_BASE, [start - 1, start + 3]);
         const r = certifyDecommission({
@@ -441,8 +438,6 @@ describe('certifyDecommission', () => {
     });
 
     it('admits the deleted route file of a removed entry, and only that one', () => {
-        const REGISTRY = 'checkin-app/src/security/registry.ts';
-        const ROUTE_FILE = 'checkin-app/src/app/api/fees/payments/route.ts';
         const start = lineOf(REGISTRY_BASE, "// Payments history");
         const registryWithoutFees = dropLines(REGISTRY_BASE, [start - 1, start + 9]);
 

--- a/checkin-app/scripts/check-boundary-decommission.js
+++ b/checkin-app/scripts/check-boundary-decommission.js
@@ -8,7 +8,12 @@
  * PR carries non-companion files:
  *
  *   node checkin-app/scripts/check-boundary-decommission.js \
- *     --base <sha> --boundary [file...] -- [violation...]
+ *     --base <sha> --head <sha> --boundary [file...] -- [violation...]
+ *
+ * --head is the PR's own head sha, never the checked-out `HEAD`: on a
+ * pull_request run that is refs/pull/N/merge — the base merged with the current
+ * tip of main — so it sweeps in main's advance. #1501 moved the workflow off
+ * that ref for the same reason; the certifier must audit the same tree.
  *
  * --boundary is the set of changed files the workflow's is_boundary matched;
  * that shell function is the single source of truth for "what is a boundary
@@ -36,37 +41,40 @@ function gitShow(rev, path) {
 // positionally up to the `--` separator; everything after `--` is a violation.
 function parseArgs(argv) {
     const baseIdx = argv.indexOf('--base');
+    const headIdx = argv.indexOf('--head');
     const boundaryIdx = argv.indexOf('--boundary');
     const sepIdx = argv.indexOf('--');
     const baseSha = baseIdx === -1 ? null : argv[baseIdx + 1] || null;
+    const headSha = headIdx === -1 ? null : argv[headIdx + 1] || null;
     const boundaryEnd = sepIdx === -1 ? argv.length : sepIdx;
     const boundaryChanged = boundaryIdx === -1 ? [] : argv.slice(boundaryIdx + 1, boundaryEnd);
     const violations = sepIdx === -1 ? [] : argv.slice(sepIdx + 1);
-    return { baseSha, boundaryChanged, violations };
+    return { baseSha, headSha, boundaryChanged, violations };
 }
 
 function main(argv) {
-    const { baseSha, boundaryChanged, violations } = parseArgs(argv);
+    const { baseSha, headSha, boundaryChanged, violations } = parseArgs(argv);
     // A flag-like token in the boundary slice means the args were misordered
     // (a flag landed after --boundary and before --); reject with a clear
     // message rather than passing it downstream as a mystery boundary file.
     const strayFlag = boundaryChanged.find(f => f.startsWith('--'));
-    if (!baseSha || strayFlag) {
-        console.error('usage: check-boundary-decommission.js --base <sha> --boundary [file...] -- [violation...]');
+    if (!baseSha || !headSha || strayFlag) {
+        console.error('usage: check-boundary-decommission.js --base <sha> --head <sha> --boundary [file...] -- [violation...]');
         if (strayFlag) console.error(`  '${strayFlag}' looks like a flag inside --boundary — check argument order`);
         return 1;
     }
 
     // Same three-dot semantics as the workflow's file list: compare against
     // the merge base, so a stale PR branch isn't blamed for main's changes.
-    const mergeBase = git(['merge-base', baseSha, 'HEAD']).trim();
-    const changed = git(['diff', '--name-status', `${mergeBase}..HEAD`])
+    const mergeBase = git(['merge-base', baseSha, headSha]).trim();
+    const changed = git(['diff', '--name-status', `${mergeBase}..${headSha}`])
         .split('\n')
         .filter(Boolean)
         .map(line => {
             const [status, ...rest] = line.split('\t');
-            // R/C rows carry two paths; a rename of a boundary file is an edit
-            // of both names, so surface each for the path checks.
+            // R/C rows carry two paths; only the destination is kept. A rename
+            // therefore reads as a change to the new name alone, so an old name
+            // can never be mistaken for a deletion the decommission implies.
             return { status: status[0], path: rest[rest.length - 1] };
         });
 
@@ -75,7 +83,7 @@ function main(argv) {
         boundaryChanged,
         violations,
         readBase: p => gitShow(mergeBase, p),
-        readHead: p => gitShow('HEAD', p),
+        readHead: p => gitShow(headSha, p),
     });
 
     if (!result.ok) {
@@ -90,7 +98,9 @@ function main(argv) {
 }
 
 if (require.main === module) {
-    process.exit(main(process.argv.slice(2)));
+    // exitCode, not process.exit(): the latter can truncate buffered stdout when
+    // it is a pipe, which is how the workflow runs this.
+    process.exitCode = main(process.argv.slice(2));
 }
 
 module.exports = { parseArgs, main };

--- a/checkin-app/scripts/lib/boundary-decommission.js
+++ b/checkin-app/scripts/lib/boundary-decommission.js
@@ -342,22 +342,39 @@ function certifyDecommission({ changed, boundaryChanged, violations, readBase, r
     }
 
     // Every removed route entry's verb must stop being served in this same PR.
+    // The base file must resolve AND export the verb first: absence at head only
+    // proves the endpoint died if the derived path pointed at a file that served
+    // it. A route group, catch-all, rewrite or `route.tsx` makes readHead return
+    // null for a path that was never right, which would certify a live endpoint.
     for (const endpoint of removedEndpoints) {
         const [verb] = endpoint.split(' ');
         const file = endpointToRouteFile(endpoint);
+        const base = readBase(file);
+        if (base == null || !exportsVerb(base, verb)) {
+            reasons.push(`${endpoint}: ${file} does not export ${verb} at base — endpoint-to-file mapping unverified`);
+            continue;
+        }
         const head = readHead(file);
         if (head != null && exportsVerb(head, verb)) {
             reasons.push(`${endpoint}: registry entry removed but ${file} still exports ${verb}`);
         }
     }
 
-    // The exception admits only the two file classes that welded the PR shut:
-    // the drop migration, and deletions of the decommissioned code itself.
+    // The exception admits the drop migration, and deletions the decommission
+    // itself implies — the route files of the endpoints whose entries left. Any
+    // other deletion ships separately: a file nothing imports can still be a
+    // security control, and removing one breaks no build and no test, so "it is
+    // a deletion" is not evidence that it belongs to the drop.
+    const impliedDeletions = new Set(removedEndpoints.map(endpointToRouteFile));
     const deleted = new Set(changed.filter(c => c.status === 'D').map(c => c.path));
     for (const v of violations) {
-        if (!v.startsWith(MIGRATIONS_DIR) && !deleted.has(v)) {
-            reasons.push(`${v}: neither a migration nor a deletion — modified/added app code must ship separately`);
-        }
+        if (v.startsWith(MIGRATIONS_DIR)) continue;
+        if (deleted.has(v) && impliedDeletions.has(v)) continue;
+        reasons.push(
+            deleted.has(v)
+                ? `${v}: deleted, but not a route file of a removed registry entry — unrelated deletions must ship separately`
+                : `${v}: neither a migration nor a deletion — modified/added app code must ship separately`,
+        );
     }
 
     return { ok: reasons.length === 0, reasons, removedModels, removedEndpoints };


### PR DESCRIPTION
Reworked. The previous revision overlapped #1526 on the boundary-set plumbing; that overlap is **gone** — #1526 owns it entirely. This PR is now two commits and nothing else.

## Rebased stack

The base moved, because one of these fixes cannot land on the old one.

```
main
 └── claude/1482-deconflicted    #1482 rebased onto main (was CONFLICTING)
      └── claude/1526-rebased    #1526's three commits, unchanged, dkay's authorship
           └── this PR           two commits
```

**Why the rebase is a prerequisite, not a tidy-up:** `HEAD_SHA` does not exist on `boundary-decommission-exception` — that branch predates #1501, which is where `HEAD_SHA` was introduced. Passing `--head "$HEAD_SHA"` there dies on the unset variable under `set -euo pipefail`. So the `--head` fix below is only expressible after the rebase. #1482 is CONFLICTING against main today regardless, so the rebase has to happen either way; `claude/1482-deconflicted` is it, both conflicts resolved keeping both sides.

If you would rather not take the rebase through my branches, the two commits here apply to whatever #1482 and #1526 land as — but the `--head` commit needs #1501's variable present.

## What changed

### 1. The certifier audited a tree the PR does not propose

#1501 moved the workflow off the checked-out `HEAD` because on a `pull_request` run that ref is `refs/pull/N/merge` — the branch merged with the *current* tip of main. The certifier never got the same treatment: it was still calling `git diff ..HEAD` and `git show HEAD:`.

Two ways that goes wrong, both of them main's changes deciding this PR's verdict:

- main lands a deletion; the certifier sees it in `changed`, and a violation that should ship separately reads as admissible.
- main deletes a route file; the route-kill check sees it absent at head and certifies an endpoint this PR never touched.

`--head` is now **required**, and the workflow passes `HEAD_SHA`. Making it required rather than defaulted is the point: there is no argument list that reaches the wrong ref.

### 2. "It is a deletion" was not evidence of anything

The exception admitted *any* deleted file riding along with a boundary drop. But a file nothing imports can still be a security control — `middleware.ts` is the standing proof — and deleting one breaks no build and no test. The class was much wider than the thing it was written for.

It now admits only the route files of the registry entries this PR removed. Everything else ships separately, deleted or not.

### 3. The route-kill check trusted a path it derived itself

`endpointToRouteFile` maps `GET /api/x` → `src/app/api/x/route.ts` by construction, and absence at head was read as "the endpoint is dead". A route group, catch-all, rewrite or `route.tsx` makes that path wrong — and a path that never existed is absent at head too, so a live endpoint certifies. The base file must now resolve *and* export the verb before its disappearance means anything.

Fail-closed corner, now documented in the workflow header: removing an already-inert entry fails certification. Only reachable on a PR that also carries a violation, since a boundary-only PR never invokes the certifier.

### 4. Rename bypass (from review)

With rename detection on, `git diff --name-only` reports only the destination. So renaming `middleware.ts` never put its name in `CHANGED`, `is_boundary` never fired, and the step exited green — disabling the site-wide org-login gate as thoroughly as deleting it, with tsc and the build green too. `--no-renames` surfaces D+A so both names hit `is_boundary`.

Verified in a scratch repo: default reports `a/mw.ts`; `--no-renames` reports `a/middleware.ts a/mw.ts`.

Note the two file lists now disagree about renames deliberately. Detection needs the *source*; the certifier's `--name-status` diff keeps the destination only, which is correct for the deletion rule — a renamed file is not a deletion and must not be admitted as one. Comment updated to say that, since it previously claimed the opposite.

### Smaller

- `process.exitCode` instead of `process.exit()`, which can truncate buffered stdout on a pipe — how the workflow runs it.
- CODEOWNERS gains `/checkin-app/src/middleware.ts`, exactly the line thpr specified.
- The failure message now names the boundary file that tripped the rule. It printed only the *feature* files; a boundary file is a companion, so a developer touching `middleware.ts` plus one other file read "must ship it ALONE" over a list not containing `middleware.ts`. Guarded — a re-tier-only failure has no boundary files.
- Hoisted the repeated `REGISTRY`/`ROUTE_FILE` test constants.

## On the previous review

@thpr — findings 1, 2, 5, 6 and the constants are done above. Two are already closed on this branch rather than by me:

- **3 (the middleware test models an impossible config)** — the test on this base is dkay's `9d89c48b`, and it already passes `boundaryChanged: [BINDINGS, MIDDLEWARE]`, which is the fix you asked for. It is the production configuration now.
- **4 (the fallback in the description would reopen the finding)** — you were right that `is_boundary` and `is_companion` are a package. Moot here: that fallback is withdrawn with the whole F3 overlap, and both lines live in #1526 unmodified.

`/checkin-app/scripts/tsconfig.json` was already at the block's column on this base — the misalignment you saw was mine, on the branch that realigned the block.

## Verification

- `scripts/__tests__/boundary-decommission.test.ts` — **25/25 pass**. New pins: `--head` required; the base-resolves guard rejects a derived path that never served the verb; the tightened deletion class rejects an unrelated deletion and admits the removed entry's own route file.
- `--head` proven to move the audited tree: same argv, two different `--head` values, two different verdicts on the same file (`deleted, but not a route file…` vs `neither a migration nor a deletion…`).
- Workflow YAML parses; the run block passes `bash -n`.
- CI on this PR is **not meaningful** — it targets a non-`main` branch, and `ci.yml`/`security-boundary-isolation.yml` only trigger on PRs into `main` or `rel/**`. Zero checks will dispatch. Everything above was run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
