### PR TITLE
fix(scan): bind the last-keyholder force close to the warning (B2 of #1529)

### DIFF
--- a/checkin-app/prisma/migrations/20260806150000_visit_force_close_warned_at/migration.sql
+++ b/checkin-app/prisma/migrations/20260806150000_visit_force_close_warned_at/migration.sql
@@ -1,0 +1,3 @@
+-- Additive, nullable: old code neither reads nor writes it, so the drain window
+-- is safe. Every existing open visit starts unstamped, i.e. unconfirmed.
+ALTER TABLE "Visit" ADD COLUMN "forceCloseWarnedAt" TIMESTAMP(3);

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -1100,6 +1100,12 @@ model Visit {
   /// @sensitivity:internal
   deletedById       Int?
 
+  /// When the kiosk last showed this keyholder the "others are still here"
+  /// force-close warning. A force close only proceeds if the scan follows a
+  /// fresh stamp, so an ordinary double-tap cannot close the building.
+  /// @sensitivity:internal
+  forceCloseWarnedAt DateTime?
+
   person Person @relation(fields: [personId], references: [id])
   event  Event?      @relation(fields: [associatedEventId], references: [id])
 

--- a/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
@@ -94,12 +94,12 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
         expect(open).toBe(0);
     });
 
-    it('force-closes (departing everyone) when a recent double-badge confirms, then sends post-event emails', async () => {
-        const kVisit = await prisma.visit.create({ data: { personId: isKeyholder.id, arrivedAt: new Date() } });
+    it('force-closes (departing everyone) when the scan follows a fresh warning, then sends post-event emails', async () => {
+        const kVisit = await prisma.visit.create({
+            // The warning was shown 5s ago (within the 60s window) → confirmed.
+            data: { personId: isKeyholder.id, arrivedAt: new Date(), forceCloseWarnedAt: new Date(Date.now() - 5000) },
+        });
         await prisma.visit.create({ data: { personId: normal.id, arrivedAt: new Date() } });
-        // Two isKeyholder badge events 5s apart (<=12s) → confirmed force-close.
-        await prisma.rawBadgeLog.create({ data: { personId: isKeyholder.id, timestamp: new Date(Date.now() - 5000) } });
-        await prisma.rawBadgeLog.create({ data: { personId: isKeyholder.id, timestamp: new Date() } });
 
         const res = await processCheckout(isKeyholder, kVisit.id, 'kiosk');
         const json = await res.json();
@@ -115,9 +115,12 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
         expect(openAnyone).toBe(0);
     });
 
-    it('warns instead of closing when others are present and there is no recent double-badge', async () => {
+    it('warns instead of closing when others are present and no warning has been shown', async () => {
         const kVisit = await prisma.visit.create({ data: { personId: isKeyholder.id, arrivedAt: new Date() } });
         await prisma.visit.create({ data: { personId: normal.id, arrivedAt: new Date() } });
+        // An ordinary double-tap: two badge events 5s apart, no warning behind them.
+        await prisma.rawBadgeLog.create({ data: { personId: isKeyholder.id, timestamp: new Date(Date.now() - 5000) } });
+        await prisma.rawBadgeLog.create({ data: { personId: isKeyholder.id, timestamp: new Date() } });
 
         const res = await processCheckout(isKeyholder, kVisit.id, 'kiosk');
         expect(res.status).toBe(400);
@@ -130,5 +133,9 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
         });
         expect(open).toBe(2);
         expect(processPostEventEmails).not.toHaveBeenCalled();
+
+        // The warning is now stamped, so the next scan may confirm.
+        const stamped = await prisma.visit.findUnique({ where: { id: kVisit.id } });
+        expect(stamped?.forceCloseWarnedAt).toBeInstanceOf(Date);
     });
 });

