### PR TITLE
fix(membership): enforce COI on the EXTERNAL-phase board actions (B7)

### DIFF
--- a/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipExternalAPI.integration.test.ts
@@ -101,6 +101,28 @@ describe('Membership EXTERNAL phase API', () => {
         await prisma.$disconnect();
     });
 
+    it('rejects a board member acting on their OWN household application (COI), with no mutation', async () => {
+        // A board member inside the applicant household: marking the contract or the BG
+        // consent would advance it to PENDING_PAYMENT with no Zoho envelope, no
+        // signature and no consent behind it.
+        const insider = await prisma.person.create({
+            data: { email: `insider-${TAG}@example.com`, name: 'Insider Board', isBoardMember: true, householdId: hhB },
+        });
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: insider.id, isSysadmin: true, isBoardMember: true } });
+
+        for (const action of ['mark-contract', 'mark-bg-consent', 'set-envelope']) {
+            const res = await BOARD_EXTERNAL(boardReq({ processId: procB, action, envelopeId: 'zoho-COI' }) as never);
+            expect(res.status).toBe(403);
+        }
+
+        // Sysadmin is no exemption, and nothing moved.
+        const p = await prisma.orgMembershipProcess.findUnique({ where: { id: procB } });
+        expect(p?.contractSignedAt).toBeNull();
+        expect(p?.bgConsentAt).toBeNull();
+        expect(p?.zohoEnvelopeId).toBe('zoho-B');
+        expect(p?.status).toBe('PENDING_EXTERNAL_ACTION');
+    });
+
     it('rejects a non-board user from the external controls', async () => {
         asUser(plainUserId);
         const res = await BOARD_EXTERNAL(boardReq({ processId: procA, action: 'mark-contract' }) as never);

--- a/checkin-app/src/app/api/membership-ops/applications/external/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/external/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+import prisma from "@/lib/prisma";
 import { withAuth } from "@/lib/auth";
 import { markContractSigned, markBgConsent, setZohoEnvelope, ExternalError } from "@/lib/membership/external";
+import { applicantHousehold } from "@/lib/membership/review";
+import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
@@ -31,6 +34,23 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
     const { processId, action, envelopeId } = body;
     if (!processId || !action) {
         return apiError("processId and action are required", 400);
+    }
+
+    // Conflict of interest, guarding EVERY action here — mirrors certifyPaymentPlan
+    // and overrideBlocked. Marking your own household's contract signed or its BG
+    // consent received advances the application to PENDING_PAYMENT with no Zoho
+    // envelope and no consent behind it. No role bypasses this.
+    //
+    // The guard belongs on the route, not in the service: markContractSigned is also
+    // the Zoho webhook's entry point (system actor), and markBgConsent is what
+    // selfAttestBgConsent calls, where the actor IS the applicant by design.
+    const process = await prisma.orgMembershipProcess.findUnique({
+        where: { id: processId },
+        select: { orgMembershipId: true, subjectPersonId: true },
+    });
+    if (!process) return apiError("Application not found", 404);
+    if (await hasHouseholdConflict(prisma, actorId, await applicantHousehold(prisma, process))) {
+        return apiError("You cannot act on your own household's application — someone outside your household must.", 403);
     }
 
     try {

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -73,8 +73,9 @@ export default function AdminMembershipPage() {
 function ApplicationsBoard() {
   const { data: session } = useSession();
   const me = session?.user;
-  // Conflict of interest: no actor may certify/override their OWN household's
-  // application (mirrors the server guards in certifyPaymentPlan/overrideBlocked).
+  // Conflict of interest: no actor may advance/certify/override their OWN household's
+  // application (mirrors the server guards in certifyPaymentPlan, overrideBlocked and
+  // the EXTERNAL-phase route).
   // The disabled state is UX only — the server is the real enforcement.
   const ownHousehold = (r: ProcessRow) =>
     sharesHousehold(me?.householdId, r.orgMembership?.householdId);
@@ -379,7 +380,7 @@ function ApplicationsBoard() {
                     {r.contractSignedAt ? (
                       <Text c="green" fw={600}>✓ Signed</Text>
                     ) : (
-                      <Button size="xs" fz={15} disabled={busyId === r.id} onClick={() => act(r.id, "mark-contract")}>
+                      <Button size="xs" fz={15} disabled={busyId === r.id || ownHousehold(r)} onClick={() => act(r.id, "mark-contract")}>
                         Confirm contract signed
                       </Button>
                     )}
@@ -389,11 +390,14 @@ function ApplicationsBoard() {
                     {r.bgConsentAt ? (
                       <Text c="green" fw={600}>✓ Received</Text>
                     ) : (
-                      <Button size="xs" fz={15} variant="default" disabled={busyId === r.id} onClick={() => act(r.id, "mark-bg-consent")}>
+                      <Button size="xs" fz={15} variant="default" disabled={busyId === r.id || ownHousehold(r)} onClick={() => act(r.id, "mark-bg-consent")}>
                         Confirm BG consent
                       </Button>
                     )}
                   </div>
+                  {ownHousehold(r) && (
+                    <Text size="xs" c="dimmed">You can&apos;t confirm your own household&apos;s contract or consent — someone outside your household must.</Text>
+                  )}
                 </Group>
               )}
 

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -122,8 +122,11 @@ async function loadReviewer(reviewerId: number) {
  * household INITIAL/RENEWAL it's the membership's household. Null when neither is
  * resolvable (e.g. a PERSON_BG whose subject has no household to exclude) — the
  * caller then applies no exclusion.
+ *
+ * Exported for the EXTERNAL-phase route guard, which holds the same process shape
+ * and needs the same subject household to feed hasHouseholdConflict.
  */
-async function applicantHousehold(db: DbClient, process: { orgMembershipId: number | null; subjectPersonId: number | null }): Promise<number | null> {
+export async function applicantHousehold(db: DbClient, process: { orgMembershipId: number | null; subjectPersonId: number | null }): Promise<number | null> {
     if (process.subjectPersonId) {
         const p = await db.person.findUnique({ where: { id: process.subjectPersonId }, select: { householdId: true } });
         return p?.householdId ?? null;


### PR DESCRIPTION
Addresses **B7** of #1529 — "COI missing on mark-contract / bg-consent".

## The gap

`hasHouseholdConflict` guards `attest`, `overrideBlocked`, `certifyPaymentPlan` and the grant paths. It appeared nowhere in `api/membership-ops/applications/external/route.ts`, whose only gate was `withAuth({ roles: ["isSysadmin", "isBoardMember"] })`. A board member could post `mark-contract` and `mark-bg-consent` against their own household's application and `advanceExternalIfComplete` would move it to `PENDING_PAYMENT` — no Zoho envelope, no signature, no consent.

The register entry reads as a server-side gap with client enforcement intact. It is not. The applications page computes `ownHousehold(r)` but applies it to only four buttons — reset-review, certify, override reset, override approve. The two external buttons were gated on `busyId` alone, so a board member saw enabled controls on their own household's row, clicked them, and the server accepted. No crafted POST required.

## The fix

**Route** — one guard before the `switch`, so it covers `mark-contract`, `mark-bg-consent`, `set-envelope`, and anything added later. Probe the process (404 if absent, mirroring the membership payment-plan refuse route's probe order), resolve the subject household, `hasHouseholdConflict` → 403.

The guard belongs on the route, not in the service:

- `markContractSigned` is also the Zoho webhook's entry point, called with `SYSTEM_ACTOR`.
- `markBgConsent` is what `selfAttestBgConsent` (`POST /api/membership/bg-consent`) calls, where the actor **is** the applicant by design (#875).

A service-level check would break both.

**Helper** — `applicantHousehold` is exported from `review.ts` rather than re-derived inline. It already encodes the subject-household precedence: a `PERSON_BG` process resolves through `subjectPersonId`, an `INITIAL`/`RENEWAL` through `orgMembershipId`. Deriving it a second time in the route would have missed the `PERSON_BG` case, since those rows have a null `orgMembershipId`.

**Client** — the two external buttons take `|| ownHousehold(r)` like the other four, plus the same "someone outside your household must" note. Still UX-only; the route is the enforcement.

## Test

`membershipExternalAPI.integration.test.ts`: a board member inside the applicant household, `isSysadmin: true` to prove no role exempts, all three actions 403, and the process asserted unmutated (`contractSignedAt`, `bgConsentAt`, `zohoEnvelopeId`, `status`).

## Verification

- `tsc --noEmit` clean.
- The target suite: 17/17.
- The first (accidentally un-narrowed) run took the full unit + integration set: 131 suites, 1341 passed, 6 skipped, 0 failed.
- Flow tests not run.

## Reviewer notes

- `set-envelope` is swept up by the pre-switch placement. It is not reachable from the applications page today, and associating an envelope id is less of a decision than the other two — but a uniform guard leaves no gap and is the smaller diff.
- The existence probe precedes the authz check, which is B13's shape. It matches the sibling refuse routes, and the actor is already board-gated by `withAuth`, so nothing leaks. Left alone deliberately.
- Nothing under `checkin-app/src/security/` is touched, so the boundary-isolation rule does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)