### PR TITLE
fix(membership): unset membership-year boundary no longer acts as "now"

### DIFF
--- a/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipBgNonBlocking.integration.test.ts
@@ -94,22 +94,38 @@ async function wipe() {
 
 const isVolunteerOf = async (id: number) => (await prisma.orgMembership.findUnique({ where: { id } }))?.isVolunteer;
 
+/**
+ * Turn the fresh-check shortcut on. It needs BOTH halves of the policy — a recheck
+ * window AND a membership-year boundary — since householdBgIsFresh treats either
+ * being unset as "no policy, nothing is fresh". The boundary sits ~30 days out, so
+ * the freshness threshold (boundary - 12 months) lands ~11 months back and a check
+ * stamped today counts as fresh.
+ */
+async function setBgPolicy() {
+    const data = { bgRecheckMonths: 12, orgMembershipYearBoundary: new Date(Date.now() + 30 * 86400_000) };
+    await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, ...data }, update: data });
+}
+
 describe('background check is non-blocking', () => {
     let revA: number, revB: number;
-    let prevBgRecheckMonths = 0;
+    let prevPolicy: { bgRecheckMonths: number; orgMembershipYearBoundary: Date | null } = { bgRecheckMonths: 0, orgMembershipYearBoundary: null };
 
     beforeAll(async () => {
         await wipe();
         // BoardSettings (id=1) is a global singleton; remember what we change so the
         // auto-clear scenario doesn't pollute other suites' BoardSettings reads.
-        prevBgRecheckMonths = (await prisma.boardSettings.findUnique({ where: { id: 1 } }))?.bgRecheckMonths ?? 0;
+        const prev = await prisma.boardSettings.findUnique({ where: { id: 1 } });
+        prevPolicy = {
+            bgRecheckMonths: prev?.bgRecheckMonths ?? 0,
+            orgMembershipYearBoundary: prev?.orgMembershipYearBoundary ?? null,
+        };
         revA = await makeReviewer('RevA');
         revB = await makeReviewer('RevB');
         await makeBoardMember(); // recipient for the paid-reject refund alert
     });
     afterAll(async () => {
         await wipe();
-        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: prevBgRecheckMonths }, update: { bgRecheckMonths: prevBgRecheckMonths } });
+        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, ...prevPolicy }, update: prevPolicy });
         await prisma.$disconnect();
     });
 
