### PR TITLE
fix(membership): capture what archive and merge destroy (B18, B19, B20)

### DIFF
--- a/checkin-app/docs/designs/LIFECYCLE.md
+++ b/checkin-app/docs/designs/LIFECYCLE.md
@@ -43,6 +43,14 @@ Dues + background-check + renewal. BG and payment are **parallel tracks** that c
 PERSON_BG`. `RENEWAL_PENDING_BG` is dead-but-guarded legacy (the reachability test asserts it's
 unreachable). Full diagram/table: `../generated/lifecycle/membership.md`.
 
+**Archive is reversible, so ARCHIVED is not sealed.** The board can archive from any
+pre-terminal status (never `ACTIVE`); that write captures the collapsed phase in
+`OrgMembershipProcess.archivedFromStatus`, and `unarchiveApplication` restores from the column —
+never from the audit trail (`docs/rules/principles.md`, *Decisions are reversible*). Both
+directions of edges are generated from one list, `ARCHIVABLE_STATUSES`
+(`lib/membership/lifecycle.ts`), so archive and restore cannot disagree. ARCHIVED is where a
+disposed application comes to rest — an accepting state with an outbound edge, not a terminal one.
+
 **Who fires the payment edge (`PENDING_PAYMENT → ACTIVE`).** The generated matrix records that
 the edge is *legal*, not who drives it. The recovery choke point is `activate()` (renewals route
 through it too — `grantRenewalPayment` is the board-only renewal path, actor `board/sysadmin`).

--- a/checkin-app/docs/generated/lifecycle/enrollment.md
+++ b/checkin-app/docs/generated/lifecycle/enrollment.md
@@ -44,6 +44,6 @@ A blank (`—`) cell is a **deliberate** absent edge — a decision to ratify, n
 - **Initial:** UNENROLLED
 - **Reachable (6):** ACTIVE, PENDING_HELD, PENDING_HELD_DENIED, PENDING_HOLD_FAILED, PENDING_UNPAID, UNENROLLED
 - **Terminal (no outbound edge):** ACTIVE
-- **Accepting terminals:** ACTIVE
+- **Accepting (designated resting states):** ACTIVE
 - **Dead-ends (reachable terminal, not accepting):** (none)
 - **Unreachable (declared but no legal path from ∅):** (none)

--- a/checkin-app/docs/generated/lifecycle/membership.md
+++ b/checkin-app/docs/generated/lifecycle/membership.md
@@ -11,6 +11,13 @@ Generated from the machine’s `TRANSITIONS` (docs/designs/LIFECYCLE.md). Do not
 
 ```mermaid
 stateDiagram-v2
+    ARCHIVED --> BLOCKED: unarchiveApplication
+    ARCHIVED --> INTAKE: unarchiveApplication
+    ARCHIVED --> PENDING_BG_CLEARANCE: unarchiveApplication
+    ARCHIVED --> PENDING_BG_REVIEW: unarchiveApplication
+    ARCHIVED --> PENDING_EXTERNAL_ACTION: unarchiveApplication
+    ARCHIVED --> PENDING_PAYMENT: unarchiveApplication
+    ARCHIVED --> PENDING_RENEWAL: unarchiveApplication
     BLOCKED --> ACTIVE: overrideBlocked approve
     BLOCKED --> ARCHIVED: archiveApplication
     BLOCKED --> PENDING_BG_CLEARANCE: overrideBlocked reset
@@ -49,25 +56,25 @@ stateDiagram-v2
 
 A blank (`—`) cell is a **deliberate** absent edge — a decision to ratify, not an oversight.
 
