### PR TITLE
fix(auth): a merged-away person loses its session on the next refresh (B1)

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -385,8 +385,9 @@ export const POST = withAuth(
                 await tx.account.updateMany({ where: { userId: mergeId }, data: { userId: keepId } });
                 // DELIBERATE exception to the no-deletion principle above: sessions are
                 // auth artifacts, not person data, and there's no reason for the keeper
-                // to inherit the tombstone's login session. Deleting forces a re-login
-                // (smaller and safer than moving a session onto a different person mid-use).
+                // to inherit the tombstone's login session. Sessions are JWT-strategy, so
+                // this row is not what ends the tombstone's access — the LIVE_PERSON filter
+                // on the jwt() re-sync (auth-options.ts) collapses that token on next refresh.
                 await tx.session.deleteMany({ where: { userId: mergeId } });
                 await tx.orgMembershipProcess.updateMany({ where: { subjectPersonId: mergeId }, data: { subjectPersonId: keepId } });
                 // Both sides can have owed a check — the survivor keeps exactly one.

--- a/checkin-app/src/lib/__tests__/auth-options-jwt.test.ts
+++ b/checkin-app/src/lib/__tests__/auth-options-jwt.test.ts
@@ -128,6 +128,19 @@ describe('jwt() callback — revocation enforcement on refresh', () => {
         expect((result as { isSysadmin?: unknown }).isSysadmin).toBeUndefined();
     });
 
+    it('merge tombstone (LIVE_PERSON filter misses) ⇒ returns an empty token', async () => {
+        // A merged-away person keeps its row and its roles; the filter in the where clause
+        // is what makes the lookup miss, so assert the clause itself as well as the outcome.
+        mockFindUnique.mockResolvedValue(null);
+
+        const result = await callRefresh({ id: 7, isBoardMember: true });
+
+        expect(mockFindUnique).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { id: 7, mergedIntoId: null } }),
+        );
+        expect(result).toEqual({});
+    });
+
     it('DENIED membership ⇒ denied=true and every role flag forced false', async () => {
         mockFindUnique.mockResolvedValue(
             dbParticipant({ household: { orgMembership: { status: 'DENIED' } } }),
@@ -162,7 +175,7 @@ describe('jwt() callback — revocation enforcement on refresh', () => {
         })) as Record<string, unknown>;
 
         expect(mockFindUnique).toHaveBeenCalledWith(
-            expect.objectContaining({ where: { id: 7 } }),
+            expect.objectContaining({ where: { id: 7, mergedIntoId: null } }),
         );
         expect(result.denied).toBe(false);
         expect(result.isSysadmin).toBe(true);
@@ -201,7 +214,7 @@ describe('jwt() callback — initial sign-in branch (user present)', () => {
 
         // Resolved by email on sign-in (not by id).
         expect(mockFindUnique).toHaveBeenCalledWith(
-            expect.objectContaining({ where: { email: 'p@example.com' } }),
+            expect.objectContaining({ where: { email: 'p@example.com', mergedIntoId: null } }),
         );
         expect(result.id).toBe(7);
         expect(result.isSysadmin).toBe(true);
@@ -223,7 +236,7 @@ describe('jwt() callback — initial sign-in branch (user present)', () => {
         // Stored emails are lowercased on write, so the sign-in lookup key must be too —
         // otherwise Google's casing misses the row and NextAuth mints a duplicate.
         expect(mockFindUnique).toHaveBeenCalledWith(
-            expect.objectContaining({ where: { email: 'john.doe@example.com' } }),
+            expect.objectContaining({ where: { email: 'john.doe@example.com', mergedIntoId: null } }),
         );
     });
 

--- a/checkin-app/src/lib/auth-options.ts
+++ b/checkin-app/src/lib/auth-options.ts
@@ -328,7 +328,7 @@ export const authOptions: NextAuthOptions = {
                 // (issue #292); Google's casing is otherwise passed through verbatim.
                 const email = normalizeEmail(user.email);
                 const dbParticipant = await withAuroraResumeRetry(() => prisma.person.findUnique({
-                    where: { email },
+                    where: { email, mergedIntoId: null },
                     include: {
                         toolStatuses: {
                             select: {
@@ -372,7 +372,11 @@ export const authOptions: NextAuthOptions = {
                 // privileges (including the /api/roles endpoint) until the JWT
                 // aged out — up to 30 days.
                 const dbParticipant = await withAuroraResumeRetry(() => prisma.person.findUnique({
-                    where: { id: token.id as number },
+                    // A merge tombstone keeps its row and its roles, so `mergedIntoId: null`
+                    // (LIVE_PERSON) is what makes this lookup miss and collapses the token
+                    // below — otherwise the re-sync re-grants authority from a record every
+                    // other surface refuses to show.
+                    where: { id: token.id as number, mergedIntoId: null },
                     include: {
                         toolStatuses: {
                             select: {


### PR DESCRIPTION
Class B finding **B1** from #1529 — no closing keyword, since that issue tracks 28 findings and only this one is fixed here.

## The bug

The `jwt()` callback re-syncs authority claims from the DB on every request, so a revoked `isSysadmin`/`isKeyholder` cannot outlive the token. It looked the person up by id with no liveness filter:

```ts
prisma.person.findUnique({ where: { id: token.id as number }, ... })
```

A merge never deletes the loser's row — it sets `mergedIntoId`, rewrites the email to `merged-N@deleted.invalid`, and leaves the `PersonRole` rows in place. So the lookup succeeded, the `if (!dbParticipant) return {}` fail-closed branch beneath it never fired, and `assignParticipantClaims` re-stamped all five authority claims from the tombstone on every request for the token's remaining lifetime (`maxAge: 8h`).

Concretely: a board member signed in on a duplicate Person row keeps `isBoardMember` for up to eight hours after ops merges that duplicate away — on a record every roster in the app correctly refuses to show, auditing their actions against a person id the UI renders as "merged."

The mitigation the merge route believed it had does not apply. `session.deleteMany({ where: { userId: mergeId } })` carries a comment saying it "forces a re-login," but sessions are `strategy: "jwt"` and the `Session` table is never consulted.

## The fix

Both Person lookups in the `jwt()` callback carry the `LIVE_PERSON` condition:

- **refresh path** (`token.id`, no `user`) — the lookup now misses, the existing fail-closed branch returns `{}`, and the session collapses on the next refresh.
- **sign-in path** (by email) — the same read, filtered the same way. A tombstone's email is rewritten at merge time so it rarely matches a real Google address, but this is the same class of read and is now closed by construction rather than by that side effect.

The merge route's comment is corrected to name the mechanism that actually ends the tombstone's access instead of the one that does not.

`LIVE_PERSON` is spelled out as the literal `mergedIntoId: null` rather than spread in: the exported constant is typed `Prisma.PersonWhereInput`, and spreading it into `findUnique` widens the argument enough to break Prisma's overload resolution (the `include` stops type-checking). The constant is named in the comment so the connection is greppable.

`livePersonDriftGuard` is unchanged — it excludes `findUnique` by design, on the reasoning that a single-row read cannot leak a tombstone into a roster or inflate a count. That reasoning holds for rosters and counts and is silent about a single-row read that feeds an authorization gate. Widening the guard to cover that case is a separate change, not folded in here.

## Tests

- New case in `auth-options-jwt.test.ts`: a merge tombstone returns an empty token, asserting the `where` clause itself as well as the outcome — the filter is the whole fix, so a regression that drops it should fail loudly rather than pass on a mock that returns null anyway.
- Three existing `where`-clause assertions updated to match.
- `npx tsc --noEmit` clean; the CI unit suite passes: 2544 tests, 268 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