@@ -193,7 +209,7 @@ describe('background check is non-blocking', () => {
     });
 
     it('a still-valid prior check auto-clears at submit — no consent needed, pay activates directly', async () => {
-        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
+        await setBgPolicy();
         const { processId, orgMembershipId, householdId } = await makeApplicant('PENDING_EXTERNAL_ACTION', { lastBackgroundCheck: new Date() });
         // Reset the process to INTAKE with the household fully filled so submitIntake passes validation.
         await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
@@ -229,7 +245,7 @@ describe('background check is non-blocking', () => {
     });
 
     it('fresh-check intake shortcut still matches the designation allowlist (#874)', async () => {
-        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
+        await setBgPolicy();
         const { processId, orgMembershipId, householdId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION', { lastBackgroundCheck: new Date() });
         await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
         await prisma.household.update({ where: { id: householdId }, data: { line1: '123 Test St', city: 'Austin', state: 'TX', postalCode: '78701' } });
@@ -245,7 +261,7 @@ describe('background check is non-blocking', () => {
     });
 
     it('renewal with a still-valid background check matches a designation added since the last cycle (#874)', async () => {
-        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
+        await setBgPolicy();
         const { orgMembershipId, processId, leadEmail } = await makeFreshRenewal();
         await prisma.volunteerDesignation.create({ data: { email: leadEmail } });
 
@@ -281,7 +297,7 @@ describe('background check is non-blocking', () => {
     });
 
     it('fresh check + intake note → no auto-clear at submit; the note goes through review (#907)', async () => {
-        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
+        await setBgPolicy();
         const { processId, householdId, leadId } = await makeApplicant('PENDING_EXTERNAL_ACTION', { lastBackgroundCheck: new Date() });
         await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: 'INTAKE' } });
         await prisma.household.update({
@@ -301,7 +317,7 @@ describe('background check is non-blocking', () => {
     });
 
     it('fresh-check renewal with a household note re-reviews instead of opening payment (#907)', async () => {
-        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
+        await setBgPolicy();
         const { orgMembershipId, processId } = await makeFreshRenewal();
         const m = await prisma.orgMembership.findUnique({ where: { id: orgMembershipId } });
         await prisma.household.update({ where: { id: m!.householdId }, data: { intakeNotes: 'note for the reviewer' } });
@@ -385,7 +401,7 @@ describe('background check is non-blocking', () => {
     });
 
     it('renewal with a still-valid background check: bgClearedAt stamped, signature opens payment, paying activates (not stuck)', async () => {
-        await prisma.boardSettings.upsert({ where: { id: 1 }, create: { id: 1, bgRecheckMonths: 12 }, update: { bgRecheckMonths: 12 } });
+        await setBgPolicy();
         const { orgMembershipId, processId } = await makeFreshRenewal();
         await beginRenewal(processId);
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });

--- a/checkin-app/src/app/api/membership-audit/compliance/route.ts
+++ b/checkin-app/src/app/api/membership-audit/compliance/route.ts
@@ -14,7 +14,8 @@ export const dynamic = "force-dynamic";
  * from real data; there is no GRACE status modeled, so no grace bucket. Reasons:
  *   STALE_BG  — ACTIVE household whose background check aged past bgRecheckMonths
  *               (predicate owned by householdBgIsFresh; skipped when the board
- *               hasn't set the policy, i.e. bgRecheckMonths = 0).
+ *               hasn't set the policy — bgRecheckMonths = 0 or no membership-year
+ *               boundary).
  *   REVOKED / DENIED — OrgMembership status.
  *   STUCK_BG_CLEARANCE — a process parked at PENDING_BG_CLEARANCE (paid, never cleared).
  * A household with multiple problems gets all its reason tags.
@@ -22,7 +23,7 @@ export const dynamic = "force-dynamic";
  * Also returns two PERSON-scoped lists (program people may not sit in a member
  * household, so they can't key on householdId):
  *   peopleNeedingBgCheck — program-attached people ≥18 (as of the boundary) with
- *                          no fresh check. Skipped when bgRecheckMonths = 0.
+ *                          no fresh check. Skipped when the policy is unset.
  *   peopleMissingDob     — program-attached people whose age is unknown (no DOB,
  *                          not declared 25+): data hygiene, NOT bg-needed.
  */
@@ -31,7 +32,7 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
     const bgRecheckMonths = settings?.bgRecheckMonths ?? 0;
     const boundary = settings?.orgMembershipYearBoundary
         ? nextBoundary(settings.orgMembershipYearBoundary, new Date())
-        : new Date();
+        : null;
 
     // householdId -> Set<reason>
     const reasons = new Map<number, Set<string>>();
@@ -41,10 +42,11 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
         reasons.set(householdId, set);
     };
 
-    // 1. Stale background check — only when the board has configured a window.
-    //    Reuse householdBgIsFresh per household (stale = returns false); when
-    //    bgRecheckMonths = 0 it always returns false, so skip the whole bucket.
-    if (bgRecheckMonths > 0) {
+    // 1. Stale background check — only when the board has configured a window AND a
+    //    membership-year boundary. Reuse householdBgIsFresh per household (stale =
+    //    returns false); with either half of the policy unset it always returns false,
+    //    so skip the whole bucket rather than tag every household.
+    if (bgRecheckMonths > 0 && boundary) {
         const active = await prisma.orgMembership.findMany({
             where: { status: "ACTIVE" },
             select: { householdId: true },
@@ -74,8 +76,8 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
     //    Subject = union of ProgramParticipant / ProgramVolunteer / Program.leadMentor.
     //    A program lead/volunteer may sit in a household that isn't a member household,
     //    so these are person-scoped, NOT folded into the householdId reason map above.
-    //    Skip the whole bucket when the board hasn't set a recheck window, exactly
-    //    like STALE_BG — bgRecheckMonths = 0 means "no policy", nothing is stale.
+    //    Skip the whole bucket when the board hasn't set a recheck window or a
+    //    membership-year boundary, exactly like STALE_BG — no policy, nothing is stale.
     type PersonRow = {
         personId: number;
         name: string;
@@ -86,7 +88,7 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
     };
     const peopleNeedingBgCheck: PersonRow[] = [];
     const peopleMissingDob: PersonRow[] = [];
-    if (bgRecheckMonths > 0) {
+    if (bgRecheckMonths > 0 && boundary) {
         const threshold = bgFreshThreshold(boundary, bgRecheckMonths);
         const people = await prisma.person.findMany({
             where: {

--- a/checkin-app/src/lib/membership/__tests__/renewal.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/renewal.test.ts
@@ -3,9 +3,9 @@
  */
 /**
  * Unit tests for renewal.ts edge logic (prisma mocked, no DB):
- *   - householdBgIsFresh: the recheckMonths<=0 short-circuit, and the `gte`
- *     threshold boundary (a background check exactly at the threshold counts
- *     as fresh).
+ *   - householdBgIsFresh: the unset-policy short-circuits (recheckMonths<=0, null
+ *     boundary), and the `gte` threshold boundary (a background check exactly at
+ *     the threshold counts as fresh).
  *   - beginRenewal: a process not in PENDING_RENEWAL → RenewalError wrong_phase;
  *     every path lands at PENDING_EXTERNAL_ACTION (a fresh agreement is signed
  *     each cycle) and only a still-valid background check with no household
@@ -51,6 +51,17 @@ describe('householdBgIsFresh', () => {
         prisma.person.findFirst.mockResolvedValue({ id: 1 });
 
         const result = await householdBgIsFresh(42, boundary, 0);
+
+        expect(result).toBe(false);
+        expect(prisma.person.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('no boundary → not fresh, and never queries (membership year unset)', async () => {
+        // An unset boundary must not become "now": that would measure freshness against
+        // a boundary the board never configured and hand out the shortcut.
+        prisma.person.findFirst.mockResolvedValue({ id: 1 });
+
+        const result = await householdBgIsFresh(42, null, 12);
 
         expect(result).toBe(false);
         expect(prisma.person.findFirst).not.toHaveBeenCalled();

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -388,7 +388,7 @@ export async function submitIntake(userId: number) {
     // payment (#907), and the review track is the only surface that shows it —
     // the application instead holds at PENDING_BG_REVIEW (advanceExternalIfComplete).
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, new Date()) : new Date();
+    const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, new Date()) : null;
     const bgFresh = !household.intakeNotes?.trim() && (await householdBgIsFresh(household.id, boundary, settings?.bgRecheckMonths ?? 0));
 
     const advanced = await prisma.orgMembershipProcess.update({

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -187,7 +187,7 @@ export async function beginRenewal(processId: number) {
     });
     if (!membership) throw new RenewalError("not_found", "Membership not found.");
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, new Date()) : new Date();
+    const boundary = settings?.orgMembershipYearBoundary ? nextBoundary(settings.orgMembershipYearBoundary, new Date()) : null;
     const bgFresh = await householdBgIsFresh(membership.householdId, boundary, settings?.bgRecheckMonths ?? 0);
     const hasNote = !!membership.household.intakeNotes?.trim();
 
@@ -313,11 +313,12 @@ export async function beginRenewalForUser(userId: number) {
 
 /**
  * True if EITHER guardian (household lead) has a background check still valid at the boundary,
- * i.e. lastBackgroundCheck >= boundary - recheckMonths. When recheckMonths is 0 (the
- * board hasn't set the policy), nothing counts as fresh — renewals re-run review.
+ * i.e. lastBackgroundCheck >= boundary - recheckMonths. Unset policy — recheckMonths 0 or a
+ * null boundary (no membership year configured) — means nothing counts as fresh; renewals
+ * re-run review rather than measuring freshness against an invented boundary.
  */
-export async function householdBgIsFresh(householdId: number, boundary: Date, recheckMonths: number): Promise<boolean> {
-    if (recheckMonths <= 0) return false;
+export async function householdBgIsFresh(householdId: number, boundary: Date | null, recheckMonths: number): Promise<boolean> {
+    if (recheckMonths <= 0 || !boundary) return false;
     const threshold = monthsBefore(boundary, recheckMonths);
     const fresh = await prisma.person.findFirst({
         where: { householdId, isHouseholdLead: true, lastBackgroundCheck: { gte: threshold }, ...LIVE_PERSON },


### PR DESCRIPTION
Addresses **B21** of the Class B audit register (#1529): *absent configuration acting*.

## The problem

`householdBgIsFresh(householdId, boundary, recheckMonths)` took a non-null `boundary`, so every caller had to supply one. Three of them fell back to `new Date()` when `BoardSettings.orgMembershipYearBoundary` was unset — silently making "now" the membership-year boundary and measuring background-check freshness against a date the board never configured.

The contrast the audit calls out is in the same file family: `bgValidUntilBoundary` returns `null` on an unset boundary, `personBgTriggers` returns `"no membership-year boundary configured"`, and `membership-ops/households` already passes `null`. Only these three sites invented a boundary.

## The fix

The guard belongs in the shared predicate, next to the existing `recheckMonths <= 0` short-circuit, so every caller inherits it rather than each one repeating it:

```ts
export async function householdBgIsFresh(householdId: number, boundary: Date | null, recheckMonths: number) {
    if (recheckMonths <= 0 || !boundary) return false;
```

Call sites:

- **`renewal.ts` `beginRenewal`** and **`intake.ts` `submitIntake`** pass `null` instead of `new Date()`. With no boundary configured the background-check shortcut is no longer handed out — `bgClearedAt` is not pre-stamped and the process runs review, the same fail-closed direction `recheckMonths = 0` already took.
- **`membership-audit/compliance`** had the same fallback. Passing `null` alone would flip it the other way and tag *every* ACTIVE household `STALE_BG`, so both background-check buckets now gate on `bgRecheckMonths > 0 && boundary` — the same "policy unset, skip the bucket" rule the route already applied to `bgRecheckMonths = 0`.

## Reviewer notes

- **Behaviour only changes when `orgMembershipYearBoundary` is null.** With a boundary configured, every path is byte-identical to before.
- The two directions are deliberate and not inconsistent: the intake/renewal shortcut fails **closed** (no shortcut without a policy), while the compliance dashboard **skips the bucket** rather than raising a wall of false STALE_BG rows. Both follow from "unset policy means the rule does not apply".
- No schema, migration, or security-boundary changes.

## Verification

- `tsc --noEmit` — clean.
- Full unit suite — 2544 passed, 268 suites.
- Full integration suite — 131 suites, 1340 passed, against a migrated + seeded local Postgres.
- New unit test: `householdBgIsFresh(42, null, 12)` returns `false` and never issues the person query.

The first CI run failed four cases in `membershipBgNonBlocking.integration.test.ts`, which is exactly the regression net working: those scenarios set `bgRecheckMonths` but never a membership-year boundary, so they had been passing on the `new Date()` fallback this PR removes. Second commit sets both halves of the policy through one `setBgPolicy()` helper (boundary ~30 days out, so the freshness threshold lands ~11 months back and a check stamped today is fresh) and restores the boundary alongside `bgRecheckMonths` in `afterAll` — `BoardSettings` is a global singleton other suites read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