--- a/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
+++ b/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
@@ -2,26 +2,40 @@
  * The last-keyholder warning is rendered on the kiosk screen. `Person.email` is
  * tier `pii`, so a person with no `name` must degrade to the email local-part —
  * never the full address (#329).
+ *
+ * The force close itself is bound to that warning: it proceeds only for a scan
+ * that follows a fresh `Visit.forceCloseWarnedAt` stamp, never for two badge
+ * events that merely happen to be close together (B2 of #1529).
  */
 import type { Person } from "@/generated/prisma/client";
 import type { DbClient } from "@/lib/db-client";
 import { processCheckout } from "@/lib/scan-service";
 
 jest.mock("@/lib/prisma", () => ({ __esModule: true, default: {} }));
-jest.mock("@/lib/notifications", () => ({ sendCheckinNotifications: jest.fn() }));
+jest.mock("@/lib/notifications", () => ({
+    sendCheckinNotifications: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("@/lib/attendanceTransitions", () => ({
+    findAssociatedEventAt: jest.fn().mockResolvedValue(null),
+    processVisitCheckout: jest.fn().mockResolvedValue([]),
+}));
 
 const keyholder = { id: 1, isKeyholder: true } as Person;
 
 /** Tx-shaped fake (no `$transaction`, so isRootClient() is false). */
-function fakeDb(remaining: Array<{ name: string | null; email: string | null }>): DbClient {
+function fakeDb(
+    remaining: Array<{ name: string | null; email: string | null }>,
+    warnedAt: Date | null = null
+): DbClient {
     return {
         visit: {
             count: jest.fn().mockResolvedValue(0), // no other keyholders present
             findMany: jest.fn().mockResolvedValue(
                 remaining.map((person, i) => ({ id: 100 + i, person }))
             ),
+            findUnique: jest.fn().mockResolvedValue({ forceCloseWarnedAt: warnedAt }),
+            update: jest.fn().mockResolvedValue({}),
         },
-        rawBadgeLog: { findMany: jest.fn().mockResolvedValue([]) }, // no double-badge confirm
     } as unknown as DbClient;
 }
 
@@ -58,4 +72,36 @@ it("omits a person with neither name nor email rather than rendering an empty sl
 
     expect(body.error).toContain("solo");
     expect(body.error).not.toMatch(/, ,|:\n, /);
+});
+
+describe("force close is bound to the warning", () => {
+    const present = [{ name: "Someone Inside", email: "inside@example.com" }];
+
+    it("warns and stamps the visit when no warning has been shown yet", async () => {
+        const db = fakeDb(present);
+        const res = await processCheckout(keyholder, 42, "kiosk", db);
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).facilityClosed).toBeUndefined();
+        expect(db.visit.update).toHaveBeenCalledWith({
+            where: { id: 42 },
+            data: { forceCloseWarnedAt: expect.any(Date) },
+        });
+    });
+
+    it("closes the facility when the scan follows a fresh warning stamp", async () => {
+        const db = fakeDb(present, new Date(Date.now() - 8000));
+        const res = await processCheckout(keyholder, 42, "kiosk", db);
+
+        expect(res.status).toBe(200);
+        expect((await res.json()).facilityClosed).toBe(true);
+    });
+
+    it("warns again when the stamp has expired", async () => {
+        const db = fakeDb(present, new Date(Date.now() - 5 * 60_000));
+        const res = await processCheckout(keyholder, 42, "kiosk", db);
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).type).toBe("warning");
+    });
 });

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -5,6 +5,10 @@ import { apiError, apiJson } from "@/lib/api-response";
 import type { Person } from "@/generated/prisma/client";
 import { type DbClient, isRootClient } from "@/lib/db-client";
 
+/** How long a displayed force-close warning stays confirmable. The scan route's
+ *  3s debounce eats the front of it, so the kiosk copy says "3 to 60 seconds". */
+const FORCE_CLOSE_CONFIRM_MS = 60_000;
+
 /**
  * Process a check-in for a participant who has no active visit.
  *
@@ -91,22 +95,23 @@ export async function processCheckout(
             });
 
             if (remainingUsers.length > 0) {
-                let confirmForceClose = false;
-
-                const recentEvents = await db.rawBadgeLog.findMany({
-                    where: { personId: participant.id },
-                    orderBy: { timestamp: "desc" },
-                    take: 2
+                const ownVisit = await db.visit.findUnique({
+                    where: { id: activeVisitId },
+                    select: { forceCloseWarnedAt: true }
                 });
-
-                if (recentEvents.length === 2) {
-                    const timeDiff = recentEvents[0].timestamp.getTime() - recentEvents[1].timestamp.getTime();
-                    if (timeDiff <= 12000) {
-                        confirmForceClose = true;
-                    }
-                }
+                const warnedAt = ownVisit?.forceCloseWarnedAt;
+                const confirmForceClose =
+                    warnedAt != null && Date.now() - warnedAt.getTime() <= FORCE_CLOSE_CONFIRM_MS;
 
                 if (!confirmForceClose) {
+                    // Stamp the warning on this visit; only a scan that follows the
+                    // stamp may force-close, so the confirmation is bound to the
+                    // warning having been shown rather than to badge adjacency.
+                    await db.visit.update({
+                        where: { id: activeVisitId },
+                        data: { forceCloseWarnedAt: new Date() }
+                    });
+
                     // Never render the raw address (tier `pii`) on the kiosk screen (#329):
                     // fall back to the email local-part, same as getFullAttendance /
                     // kioskdisplay/certifications.
@@ -115,7 +120,7 @@ export async function processCheckout(
                         .filter(Boolean)
                         .join(", ");
                     return apiJson({
-                        error: `Warning! You are the last isKeyholder, but others are here:\n${names}\n\nBadge again within 10 seconds to confirm you've checked them and close the facility.`,
+                        error: `Warning! You are the last isKeyholder, but others are here:\n${names}\n\nBadge again in 3 to 60 seconds to confirm you've checked them and close the facility.`,
                         type: "warning" as const
                     }, 400);
                 }

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -285,6 +285,7 @@ export const classifications = {
         associatedEventId: 'public',
         deletedAt: 'internal',
         deletedById: 'internal',
+        forceCloseWarnedAt: 'internal',
     },
     AuditLog: {
         id: 'internal',


### PR DESCRIPTION
Addresses **B2** of #1529 (no closing keyword — that issue tracks 28 findings; only this one is fixed here).

## The bug

The last-keyholder force close was confirmed by badge adjacency: `processCheckout` read the person's last two `RawBadgeLog` rows and treated any gap ≤ 12000 ms as "the keyholder saw the warning and badged again to confirm." Nothing tied those two rows to the warning having been displayed.

So: the only keyholder badges in at 18:00:00 with four members already inside. At 18:00:07 they badge again — screen didn't refresh, habitual double-tap, past the route's 3 s debounce, so it processes as a checkout. Last keyholder, others present, two badge rows 7 s apart → force close. All four open visits stamped `departedAt = now`, `departedVia = FACILITY_CLOSE`, warning never shown. Four people recorded as having left a building they are standing in, and the next arrival sees an empty roster.

## The fix

Hang the confirmation off the warning instead of off badge timing.

- New nullable `Visit.forceCloseWarnedAt` (`@sensitivity:internal`), migration `20260806150000_visit_force_close_warned_at`.
- Showing the warning stamps that column on the keyholder's own open visit, then returns the 400 warning as before.
- A checkout only force-closes when the visit carries a stamp less than `FORCE_CLOSE_CONFIRM_MS` (60 s) old. `RawBadgeLog` is no longer consulted for this decision.

An unwarned double-tap now warns, which is the correct outcome. Widening or narrowing the old window would not have helped — any adjacency window is reachable by an ordinary double-tap.

Also fixes the two smaller defects in the same block, both called out in the audit:

- The kiosk copy said "Badge again within 10 seconds" while the code allowed 12000 ms.
- The route's 3 s debounce silently eats the front of the window, so a deliberate second badge inside 3 s is ignored rather than confirming. Copy now reads "Badge again in 3 to 60 seconds."

## Server-side, deliberately

The stamp lives in the DB rather than in the kiosk client. `client/client.py` is a dumb display — it posts `{participantId}` and renders `body.error` when `type === "warning"`; it has no state and no way to prove the warning was shown, so a client-sent confirm flag would be the client asserting the exact fact that needs verifying. The same route also serves web/session scans, which have no kiosk UI at all. Nothing on the Pi changes.

## Migration safety

Additive, nullable, single statement — old code neither reads nor writes the column, so the rolling-deploy drain window is safe and no backfill is needed. Every existing open visit starts unstamped, i.e. unconfirmed. No index: the column is only ever read by primary key alongside the checkout.

## Tests

- `scanServiceKeyholderWarning.test.ts` — three new cases: unwarned checkout warns *and* stamps the visit; a scan following a fresh stamp closes the facility; an expired stamp warns again.
- `scanCausalChain.integration.test.ts` — the force-close case now seeds `forceCloseWarnedAt` instead of two adjacent badge rows; the warn case seeds two badge rows 5 s apart to prove adjacency alone no longer closes, and asserts the stamp is written.
- `tsc --noEmit` clean; `npm run test:ci` 2546 pass / 268 suites; scan integration suites (causal chain, checkin, concurrency) 10 pass against a migrated + seeded Postgres.

## Reviewer notes

- The warning path writes inside the scan route's per-participant advisory-lock transaction, which commits normally on the 400 return — the stamp and the `RawBadgeLog` row both persist.
- The stamp is not cleared on a successful close; the visit is closed by the sweep in the same breath, and a fresh check-in creates a new unstamped visit.
- No audit row is written for the force close itself. Out of scope here; say the word if it belongs in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)