### PR TITLE
fix(security): keep the intake note to household leads in the intake state

### DIFF
--- a/checkin-app/src/lib/membership/__tests__/intake.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/intake.test.ts
@@ -204,6 +204,31 @@ describe('getIntakeState', () => {
         expect(state.prefill.household?.notes).toBe('volunteer only, no students');
     });
 
+    it('a non-lead household member (e.g. a youth) gets no intake note in the prefill', async () => {
+        prisma.person.findUnique.mockResolvedValue({
+            id: 3,
+            householdId: 7,
+            household: {
+                name: 'Test Household',
+                intakeNotes: 'we are volunteer only; dad lost his job',
+                line1: '1 Main St', line2: null, city: 'Austin', state: 'TX', postalCode: '78701',
+                householdMembers: [
+                    { id: 1, name: 'Primary', email: 'p@x.com', dateOfBirth: null, allergies: null, isHouseholdLead: true },
+                    { id: 3, name: 'Kid', email: null, dateOfBirth: null, allergies: null, isHouseholdLead: false },
+                ],
+                orgMembership: { status: 'ACTIVE', processes: [] },
+                emergencyContacts: [],
+            },
+        });
+
+        const state = await getIntakeState(3);
+
+        expect(state.isLead).toBe(false);
+        expect(state.prefill.household?.notes).toBeNull();
+        // The rest of the household prefill is family-authored shared data.
+        expect(state.prefill.household?.name).toBe('Test Household');
+    });
+
     it('every process ACTIVE → process is null, no external lookup', async () => {
         prisma.person.findUnique.mockResolvedValue({
             id: 1,

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -111,6 +111,7 @@ export async function getIntakeState(userId: number) {
         allergies: p.allergies,
     });
 
+    const canSeeNotes = leadIds.has(userId) || user.isSysadmin;
     const external = process ? await getExternalStatus(process) : null;
 
     return {
@@ -123,7 +124,11 @@ export async function getIntakeState(userId: number) {
             household: household
                 ? {
                       name: household.name,
-                      notes: household.intakeNotes,
+                      // intakeNotes is the lead's free-text note TO the board
+                      // (pii); household peers — including youth with their own
+                      // logins — must not read it. Same lead gate as
+                      // GET /api/household, and only a lead can write it back.
+                      notes: canSeeNotes ? household.intakeNotes : null,
                       ...pickAddress(household),
                       // The primary (lowest-priority) contact backs the single-field
                       // form. Shown even when flagged invalid so the lead can fix it.


### PR DESCRIPTION
## What

`getIntakeState()` returned `prefill.household.notes` — the household's `intakeNotes` — to any authenticated caller in the household. Two routes expose it:

- `GET /api/membership` — [route.ts:13](https://github.com/innovationtreehouse/checkin/blob/main/checkin-app/src/app/api/membership/route.ts#L13)
- `GET /api/household/intake` — [route.ts:24](https://github.com/innovationtreehouse/checkin/blob/main/checkin-app/src/app/api/household/intake/route.ts#L24)

Both are `withAuth({})`, so a session is the only requirement. `intakeNotes` is the lead's free-text "anything else we should know?" message to the board and the background-check reviewers — hardship, medical and family disclosures, classified `pii` in the schema. A non-lead household member, including a youth with their own login, could read it by loading `/membership` or the program intake panel.

The write path was already gated: `saveIntake` calls `assertLead`. Only the read path was open.

Neither route goes through `handler()`, and the response is a hand-built shape rather than model rows, so the response stripper never saw the field — the boundary layer was not bypassed, the data simply never entered it.

## The fix

One gate in `getIntakeState`, applied where the field is shaped:

```ts
const canSeeNotes = leadIds.has(userId) || user.isSysadmin;
...
notes: canSeeNotes ? household.intakeNotes : null,
```

Same rule as the one #1119 put on `GET /api/household` (`isHouseholdLead || isSysadmin`). It reads the same `leadIds` set that backs the `isLead` flag the function already returns, so the gate and the reported flag cannot drift apart.

Fixing it in the service covers both routes at once; gating each route would have left the next caller of `getIntakeState` to rediscover this.

## Reviewer notes

- **Behaviour change:** a non-lead household member now sees an empty notes box on `/membership` and in the program intake panel. They already received a 403 from `saveIntake`, so no working flow regresses.
- **Not the security boundary:** this touches `src/lib/membership/`, not `src/security/` — no registry, handler, or `@sensitivity` change, so the boundary-isolation rule does not apply.
- **Audited the other `intakeNotes` readers, all clean:** `GET /api/membership/reviews` is reviewer-eligibility gated and holds the pii band deliberately; `renewal.ts`, `external.ts` and `review.ts` read only a `hasNote` boolean, never the text; merge-analyze and people-search exclude it explicitly.

## Testing

`npm run test:ci -- src/lib/membership/__tests__/intake.test.ts` — 30/30 pass, including a new case asserting a non-lead household member gets `notes: null` while the rest of the household prefill is unchanged.