-| state ╲ event | activate | advanceExternalIfComplete | archiveApplication | attest REJECT | beginRenewal | clearBackgroundCheck | createRenewalProcess | grantRenewalPayment | markContractSigned | overrideBlocked approve | overrideBlocked reset | personAgreementTriggers | personBgTriggers | startIntake | submitIntake |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| ∅ | — | — | — | — | — | — | PENDING_RENEWAL | — | — | — | — | PENDING_EXTERNAL_ACTION | PENDING_BG_REVIEW | INTAKE | — |
-| INTAKE | — | — | ARCHIVED | — | — | — | — | — | — | — | — | — | — | — | PENDING_EXTERNAL_ACTION |
-| PENDING_EXTERNAL_ACTION | — | PENDING_BG_REVIEW, PENDING_PAYMENT | ARCHIVED | — | — | — | — | — | ACTIVE | — | — | — | — | — | — |
-| PENDING_BG_REVIEW | — | — | ARCHIVED | BLOCKED | — | ACTIVE, PENDING_PAYMENT | — | — | — | — | — | — | — | — | — |
-| PENDING_PAYMENT | ACTIVE, PENDING_BG_CLEARANCE | — | ARCHIVED | BLOCKED | — | — | — | ACTIVE | — | — | — | — | — | — | — |
-| PENDING_BG_CLEARANCE | — | — | ARCHIVED | BLOCKED | — | ACTIVE | — | — | — | — | — | — | — | — | — |
-| ACTIVE | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| BLOCKED | — | — | ARCHIVED | — | — | — | — | — | — | ACTIVE | PENDING_BG_CLEARANCE, PENDING_BG_REVIEW, PENDING_EXTERNAL_ACTION, PENDING_PAYMENT | — | — | — | — |
-| PENDING_RENEWAL | — | — | ARCHIVED | — | PENDING_EXTERNAL_ACTION | — | — | — | — | — | — | — | — | — | — |
-| RENEWAL_PENDING_BG | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
-| ARCHIVED | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| state ╲ event | activate | advanceExternalIfComplete | archiveApplication | attest REJECT | beginRenewal | clearBackgroundCheck | createRenewalProcess | grantRenewalPayment | markContractSigned | overrideBlocked approve | overrideBlocked reset | personAgreementTriggers | personBgTriggers | startIntake | submitIntake | unarchiveApplication |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| ∅ | — | — | — | — | — | — | PENDING_RENEWAL | — | — | — | — | PENDING_EXTERNAL_ACTION | PENDING_BG_REVIEW | INTAKE | — | — |
+| INTAKE | — | — | ARCHIVED | — | — | — | — | — | — | — | — | — | — | — | PENDING_EXTERNAL_ACTION | — |
+| PENDING_EXTERNAL_ACTION | — | PENDING_BG_REVIEW, PENDING_PAYMENT | ARCHIVED | — | — | — | — | — | ACTIVE | — | — | — | — | — | — | — |
+| PENDING_BG_REVIEW | — | — | ARCHIVED | BLOCKED | — | ACTIVE, PENDING_PAYMENT | — | — | — | — | — | — | — | — | — | — |
+| PENDING_PAYMENT | ACTIVE, PENDING_BG_CLEARANCE | — | ARCHIVED | BLOCKED | — | — | — | ACTIVE | — | — | — | — | — | — | — | — |
+| PENDING_BG_CLEARANCE | — | — | ARCHIVED | BLOCKED | — | ACTIVE | — | — | — | — | — | — | — | — | — | — |
+| ACTIVE | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| BLOCKED | — | — | ARCHIVED | — | — | — | — | — | — | ACTIVE | PENDING_BG_CLEARANCE, PENDING_BG_REVIEW, PENDING_EXTERNAL_ACTION, PENDING_PAYMENT | — | — | — | — | — |
+| PENDING_RENEWAL | — | — | ARCHIVED | — | PENDING_EXTERNAL_ACTION | — | — | — | — | — | — | — | — | — | — | — |
+| RENEWAL_PENDING_BG | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| ARCHIVED | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | BLOCKED, INTAKE, PENDING_BG_CLEARANCE, PENDING_BG_REVIEW, PENDING_EXTERNAL_ACTION, PENDING_PAYMENT, PENDING_RENEWAL |
 
 ## Reachability
 
 - **Initial:** INTAKE, PENDING_BG_REVIEW, PENDING_RENEWAL
 - **Reachable (9):** ACTIVE, ARCHIVED, BLOCKED, INTAKE, PENDING_BG_CLEARANCE, PENDING_BG_REVIEW, PENDING_EXTERNAL_ACTION, PENDING_PAYMENT, PENDING_RENEWAL
-- **Terminal (no outbound edge):** ACTIVE, ARCHIVED, RENEWAL_PENDING_BG
-- **Accepting terminals:** ACTIVE, ARCHIVED
+- **Terminal (no outbound edge):** ACTIVE, RENEWAL_PENDING_BG
+- **Accepting (designated resting states):** ACTIVE, ARCHIVED
 - **Dead-ends (reachable terminal, not accepting):** (none)
 - **Unreachable (declared but no legal path from ∅):** RENEWAL_PENDING_BG

