### PR TITLE
fix(attendance): don't manually check in a merged-away person

### DIFF
--- a/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
@@ -29,6 +29,7 @@ describe('General Attendance API Integration Tests', () => {
     let householdChildId: number;
     let boardMemberId: number;
     let keyholderId: number;
+    let tombstoneId: number;
 
     let activeVisitId: number;
     let childActiveVisitId: number;
@@ -120,6 +121,17 @@ describe('General Attendance API Integration Tests', () => {
             data: { personId: keyholderId, arrivedAt: new Date() }
         });
 
+        // A merge tombstone: the row survives with mergedIntoId set at the survivor.
+        const tombstone = await prisma.person.create({
+            data: {
+                email: 'tombstone-attend-api-test@example.com',
+                name: 'Merged Away',
+                mergedInto: { connect: { id: commonId } },
+                household: { create: { name: "Test HH" } }
+            }
+        });
+        tombstoneId = tombstone.id;
+
         // Create initial active visits
         const commonVisit = await prisma.visit.create({
             data: { personId: commonId, arrivedAt: new Date() }
@@ -133,7 +145,7 @@ describe('General Attendance API Integration Tests', () => {
     });
 
     afterAll(async () => {
-        const existingUserIds = [adminId, commonId, householdLeadId, householdChildId, boardMemberId, keyholderId].filter(id => id !== undefined);
+        const existingUserIds = [adminId, commonId, householdLeadId, householdChildId, boardMemberId, keyholderId, tombstoneId].filter(id => id !== undefined);
 
         if (existingUserIds.length > 0) {
             await prisma.visit.deleteMany({
@@ -357,6 +369,23 @@ describe('General Attendance API Integration Tests', () => {
              const data = await res.json();
              expect(data.success).toBe(true);
              expect(data.visit.personId).toBe(householdChildId);
+        });
+
+        // A merged-away Person is a tombstone: nobody can walk through the door as
+        // one, so an admin must not be able to open a Visit for it either.
+        it('should refuse to check in a merged-away (tombstoned) person', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+             const req = new Request(`http://localhost:4000/api/attendance`, {
+                 method: 'POST',
+                 body: JSON.stringify({ type: 'MANUAL_CHECKIN', participantId: tombstoneId })
+             });
+
+             const res = await POST(req as unknown as import("next/server").NextRequest) as Response;
+             expect(res.ok).toBe(false);
+
+             const visits = await prisma.visit.count({ where: { personId: tombstoneId } });
+             expect(visits).toBe(0);
         });
 
         it('should allow an admin to check in any user', async () => {

--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -172,9 +172,10 @@ export const POST = withAuth({}, async (req, auth) => {
                 return apiError("participantId is required", 400);
             }
 
-            // Verify participant exists
-            const participant = await prisma.person.findUnique({
-                where: { id: participantId }
+            // Verify participant exists. LIVE_PERSON: a merge tombstone must not be
+            // checked into the building — it would create a Visit nobody can act on.
+            const participant = await prisma.person.findFirst({
+                where: { id: participantId, ...LIVE_PERSON }
             });
 
             if (!participant) {


### PR DESCRIPTION
## What

`POST /api/attendance` with `{ type: "MANUAL_CHECKIN", participantId }` resolved its subject with a bare `prisma.person.findUnique({ where: { id: participantId } })` — no liveness filter. A **merge tombstone** (a `Person` row kept for audit with `mergedIntoId` set, never deleted) resolved like any live record, passed the permission and facility-open gates, and got a `Visit` created for it.

The lookup now routes through `LIVE_PERSON` — the filter this same file already imports and uses for the `TWO_DEEP_VIOLATION` board-member query.

```diff
-            // Verify participant exists
-            const participant = await prisma.person.findUnique({
-                where: { id: participantId }
+            // Verify participant exists. LIVE_PERSON: a merge tombstone must not be
+            // checked into the building — it would create a Visit nobody can act on.
+            const participant = await prisma.person.findFirst({
+                where: { id: participantId, ...LIVE_PERSON }
             });
```

## Why

A tombstone cannot walk through the door, so it must not hold an open visit. One created for it inflates the in-building roster and the **two-deep supervision count**, and nobody can check it back out through any normal surface — the checkout paths resolve live people.

## Reviewer notes

**`findFirst`, not `findUnique`.** Prisma 7's `PersonWhereUniqueInput` rejects a spread `PersonWhereInput` (`TS2322`), so the filter cannot be added to `findUnique` in place. `findFirst` with an `id` equality is the same one-row shape and is exactly what `lib/visit/scope.ts#visitSubject` already uses for this.

**Why the drift guard did not catch this.** `src/__tests__/livePersonDriftGuard.test.ts` deliberately excludes `findUnique` — its model is lists and counts, where a by-unique-key read cannot leak an extra tombstone or inflate a total. That reasoning is sound for reads and is not being changed here; this is a **write** path, which the guard's scope does not cover. Post-fix the call is a class-1 `findFirst` site carrying `LIVE_PERSON`, so it passes. The file's existing `ALLOWLIST` entry (for the `DELETE` handler's `visit.findUnique({ include: { person: true } })`) is untouched and still live — no allowlist churn, no boundary-isolation concern.

**Sibling check-in paths audited, both already correct — no change needed:**
- `/api/attendance/manual` resolves its subject through `visitSubject()`, which already filters `LIVE_PERSON`.
- `/api/scan` *deliberately* walks `mergedIntoId` to the live survivor and scans as them, so a badge still encoding a tombstone's id admits its owner at the door. Filtering it there would be a regression, not a fix.

**Scope.** Diff is the `LIVE_PERSON` gap only. No status codes or error strings changed — a separate in-flight branch is addressing the 404/403 existence oracle in this same handler, and the new test asserts `res.ok === false` rather than a specific code so the two do not collide.

**Vocabulary note for the audit ledger:** the finding as filed said "soft-deleted / `deletedAt`". `Person` has no `deletedAt` column — the tombstone marker is `mergedIntoId`, which is what `LIVE_PERSON` filters. (`deletedAt` is on `Visit`.) The test asserts against `mergedInto`.

## Testing

- `tsc --noEmit` — clean
- `npm run test:integration -- --testPathPatterns attendanceAPI` — 25/25 pass, including the new case
- **Negative control**: reverted just the filter and re-ran — exactly one failure, the new test. It is not a vacuous pass.
- `npm run test:ci` — 268 suites / 2543 tests pass (drift guards included)

New integration case in `src/app/__tests__/attendanceAPI.integration.test.ts`: an admin manually checking in a tombstoned person is refused and **no `Visit` row is created**.

Found by the domain-register audit on #1529 (adjacent to finding B28, the LIVE_PERSON filter/guard/allowlist row). Not B13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)