--- a/checkin-app/prisma/migrations/20260806160000_org_membership_process_archived_from_status/migration.sql
+++ b/checkin-app/prisma/migrations/20260806160000_org_membership_process_archived_from_status/migration.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+ALTER TABLE "OrgMembershipProcess" ADD COLUMN "archivedFromStatus" "OrgMembershipProcessStatus";
+
+-- Backfill rows archived before the column existed, from the audit row that recorded
+-- the transition — the one-time end of reading the log to find a restore target.
+-- Legacy audit payloads are double-encoded JSON strings, hence the unwrap.
+UPDATE "OrgMembershipProcess" p
+SET "archivedFromStatus" = a.old_status::"OrgMembershipProcessStatus"
+FROM (
+    SELECT DISTINCT ON (l."affectedEntityId")
+        l."affectedEntityId" AS process_id,
+        (CASE WHEN jsonb_typeof(l."oldData") = 'string' AND (l."oldData" #>> '{}') LIKE '{%'
+              THEN (l."oldData" #>> '{}')::jsonb ELSE l."oldData" END) ->> 'status' AS old_status
+    FROM "AuditLog" l
+    WHERE l."tableName" = 'OrgMembershipProcess'
+      AND (CASE WHEN jsonb_typeof(l."newData") = 'string' AND (l."newData" #>> '{}') LIKE '{%'
+                THEN (l."newData" #>> '{}')::jsonb ELSE l."newData" END) ->> 'status' = 'ARCHIVED'
+    ORDER BY l."affectedEntityId", l.id DESC
+) a
+WHERE p.id = a.process_id
+  AND p.status = 'ARCHIVED'
+  AND a.old_status IN (
+      'INTAKE', 'PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW', 'PENDING_PAYMENT',
+      'PENDING_BG_CLEARANCE', 'PENDING_RENEWAL', 'RENEWAL_PENDING_BG', 'BLOCKED'
+  );
+
+COMMIT;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -467,6 +467,11 @@ model OrgMembershipProcess {
   kind                  OrgMembershipProcessKind
   /// @sensitivity:internal
   status                OrgMembershipProcessStatus
+  /// The status ARCHIVED collapsed — captured by the archive write itself, since
+  /// afterwards there is nothing left to read. Unarchive restores from this and
+  /// clears it; null on every process that is not (or never was) archived.
+  /// @sensitivity:internal
+  archivedFromStatus    OrgMembershipProcessStatus?
   /// @sensitivity:internal
   stageEnteredAt        DateTime?               @default(now())
   /// @sensitivity:public

--- a/checkin-app/src/app/__tests__/adminBulkImport.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminBulkImport.integration.test.ts
@@ -72,6 +72,7 @@ describe('Admin Bulk Import API Integration Tests', () => {
     afterEach(async () => {
         try {
             // Clean up participants created during tests
+            await prisma.auditLog.deleteMany({ where: { actorId: testAdminId } });
             await prisma.orgMembership.deleteMany({});
             await prisma.person.deleteMany({
                 where: { email: { contains: 'batch-import-test' } }
@@ -193,6 +194,16 @@ describe('Admin Bulk Import API Integration Tests', () => {
             const charlie = await prisma.person.findUnique({ where: { email: 'charlie-batch-import-test@example.com' } });
             expect(charlie).toBeDefined();
             expect(charlie?.householdId).toBe(alice?.householdId);
+
+            // Charlie's own pass-1 household was deleted by the merge — the pre-image
+            // of the destroyed household is on record.
+            const audit = await prisma.auditLog.findFirst({
+                where: { tableName: 'Household', action: 'DELETE', secondaryAffectedEntity: alice!.householdId },
+                orderBy: { id: 'desc' },
+            });
+            expect(audit?.actorId).toBe(testAdminId);
+            expect(audit?.oldData).toMatchObject({ household: { name: "Charlie Batch Import Test's Household" } });
+            expect(audit?.newData).toMatchObject({ mergedIntoHouseholdId: alice!.householdId, movedByImportOfPersonId: charlie!.id });
         });
 
         it('should automatically create households for participants with no household links, and correctly assign lead status based on age', async () => {

--- a/checkin-app/src/app/__tests__/membershipArchiveAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipArchiveAPI.integration.test.ts
@@ -9,8 +9,8 @@
  * sees a clean slate, can file a fresh application (past the partial unique index),
  * and cannot resume or submit the archived one.
  *
- * Also covers board recovery (unarchive): round-trips back to the status recorded
- * in the archive audit row, refuses when there's nothing to restore or the target
+ * Also covers board recovery (unarchive): round-trips back to the status captured
+ * on the row at archive time, refuses when there's nothing to restore or the target
  * is no longer restorable, and refuses when a fresh in-flight process now occupies
  * the one-in-flight slot for the same membership (P2002 → wrong_phase).
  */
@@ -200,12 +200,14 @@ describe('Membership application archive API', () => {
 
     // --- board recovery: unarchive ---
 
-    it('archive→unarchive round-trip restores the audit-recorded prior status', async () => {
+    it('archive→unarchive round-trip restores the captured prior status', async () => {
         const { processId } = await makeProcess('RoundTrip', 'PENDING_PAYMENT');
         asBoard(boardId);
         await ARCHIVE(req({ processId }) as never);
         const archived = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(archived?.status).toBe('ARCHIVED');
+        // The archive write captured the collapsed phase on the row itself.
+        expect(archived?.archivedFromStatus).toBe('PENDING_PAYMENT');
         await new Promise((r) => setTimeout(r, 5)); // ensure stageEnteredAt strictly advances
 
         const res = await UNARCHIVE(unarchiveReq({ processId }) as never);
@@ -214,6 +216,7 @@ describe('Membership application archive API', () => {
 
         const after = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
         expect(after?.status).toBe('PENDING_PAYMENT');
+        expect(after?.archivedFromStatus).toBeNull();
         expect(after!.stageEnteredAt!.getTime()).toBeGreaterThan(archived!.stageEnteredAt!.getTime());
 
         const audit = await prisma.auditLog.findFirst({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: processId }, orderBy: { id: 'desc' } });
@@ -249,9 +252,9 @@ describe('Membership application archive API', () => {
         expect(after?.status).toBe('ARCHIVED');
     });
 
-    it('refuses to unarchive when there is no ARCHIVED audit row to restore from (409 wrong_phase)', async () => {
-        const { processId } = await makeProcess('NoAudit', 'PENDING_PAYMENT');
-        // Hand-set to ARCHIVED without going through archiveApplication — no audit row records it.
+    it('refuses to unarchive when no pre-archive status was captured (409 wrong_phase)', async () => {
+        const { processId } = await makeProcess('NoPreImage', 'PENDING_PAYMENT');
+        // Hand-set to ARCHIVED without going through archiveApplication — archivedFromStatus stays null.
         await prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: 'ARCHIVED' } });
         asBoard(boardId);
         const res = await UNARCHIVE(unarchiveReq({ processId }) as never);

--- a/checkin-app/src/app/api/membership-ops/participants/import/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/import/route.ts
@@ -381,12 +381,29 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
                                 throw new HouseholdLeadLimitError(targetHouseholdId);
                             }
 
+                            // Pre-image of everything this merge destroys, read before the
+                            // deletes: the household row and any OrgMembership on it.
+                            const sourceHousehold = await tx.household.findUnique({ where: { id: sourceHouseholdId } });
+                            const sourceMemberships = await tx.orgMembership.findMany({ where: { householdId: sourceHouseholdId } });
+
                             // Delete memberships from the old source household
                             await tx.orgMembership.deleteMany({ where: { householdId: sourceHouseholdId } });
 
                             // Finally delete the source household (empty now, so the
                             // RESTRICT FK allows it)
                             await tx.household.delete({ where: { id: sourceHouseholdId } });
+
+                            await tx.auditLog.create({
+                                data: {
+                                    actorId: auth.user.id,
+                                    action: "DELETE",
+                                    tableName: "Household",
+                                    affectedEntityId: sourceHouseholdId,
+                                    secondaryAffectedEntity: targetHouseholdId,
+                                    oldData: { household: sourceHousehold, orgMemberships: sourceMemberships },
+                                    newData: { mergedIntoHouseholdId: targetHouseholdId, movedByImportOfPersonId: participantId },
+                                },
+                            });
 
                             // If the row that initiated the merge is an adult with an email, ensure they are a lead
                             if (pr.email) {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -168,14 +168,22 @@ describe("Merge Participants API", () => {
 
         // Full pre-image of the merged-away Person: every field the merge
         // rewrites (tombstone) or moves (backfill), captured before either update.
+        const PRE_IMAGE_KEYS = [
+            "dateOfBirth", "email", "emailSuppressed", "emailVerified", "googleId",
+            "householdId", "id", "image", "isHouseholdLead", "lastBackgroundCheck",
+            "lastWaiverSign", "name", "phone",
+        ].sort();
         const oldData = log?.oldData as Record<string, unknown>;
-        expect(Object.keys(oldData).sort()).toEqual([
-            "dateOfBirth", "email", "googleId", "householdId", "id", "image",
-            "isHouseholdLead", "lastBackgroundCheck", "lastWaiverSign", "name", "phone",
-        ].sort());
+        expect(Object.keys(oldData).sort()).toEqual([...PRE_IMAGE_KEYS, "keeper"].sort());
         expect(oldData.id).toBe(pMergeId);
         expect(oldData.email).toBe("merge@example.com");
         expect(oldData.phone).toBe("123-456-7890");
+
+        // …and the keeper's own pre-image, since a field choice can overwrite it.
+        const keeper = oldData.keeper as Record<string, unknown>;
+        expect(Object.keys(keeper).sort()).toEqual(PRE_IMAGE_KEYS);
+        expect(keeper.id).toBe(pKeepId);
+        expect(keeper.name).toBe("Keep User");
     });
 
     it("should succeed when the MERGED side holds googleId+email and the keeper holds neither (prod P2002 repro)", async () => {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -40,6 +40,29 @@ function valuesConflict(a: unknown, b: unknown): boolean {
     return a !== b;
 }
 
+/**
+ * Pre-image of every field a merge can rewrite on EITHER side — the tombstone's
+ * mangled identity and the keeper's overwritten name/email/DOB alike. Captured
+ * before the transaction, because afterwards neither is readable.
+ */
+function personPreImage(p: Person) {
+    return {
+        id: p.id,
+        googleId: p.googleId,
+        email: p.email,
+        emailVerified: p.emailVerified,
+        emailSuppressed: p.emailSuppressed,
+        phone: p.phone,
+        name: p.name,
+        dateOfBirth: p.dateOfBirth,
+        image: p.image,
+        lastWaiverSign: p.lastWaiverSign,
+        lastBackgroundCheck: p.lastBackgroundCheck,
+        isHouseholdLead: p.isHouseholdLead,
+        householdId: p.householdId,
+    };
+}
+
 /** A login identity is present iff email OR googleId is non-empty. */
 function hasIdentity(p: { email: string | null; googleId: string | null }): boolean {
     return !isEmpty(p.email) || !isEmpty(p.googleId);
@@ -145,7 +168,7 @@ async function archiveDuplicatePersonBg(tx: TxClient, personId: number, actorId:
         // row wins, and we leave it alone.
         const { count } = await tx.orgMembershipProcess.updateMany({
             where: { id: loser.id, ...personBgOpen.where },
-            data: { status: "ARCHIVED", stageEnteredAt: new Date() },
+            data: { status: "ARCHIVED", archivedFromStatus: loser.status, stageEnteredAt: new Date() },
         });
         if (count !== 1) continue;
         await tx.auditLog.create({
@@ -450,21 +473,12 @@ export const POST = withAuth(
                             tableName: "Person",
                             affectedEntityId: keepId,
                             secondaryAffectedEntity: mergeId,
-                            // Full pre-image of every field the merge rewrites (tombstone)
-                            // or moves (backfill) on the merged-away Person, captured
-                            // before either update ran.
+                            // Both pre-images, captured before either update ran: the
+                            // merged-away Person at the top level, the keeper — whose
+                            // name/email/DOB a field choice can overwrite — under `keeper`.
                             oldData: {
-                                id: mergeParticipant.id,
-                                googleId: mergeParticipant.googleId,
-                                email: mergeParticipant.email,
-                                phone: mergeParticipant.phone,
-                                name: mergeParticipant.name,
-                                dateOfBirth: mergeParticipant.dateOfBirth,
-                                image: mergeParticipant.image,
-                                lastWaiverSign: mergeParticipant.lastWaiverSign,
-                                lastBackgroundCheck: mergeParticipant.lastBackgroundCheck,
-                                isHouseholdLead: mergeParticipant.isHouseholdLead,
-                                householdId: mergeParticipant.householdId,
+                                ...personPreImage(mergeParticipant),
+                                keeper: personPreImage(keepParticipant),
                             },
                             newData: { keepId, fieldChoices: choices, moved },
                         }

--- a/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
+++ b/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
@@ -46,8 +46,8 @@ type GuardSite = {
     machine: 'enrollment' | 'membership';
     /** The from-state the guard's CAS names (a state in that machine). */
     from: string;
-    /** Forward transition the guard drives, as [from, to]; omit for a reverse/entry
-     *  guard whose from-state has no outgoing table edge (e.g. unarchive from ARCHIVED). */
+    /** Transition the guard drives, as [from, to]; omit for a guard that changes no
+     *  status at all (e.g. a flag-only deny). */
     edge?: [string, string];
     /** 'spread' = migrated onto fromWhere; 'literal' = intentionally kept literal. */
     mode: 'spread' | 'literal';
@@ -65,7 +65,7 @@ const GUARDS: GuardSite[] = [
     // ── membership (OrgMembershipProcess) ──
     { file: 'lib/membership/external.ts', machine: 'membership', from: 'PENDING_EXTERNAL_ACTION', edge: ['PENDING_EXTERNAL_ACTION', 'PENDING_PAYMENT'], mode: 'spread' },
     { file: 'lib/membership/renewal.ts', machine: 'membership', from: 'PENDING_RENEWAL', edge: ['PENDING_RENEWAL', 'PENDING_EXTERNAL_ACTION'], mode: 'spread' },
-    { file: 'lib/membership/archive.ts', machine: 'membership', from: 'ARCHIVED', mode: 'spread' }, // unarchive: reverse of #13, no ARCHIVED→ edge
+    { file: 'lib/membership/archive.ts', machine: 'membership', from: 'ARCHIVED', edge: ['ARCHIVED', 'PENDING_PAYMENT'], mode: 'spread' }, // unarchive: reverse of #13 (one representative target)
     { file: 'app/api/finance-ops/membership-payment-plans/route.ts', machine: 'membership', from: 'PENDING_PAYMENT', edge: ['PENDING_PAYMENT', 'ACTIVE'], mode: 'spread' },
     { file: 'app/api/finance-ops/membership-payment-plans/refuse/route.ts', machine: 'membership', from: 'PENDING_PAYMENT', mode: 'spread' }, // deny: flag-only, no status edge
 

--- a/checkin-app/src/lib/lifecycle/artifacts.ts
+++ b/checkin-app/src/lib/lifecycle/artifacts.ts
@@ -24,7 +24,8 @@ export type MachineSpec = {
     readonly allStates: readonly string[];
     /** Entry state(s) for reachability. */
     readonly initials: readonly string[];
-    /** Designated legit terminal states (a reachable terminal not here = dead-end). */
+    /** Designated legit resting states (a reachable terminal not here = dead-end).
+     *  A resting state may still have outbound edges — ARCHIVED rests, unarchive leaves. */
     readonly accepting: readonly string[];
     /** Pseudo-states rendered as mermaid `[*]` (e.g. `∅` / `UNENROLLED`). */
     readonly origins: readonly string[];
@@ -95,7 +96,7 @@ export function renderReachabilityReport(spec: MachineSpec): string {
         `- **Initial:** ${list(spec.initials)}`,
         `- **Reachable (${new Set(r.reachable).size}):** ${list(r.reachable)}`,
         `- **Terminal (no outbound edge):** ${list(r.terminal)}`,
-        `- **Accepting terminals:** ${list(spec.accepting)}`,
+        `- **Accepting (designated resting states):** ${list(spec.accepting)}`,
         `- **Dead-ends (reachable terminal, not accepting):** ${list(r.deadEnds)}`,
         `- **Unreachable (declared but no legal path from ∅):** ${list(r.unreachable)}`,
     ].join('\n');

--- a/checkin-app/src/lib/lifecycle/machineSpecs.ts
+++ b/checkin-app/src/lib/lifecycle/machineSpecs.ts
@@ -41,7 +41,9 @@ const ENROLLMENT: MachineSpec = {
 
 /**
  * OrgMembershipProcess (docs/designs/LIFECYCLE.md). `∅` is the origin
- * pseudo-state. `ACTIVE`/`ARCHIVED` are the accepting terminals; the legacy
+ * pseudo-state. `ACTIVE`/`ARCHIVED` are the accepting resting states — ARCHIVED is
+ * where a disposed application stops, not a sealed state (unarchive walks back out
+ * to whatever phase it collapsed); the legacy
  * `RENEWAL_PENDING_BG` (docs/designs/LIFECYCLE.md) is expected to show up as unreachable — the
  * report is where that dead-but-guarded status is meant to surface.
  */

--- a/checkin-app/src/lib/membership/__tests__/lifecycle.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/lifecycle.test.ts
@@ -201,6 +201,15 @@ describe('isLegalTransition covers §5', () => {
         expect(isLegalTransition('ACTIVE', 'ARCHIVED')).toBe(false);
     });
 
+    test('accepts unarchive back to every archivable status — ARCHIVED is not sealed', () => {
+        for (const to of ['INTAKE', 'PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW', 'PENDING_PAYMENT', 'PENDING_BG_CLEARANCE', 'PENDING_RENEWAL', 'BLOCKED'] as ProcessStatus[]) {
+            expect(isLegalTransition('ARCHIVED', to)).toBe(true);
+        }
+        // Nothing is ever archived from these two, so neither is a restore target.
+        expect(isLegalTransition('ARCHIVED', 'RENEWAL_PENDING_BG')).toBe(false);
+        expect(isLegalTransition('ARCHIVED', 'ARCHIVED')).toBe(false);
+    });
+
     test('rejects undeclared edges', () => {
         expect(isLegalTransition('INTAKE', 'ACTIVE')).toBe(false);
         expect(isLegalTransition('ACTIVE', 'PENDING_PAYMENT')).toBe(false);

--- a/checkin-app/src/lib/membership/archive.ts
+++ b/checkin-app/src/lib/membership/archive.ts
@@ -1,18 +1,17 @@
 import { Prisma, type OrgMembershipProcessStatus } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { ReviewError } from "@/lib/membership/review";
-import { normalizeAuditData } from "@/lib/auditPayload";
-import { fromWhere } from "@/lib/membership/lifecycle";
+import { ARCHIVABLE_STATUSES, fromWhere } from "@/lib/membership/lifecycle";
 import { personActor } from "@/lib/auditActor";
 
 /**
  * Board disposal of an abandoned application. Transitions the process to the
- * terminal ARCHIVED status so it drops off every "live application" read (board
+ * ARCHIVED resting status so it drops off every "live application" read (board
  * list + applicant intake) with a single declarative status check — no parallel
  * flag. Only non-ACTIVE (pending) applications are disposable; an ACTIVE
  * membership is never archivable (wrong_phase → 409). Idempotent: archiving an
- * already-ARCHIVED process is a no-op. Who/when/from-phase are captured in the
- * AuditLog row.
+ * already-ARCHIVED process is a no-op. The collapsed phase is captured on the row
+ * itself (`archivedFromStatus`) as part of the same write; who/when go to AuditLog.
  */
 export async function archiveApplication(processId: number, actorId: number) {
     const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
@@ -21,7 +20,10 @@ export async function archiveApplication(processId: number, actorId: number) {
     if (process.status === "ARCHIVED") return { status: "ARCHIVED" as const }; // idempotent no-op
 
     await prisma.$transaction([
-        prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: "ARCHIVED", stageEnteredAt: new Date() } }),
+        prisma.orgMembershipProcess.update({
+            where: { id: processId },
+            data: { status: "ARCHIVED", archivedFromStatus: process.status, stageEnteredAt: new Date() },
+        }),
         prisma.auditLog.create({
             data: {
                 ...personActor(actorId),
@@ -36,45 +38,26 @@ export async function archiveApplication(processId: number, actorId: number) {
     return { status: "ARCHIVED" as const };
 }
 
-/**
- * Restorable in-flight statuses an archived application can return to — every
- * INITIAL/RENEWAL in-flight status plus BLOCKED (pre-existing semantics: a
- * blocked process is the board's to resolve, not archive away). ACTIVE and
- * ARCHIVED itself are never restore targets.
- */
-const RESTORABLE_STATUSES = new Set<OrgMembershipProcessStatus>([
-    "INTAKE",
-    "PENDING_EXTERNAL_ACTION",
-    "PENDING_BG_REVIEW",
-    "PENDING_PAYMENT",
-    "PENDING_BG_CLEARANCE",
-    "PENDING_RENEWAL",
-    "RENEWAL_PENDING_BG",
-    "BLOCKED",
-]);
+/** Restore targets are exactly the statuses archive can come from — one list, so the
+ *  two directions can never disagree (the ARCHIVED↔ edges in TRANSITIONS). */
+const RESTORABLE_STATUSES = new Set<OrgMembershipProcessStatus>(ARCHIVABLE_STATUSES);
 
 /**
- * Board recovery of a wrongly-archived application. ARCHIVED collapses whatever
- * phase the process was in, so the AuditLog is the only record of it: this walks
- * the process's audit rows newest-first and takes the most recent one that
- * recorded the ARCHIVED transition — its oldData.status is the restore target.
- * Refuses (wrong_phase) if no such row exists, or its target isn't a status this
- * can still restore to. The partial unique indexes (membership_one_inflight_*)
- * are the backstop if a fresh in-flight process now occupies that slot for the
- * same membership — caught as P2002 and surfaced as wrong_phase, same shape as
- * every other conflict here.
+ * Board recovery of a wrongly-archived application. The restore target is the
+ * pre-image the archive write captured on the row (`archivedFromStatus`) — not a
+ * reconstruction from the audit trail (principles.md §"Decisions are reversible").
+ * Refuses (wrong_phase) if the column is unset, or holds a status this can no
+ * longer restore to. The partial unique indexes (membership_one_inflight_*) are
+ * the backstop if a fresh in-flight process now occupies that slot for the same
+ * membership — caught as P2002 and surfaced as wrong_phase, same shape as every
+ * other conflict here.
  */
 export async function unarchiveApplication(processId: number, actorId: number) {
     const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new ReviewError("not_found", "Application not found.");
     if (process.status !== "ARCHIVED") throw new ReviewError("wrong_phase", "Only an archived application can be unarchived.");
 
-    const auditRows = await prisma.auditLog.findMany({
-        where: { tableName: "OrgMembershipProcess", affectedEntityId: processId },
-        orderBy: { id: "desc" },
-    });
-    const archivedRow = auditRows.find((row) => (normalizeAuditData(row.newData) as { status?: string } | null)?.status === "ARCHIVED");
-    const target = (normalizeAuditData(archivedRow?.oldData) as { status?: string } | null)?.status as OrgMembershipProcessStatus | undefined;
+    const target = process.archivedFromStatus ?? undefined;
     if (!target || !RESTORABLE_STATUSES.has(target)) {
         throw new ReviewError("wrong_phase", "Cannot determine the state this application was archived from.");
     }
@@ -87,7 +70,7 @@ export async function unarchiveApplication(processId: number, actorId: number) {
             const { count } = await tx.orgMembershipProcess.updateMany({
                 // #13 unarchive CAS from-state (ARCHIVED) from the definition (#1080).
                 where: { id: processId, ...fromWhere("ARCHIVED") },
-                data: { status: target, stageEnteredAt: new Date() },
+                data: { status: target, archivedFromStatus: null, stageEnteredAt: new Date() },
             });
             if (count !== 1) return;
             await tx.auditLog.create({

--- a/checkin-app/src/lib/membership/lifecycle.ts
+++ b/checkin-app/src/lib/membership/lifecycle.ts
@@ -285,7 +285,23 @@ export type OriginState = "∅";
 type TState = ProcessStatus | OriginState;
 
 /**
- * The 14 machine edges (docs/designs/LIFECYCLE.md), each carrying the (unchanged) enforcement site
+ * Every pre-terminal status the board can archive from — and, reversed, the only
+ * statuses unarchive can restore to (§5 #13). ACTIVE is never archivable; the
+ * legacy RENEWAL_PENDING_BG is unreachable, so nothing is ever archived from it
+ * and it is not a restore target either.
+ */
+export const ARCHIVABLE_STATUSES = [
+    "INTAKE",
+    "PENDING_EXTERNAL_ACTION",
+    "PENDING_BG_REVIEW",
+    "PENDING_PAYMENT",
+    "PENDING_BG_CLEARANCE",
+    "PENDING_RENEWAL",
+    "BLOCKED",
+] as const satisfies readonly ProcessStatus[];
+
+/**
+ * The machine edges (docs/designs/LIFECYCLE.md), each carrying the (unchanged) enforcement site
  * it feeds. Not a runtime executor — powers isLegalTransition + reachability in
  * tests/doc-artifacts. Flag-only stamps (contractSignedAt/bgConsentAt) are not
  * status edges and are omitted; they gate the advance, not a state change.
@@ -323,13 +339,24 @@ export const TRANSITIONS: readonly Transition<TState, string, ProcessKind>[] = [
     { from: "BLOCKED", to: "PENDING_EXTERNAL_ACTION", event: "overrideBlocked reset", actor: "board/sysadmin", guardSite: "review.ts:368 (RENEWAL, no consent)", kind: "RENEWAL", legacy: true },
     { from: "BLOCKED", to: "ACTIVE", event: "overrideBlocked approve", actor: "board/sysadmin", guardSite: "review.ts:411 FOR UPDATE (paid)" },
     // Archive (§5 #13) — every pre-terminal status
-    ...(["INTAKE", "PENDING_EXTERNAL_ACTION", "PENDING_BG_REVIEW", "PENDING_PAYMENT", "PENDING_BG_CLEARANCE", "PENDING_RENEWAL", "BLOCKED"] as const).map(
+    ...ARCHIVABLE_STATUSES.map(
         (from): Transition<TState, string, ProcessKind> => ({
             from,
             to: "ARCHIVED",
             event: "archiveApplication",
             actor: "board",
             guardSite: "archive.ts:13 (status≠ACTIVE, idempotent)",
+        }),
+    ),
+    // Unarchive (§5 #13 reversed) — back to the status the archive write captured.
+    // ARCHIVED is where processes come to rest, but it is not sealed.
+    ...ARCHIVABLE_STATUSES.map(
+        (to): Transition<TState, string, ProcessKind> => ({
+            from: "ARCHIVED",
+            to,
+            event: "unarchiveApplication",
+            actor: "board",
+            guardSite: "archive.ts:88 updateMany CAS + P2002",
         }),
     ),
 ];

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -82,6 +82,7 @@ export const classifications = {
         subjectPersonId: 'public',
         kind: 'public',
         status: 'internal',
+        archivedFromStatus: 'internal',
         stageEnteredAt: 'internal',
         createdAt: 'public',
         zohoEnvelopeId: 'internal',


### PR DESCRIPTION
Three Class B findings from the domain-register audit (#1529), all in the same neighbourhood: a decision that collapses structure without recording what it collapsed. **No closing keyword** — #1529 tracks 28 findings and stays open for the rest.

## B19 — unarchive reconstructed its restore target from the audit log

`unarchiveApplication` walked the process's `AuditLog` rows newest-first, found the one that recorded the ARCHIVED transition, and took its `oldData.status` as the restore target — throwing when no such row existed. That is reconstruction standing in as a design, which `docs/rules/principles.md` ("Decisions are reversible") names explicitly as a fallback that must not be one: it works until a log is pruned or a payload shape changes.

The archive write now captures the collapsed phase on the row itself, in a new nullable `OrgMembershipProcess.archivedFromStatus`; unarchive reads the column and clears it on restore. The audit walk is deleted, not demoted to a legacy path — the migration backfills existing ARCHIVED rows from the log once.

## B18 — pre-images that were not captured

- **Participant merge** recorded the loser's pre-image only. The keeper's overwritten name, email and DOB were recorded nowhere, and `emailVerified`/`emailSuppressed` were uncaptured on both sides despite the merge rewriting them. One `personPreImage()` now serves both sides; the keeper's lands under `oldData.keeper`.
- **Import route's household merge** deleted a `Household` and its `OrgMembership` while writing zero audit rows. It now reads both pre-images before the deletes and writes a `DELETE`/`Household` row carrying them.

## B20 — the state machine disagreed with itself

`TRANSITIONS` had no `ARCHIVED → *` edge, so `isLegalTransition('ARCHIVED', X)` was false for every X and the drift-checked artifact called ARCHIVED terminal — while `unarchiveApplication` really moved it back to any restorable status. The parity test had already noticed and routed around it with an apology comment.

Both directions are now generated from one exported list, `ARCHIVABLE_STATUSES`, so archive and restore cannot drift apart. Consequences worth a reviewer's eye:

- **`RENEWAL_PENDING_BG` is dropped as a restore target.** It is unreachable dead-but-guarded legacy, so nothing can ever be archived from it and no row could name it as a target — the entry was vacuous, and adding the edge instead would have made it reachable and broken the reachability test.
- **ARCHIVED is still accepting, no longer terminal.** The artifact's `Accepting terminals` label stopped being true for it, so the renderer now emits `Accepting (designated resting states)` — this touches the enrollment artifact too, which is the only reason that file is in the diff.
- `isLegalTransition('ARCHIVED', 'ACTIVE')` stays false; ACTIVE was never archivable.
- `docs/designs/LIFECYCLE.md` never mentioned archive or unarchive at all — the `§5 #13` the code comments cite is not in that doc. Added a short paragraph.

## Migration

Additive: one nullable enum column plus a one-time backfill, wrapped in `BEGIN`/`COMMIT` (Prisma does not wrap migration files in a transaction on Postgres). No index — the column is never filtered on. Nothing destructive, so no split release.

The backfill was exercised against synthetic audit rows rather than trusting a green apply on an empty DB, covering: object payloads, the legacy double-encoded JSON-string form, un-parseable payloads (skipped, not fatal), and multiple ARCHIVED rows for one process (newest wins).

## Testing

Fresh Postgres, `migrate deploy` + seed. Unit **2544 passed**, integration **1340 passed** (6 skipped), `tsc --noEmit` clean.

New coverage: unarchive-edge legality; `archivedFromStatus` set on archive and nulled on restore; the keeper pre-image's key set and contents; the household-merge audit row from the import route.

## Boundary isolation

`src/security/generated/classifications.ts` gains one line for the new field. That is a purely additive classification change, which `security-boundary-isolation.yml` exempts by name — no separate registry PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)