### PR TITLE
fix(audit): name the system actor, and let the board read the log (B16, B17)

### DIFF
--- a/checkin-app/prisma/migrations/20260806140000_audit_log_actor_system/migration.sql
+++ b/checkin-app/prisma/migrations/20260806140000_audit_log_actor_system/migration.sql
@@ -1,0 +1,12 @@
+-- Names the automated path behind a system-actor audit row, and indexes the two
+-- columns the audit-log viewer now filters on. Additive and nullable: rows
+-- written by code still on the old revision leave it null, which reads as the
+-- pre-existing "some system actor" and needs no backfill.
+BEGIN;
+
+ALTER TABLE "AuditLog" ADD COLUMN "actorSystem" TEXT;
+
+CREATE INDEX "AuditLog_actorId_idx" ON "AuditLog"("actorId");
+CREATE INDEX "AuditLog_actorSystem_idx" ON "AuditLog"("actorSystem");
+
+COMMIT;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -1123,6 +1123,10 @@ model AuditLog {
   timestamp               DateTime    @default(now())
   /// @sensitivity:internal
   actorId                 Int
+  /// Which automated path wrote this row (`cron:nightly`, `webhook:shopify`, …)
+  /// when actorId is the system sentinel; null for a person's own action.
+  /// @sensitivity:internal
+  actorSystem             String?
   /// @sensitivity:internal
   action                  AuditAction
   /// @sensitivity:internal
@@ -1135,6 +1139,9 @@ model AuditLog {
   oldData                 Json?
   /// @sensitivity:internal
   newData                 Json?
+
+  @@index([actorId])
+  @@index([actorSystem])
 }
 
 model Account {

--- a/checkin-app/src/app/__tests__/adminAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminAuditAPI.integration.test.ts
@@ -15,9 +15,12 @@ jest.mock('next-auth/next', () => ({
     getServerSession: jest.fn()
 }));
 
+const SYSTEM_TAG = 'cron:nightly';
+
 describe('Admin Audit API Integration Tests', () => {
     let adminId: number;
     let commonId: number;
+    let boardId: number;
 
     beforeAll(async () => {
         // Clean up any leaked state
@@ -47,6 +50,12 @@ describe('Admin Audit API Integration Tests', () => {
         });
         commonId = commonUser.id;
 
+        // Create a board member (no sysadmin flag) — they answer for what is logged here.
+        const board = await prisma.person.create({
+            data: { email: 'board-audit-api-test@example.com', name: 'Board', isBoardMember: true, household: { create: { name: "Test HH" } } }
+        });
+        boardId = board.id;
+
         // Produce a fake audit log row
         await prisma.auditLog.create({
             data: {
@@ -57,10 +66,26 @@ describe('Admin Audit API Integration Tests', () => {
                 newData: { email: 'common-audit-api-test@example.com' }
             }
         });
+
+        // And one written by a named system actor, keyed on the same person as
+        // the SECONDARY id — the slot an entity filter must also search.
+        await prisma.auditLog.create({
+            data: {
+                actorId: 0,
+                actorSystem: SYSTEM_TAG,
+                action: 'EDIT',
+                affectedEntityId: 0,
+                secondaryAffectedEntity: commonId,
+                tableName: 'SYSTEM_NOTIFY',
+                newData: { message: 'audit-api-test system row' }
+            }
+        });
     });
 
     afterAll(async () => {
-        const existingUserIds = [adminId, commonId].filter(id => id !== undefined);
+        const existingUserIds = [adminId, commonId, boardId].filter(id => id !== undefined);
+
+        await prisma.auditLog.deleteMany({ where: { actorSystem: SYSTEM_TAG, secondaryAffectedEntity: commonId } });
 
         if (existingUserIds.length > 0) {
             await prisma.auditLog.deleteMany({
@@ -111,6 +136,43 @@ describe('Admin Audit API Integration Tests', () => {
              expect(data.pageSize).toBe(50);
              expect(Array.isArray(data.tables)).toBe(true);
              expect(ourLog.actorName).toBe('Admin');
+        });
+
+        it('should return 200 OK for a board member (non-sysadmin)', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: boardId, isSysadmin: false, isBoardMember: true } });
+
+             const req = new Request('http://localhost:4000/api/system-status/audit-log', { method: 'GET' });
+             const res = await GET(req as unknown as import("next/server").NextRequest);
+             expect(res.status).toBe(200);
+             expect(Array.isArray((await res.json()).logs)).toBe(true);
+        });
+
+        it('should filter by a person actor and by a named system actor', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+             const byPerson = await (await GET(new Request(`http://localhost:4000/api/system-status/audit-log?actor=${adminId}`) as unknown as import("next/server").NextRequest)).json();
+             expect(byPerson.logs.length).toBeGreaterThanOrEqual(1);
+             for (const log of byPerson.logs) expect(log.actorId).toBe(adminId);
+
+             const bySystem = await (await GET(new Request(`http://localhost:4000/api/system-status/audit-log?actor=${SYSTEM_TAG}`) as unknown as import("next/server").NextRequest)).json();
+             expect(bySystem.logs.length).toBeGreaterThanOrEqual(1);
+             for (const log of bySystem.logs) expect(log.actorSystem).toBe(SYSTEM_TAG);
+
+             // Both actors are offered as filter options.
+             expect(bySystem.systemActors).toContain(SYSTEM_TAG);
+             expect(bySystem.actors.map((a: { id: number }) => a.id)).toContain(adminId);
+        });
+
+        it('should filter by entity id across both the primary and secondary slot', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+
+             const data = await (await GET(new Request(`http://localhost:4000/api/system-status/audit-log?entityId=${commonId}`) as unknown as import("next/server").NextRequest)).json();
+             for (const log of data.logs) {
+                 expect([log.affectedEntityId, log.secondaryAffectedEntity]).toContain(commonId);
+             }
+             // The person row (primary slot) and the system row (secondary slot) both match.
+             expect(data.logs.some((l: { tableName: string }) => l.tableName === 'Person')).toBe(true);
+             expect(data.logs.some((l: { actorSystem: string | null }) => l.actorSystem === SYSTEM_TAG)).toBe(true);
         });
 
         it('should filter by action and entity and page server-side', async () => {

--- a/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
@@ -210,7 +210,7 @@ describe('Protected-route role rejection', () => {
         { name: 'GET /api/settings/membership/volunteer-designations', invoke: () => VOL_DESIG_GET(nreq('http://localhost/api/settings/membership/volunteer-designations')) },
         { name: 'POST /api/settings/membership/volunteer-designations', invoke: () => VOL_DESIG_POST(nreq('http://localhost/api/settings/membership/volunteer-designations', 'POST', {})) },
         { name: 'DELETE /api/settings/membership/volunteer-designations', invoke: () => VOL_DESIG_DELETE(nreq('http://localhost/api/settings/membership/volunteer-designations', 'DELETE')) },
-        { name: 'GET /api/system-status/audit-log (sysadmin-only)', invoke: () => AUDIT_LOG_GET(nreq('http://localhost/api/system-status/audit-log')) },
+        { name: 'GET /api/system-status/audit-log', invoke: () => AUDIT_LOG_GET(nreq('http://localhost/api/system-status/audit-log')) },
         { name: 'GET /api/system-status/errors', invoke: () => SS_ERRORS_GET(nreq('http://localhost/api/system-status/errors')) },
         { name: 'GET /api/system-status/links', invoke: () => SS_LINKS_GET(nreq('http://localhost/api/system-status/links')) },
         // links/[id] is a GLOBAL admin resource (integrationErrorLog keyed by a

--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -10,6 +10,7 @@ import { config } from "@/lib/config";
 import { apiError } from "@/lib/api-response";
 import { LIVE_PERSON } from "@/lib/person/filters";
 import { LIVE_VISIT } from "@/lib/visit/filters";
+import { systemActor } from "@/lib/auditActor";
 
 // GET is kiosk-first with distinct signature-failure semantics (403 on bad signature,
 // not 401), so it keeps its own kiosk plumbing rather than moving to withAuth. The one
@@ -280,7 +281,7 @@ export const POST = withAuth({}, async (req, auth) => {
             // Log that we sent the notification to prevent spam from multiple kiosks
             await prisma.auditLog.create({
                 data: {
-                    actorId: 0, // System actor
+                    ...systemActor("kiosk:two-deep"),
                     action: 'CREATE',
                     tableName: 'SYSTEM_NOTIFY',
                     affectedEntityId: 0,

--- a/checkin-app/src/app/api/cron/nightly/route.ts
+++ b/checkin-app/src/app/api/cron/nightly/route.ts
@@ -7,6 +7,7 @@ import { processVisitCheckout } from "@/lib/attendanceTransitions";
 import { LIVE_PERSON } from "@/lib/person/filters";
 import { LIVE_VISIT } from "@/lib/visit/filters";
 import { runPersonAgreementSweep } from "@/lib/membership/personAgreementTriggers";
+import { systemActor } from "@/lib/auditActor";
 
 export const GET = withCron(async () => {
         const now = new Date();
@@ -58,7 +59,7 @@ export const GET = withCron(async () => {
                 // System Audit Log for the violation
                 await prisma.auditLog.create({
                     data: {
-                        actorId: 0, 
+                        ...systemActor("cron:nightly"),
                         action: 'CREATE',
                         tableName: 'SYSTEM_NOTIFY',
                         affectedEntityId: 0,

--- a/checkin-app/src/app/api/cron/scholarship-grace-expiry/route.ts
+++ b/checkin-app/src/app/api/cron/scholarship-grace-expiry/route.ts
@@ -4,8 +4,8 @@ import { withCron } from "@/lib/cronAuth";
 import prisma from "@/lib/prisma";
 import { withdrawAndReleaseHold } from "@/lib/program/capacity";
 import { STATES } from "@/lib/programs/enrollmentState";
+import { systemActor } from "@/lib/auditActor";
 
-const SYSTEM_ACTOR = 0;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
@@ -49,7 +49,7 @@ export const GET = withCron(async () => {
 
             await prisma.auditLog.create({
                 data: {
-                    actorId: SYSTEM_ACTOR,
+                    ...systemActor("cron:scholarship-grace-expiry"),
                     action: "DELETE",
                     tableName: "ProgramParticipant",
                     affectedEntityId: record.personId,

--- a/checkin-app/src/app/api/system-status/audit-log/route.ts
+++ b/checkin-app/src/app/api/system-status/audit-log/route.ts
@@ -1,7 +1,9 @@
-// Sysadmin telemetry viewer: returns a page of AuditLog rows for forensic
-// review, newest first. Backs the "Audit Log" tab on /system-status.
+// Board + sysadmin telemetry viewer: returns a page of AuditLog rows for
+// forensic review, newest first. Backs the "Audit Log" tab on /system-status.
 // Server-side paged + filtered so the full history is reachable without ever
-// shipping it all at once.
+// shipping it all at once. The board is admitted because it answers for the
+// decisions recorded here — a trail only a sysadmin can read cannot answer a
+// family six months on (docs/rules/principles.md § Accountability).
 import { NextResponse, type NextRequest } from "next/server";
 import { logger } from "@/lib/logger";
 import prisma from "@/lib/prisma";
@@ -13,7 +15,7 @@ const PAGE_SIZE = 50;
 const ACTIONS = ["CREATE", "EDIT", "DELETE", "BECOME_ADMIN"] as const;
 
 export const GET = withAuth(
-    { roles: ['isSysadmin'] },
+    { roles: ['isSysadmin', 'isBoardMember'] },
     async (req: NextRequest) => {
         try {
             const sp = new URL(req.url).searchParams;
@@ -30,6 +32,22 @@ export const GET = withAuth(
             const table = sp.get("table");
             if (table) where.tableName = table;
 
+            // One control, two columns: a person is selected by id, a system path by
+            // its name (`cron:nightly`), which never parses as a number.
+            const actor = sp.get("actor");
+            if (actor) {
+                const actorId = Number(actor);
+                if (Number.isInteger(actorId) && actorId > 0) where.actorId = actorId;
+                else where.actorSystem = actor;
+            }
+
+            // "Everything that touched #123" — the entity may sit in either slot
+            // (a merge or an enrollment records the second id in secondary).
+            const entityId = Number(sp.get("entityId"));
+            if (Number.isInteger(entityId) && entityId > 0) {
+                where.OR = [{ affectedEntityId: entityId }, { secondaryAffectedEntity: entityId }];
+            }
+
             // from/to are yyyy-mm-dd. Inclusive day range, parsed in server TZ.
             // ponytail: server-local day boundaries; revisit if multi-TZ forensics matter.
             const from = sp.get("from");
@@ -40,7 +58,7 @@ export const GET = withAuth(
                 if (to) where.timestamp.lte = new Date(`${to}T23:59:59.999`);
             }
 
-            const [total, rows, tableRows] = await Promise.all([
+            const [total, rows, tableRows, actorIdRows, systemRows] = await Promise.all([
                 prisma.auditLog.count({ where }),
                 prisma.auditLog.findMany({
                     where,
@@ -48,16 +66,29 @@ export const GET = withAuth(
                     skip: (page - 1) * PAGE_SIZE,
                     take: PAGE_SIZE,
                 }),
-                // Distinct entity types for the filter dropdown (unfiltered, stable).
+                // Distinct entity types / actors for the filter dropdowns (unfiltered, stable).
                 prisma.auditLog.findMany({
                     distinct: ['tableName'],
                     select: { tableName: true },
                     orderBy: { tableName: 'asc' },
                 }),
+                prisma.auditLog.findMany({
+                    distinct: ['actorId'],
+                    select: { actorId: true },
+                    where: { actorId: { gt: 0 } },
+                }),
+                prisma.auditLog.findMany({
+                    distinct: ['actorSystem'],
+                    select: { actorSystem: true },
+                    where: { actorSystem: { not: null } },
+                    orderBy: { actorSystem: 'asc' },
+                }),
             ]);
 
-            // Resolve actor ids to names (one batched lookup). id 0 / missing => System.
-            const actorIds = [...new Set(rows.map((r) => r.actorId))];
+            // Resolve actor ids to names (one batched lookup) — for the rows on this
+            // page and for the actor dropdown. A since-merged actor still names itself:
+            // hiding them would falsify the history this log exists to preserve.
+            const actorIds = [...new Set([...rows.map((r) => r.actorId), ...actorIdRows.map((a) => a.actorId)])];
             const actors = await prisma.person.findMany({
                 where: { id: { in: actorIds } },
                 select: { id: true, name: true },
@@ -75,6 +106,10 @@ export const GET = withAuth(
                 page,
                 pageSize: PAGE_SIZE,
                 tables: tableRows.map((t) => t.tableName),
+                actors: actorIdRows
+                    .map((a) => ({ id: a.actorId, name: nameById.get(a.actorId) ?? `#${a.actorId}` }))
+                    .sort((a, b) => a.name.localeCompare(b.name)),
+                systemActors: systemRows.map((s) => s.actorSystem).filter((s): s is string => s !== null),
             });
         } catch (error) {
             logger.error("Failed to fetch audit logs:", error);

--- a/checkin-app/src/app/system-status/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/system-status/__tests__/layout.test.tsx
@@ -55,13 +55,13 @@ beforeEach(() => {
 });
 
 describe("SystemStatusLayout role gate", () => {
-  it("admits a board member but hides the sysadmin-only Audit Log tab", () => {
+  it("admits a board member to every tab, Audit Log included", () => {
     renderLayout("/system-status/health", {
       data: { user: { id: 1, isBoardMember: true } },
       status: "authenticated",
     });
     expect(screen.getByText(CHILD)).toBeInTheDocument();
-    expect(screen.queryByText("Audit Log")).not.toBeInTheDocument();
+    expect(screen.getByText("Audit Log")).toBeInTheDocument();
     expect(push).not.toHaveBeenCalled();
   });
 

--- a/checkin-app/src/app/system-status/audit-log/__tests__/page.test.tsx
+++ b/checkin-app/src/app/system-status/audit-log/__tests__/page.test.tsx
@@ -12,17 +12,21 @@ describe("SystemStatusAuditLogPage", () => {
     it("renders the audit log panel for a sysadmin", async () => {
         setSession({ id: 1, isSysadmin: true });
         mockFetchJson({
-            "/api/system-status/audit-log": { logs: [], total: 0, page: 1, pageSize: 25, tables: [] },
+            "/api/system-status/audit-log": { logs: [], total: 0, page: 1, pageSize: 25, tables: [], actors: [], systemActors: [] },
         });
         renderWithProviders(<SystemStatusAuditLogPage />);
 
         expect(await screen.findByText("No audit entries match these filters.")).toBeInTheDocument();
     });
 
-    it("bounces a board member (non-sysadmin) to /system-status/health", () => {
+    it("renders for a board member too — the board answers for what is logged here", async () => {
         setSession({ id: 2, isBoardMember: true });
+        mockFetchJson({
+            "/api/system-status/audit-log": { logs: [], total: 0, page: 1, pageSize: 25, tables: [], actors: [], systemActors: [] },
+        });
         renderWithProviders(<SystemStatusAuditLogPage />);
 
-        expect(router.push).toHaveBeenCalledWith("/system-status/health");
+        expect(await screen.findByText("No audit entries match these filters.")).toBeInTheDocument();
+        expect(router.push).not.toHaveBeenCalled();
     });
 });

--- a/checkin-app/src/app/system-status/audit-log/page.tsx
+++ b/checkin-app/src/app/system-status/audit-log/page.tsx
@@ -1,20 +1,9 @@
 "use client";
 
-
 import { AuditLogPanel } from "@/components/admin/AuditLogPanel";
-import { useRequireRole } from "@/hooks/useRequireRole";
 
-import { PageLoader } from "@/components/ui/PageLoader";
+// Admission (sysadmin or board) is the /system-status layout's gate; this page
+// adds nothing on top of it.
 export default function SystemStatusAuditLogPage() {
-  // Audit Log is isSysadmin-only; boardMembers reaching this URL directly are bounced.
-  const { loading, ready } = useRequireRole(["isSysadmin"], { redirectTo: "/system-status/health" });
-
-  if (loading) {
-    return (
-      <PageLoader minHeight="40vh" />
-    );
-  }
-  if (!ready) return null;
-
   return <AuditLogPanel />;
 }

--- a/checkin-app/src/app/system-status/layout.tsx
+++ b/checkin-app/src/app/system-status/layout.tsx
@@ -8,7 +8,7 @@ import { useRequireRole } from "@/hooks/useRequireRole";
 
 import { PageLoader } from "@/components/ui/PageLoader";
 export default function SystemStatusLayout({ children }: { children: React.ReactNode }) {
-  const { user, loading, ready } = useRequireRole(["isSysadmin", "isBoardMember"]);
+  const { loading, ready } = useRequireRole(["isSysadmin", "isBoardMember"]);
 
   if (loading) {
     return (
@@ -18,11 +18,9 @@ export default function SystemStatusLayout({ children }: { children: React.React
 
   if (!ready) return null;
 
-  const links = SYSTEM_STATUS_NAV_LINKS.filter((link) => !link.sysadminOnly || user?.isSysadmin);
-
   return (
     <PageContainer>
-      <SectionTabs links={links} mb="md" />
+      <SectionTabs links={SYSTEM_STATUS_NAV_LINKS} mb="md" />
       <Box style={{ minWidth: 0 }}>{children}</Box>
     </PageContainer>
   );

--- a/checkin-app/src/components/admin/AuditLogPanel.tsx
+++ b/checkin-app/src/components/admin/AuditLogPanel.tsx
@@ -14,6 +14,7 @@ import {
   Stack,
   Table,
   Text,
+  TextInput,
 } from "@mantine/core";
 
 type AuditLog = {
@@ -21,6 +22,7 @@ type AuditLog = {
   timestamp: string;
   actorId: number;
   actorName: string | null;
+  actorSystem: string | null;
   action: "CREATE" | "EDIT" | "DELETE" | "BECOME_ADMIN";
   tableName: string;
   affectedEntityId: number;
@@ -35,6 +37,8 @@ type AuditResponse = {
   page: number;
   pageSize: number;
   tables: string[];
+  actors: { id: number; name: string }[];
+  systemActors: string[];
 };
 
 const ACTION_COLOR: Record<AuditLog["action"], string> = {
@@ -52,6 +56,8 @@ export function AuditLogPanel() {
   const [page, setPage] = useState(1);
   const [action, setAction] = useState<string | null>(null);
   const [table, setTable] = useState<string | null>(null);
+  const [actor, setActor] = useState<string | null>(null);
+  const [entityId, setEntityId] = useState("");
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
 
@@ -59,6 +65,8 @@ export function AuditLogPanel() {
     const qs = new URLSearchParams({ page: String(page) });
     if (action) qs.set("action", action);
     if (table) qs.set("table", table);
+    if (actor) qs.set("actor", actor);
+    if (entityId.trim()) qs.set("entityId", entityId.trim());
     if (from) qs.set("from", from);
     if (to) qs.set("to", to);
 
@@ -72,7 +80,7 @@ export function AuditLogPanel() {
         setFailed(false);
       })
       .catch(() => setFailed(true));
-  }, [page, action, table, from, to]);
+  }, [page, action, table, actor, entityId, from, to]);
 
   // Filter changes reset to page 1.
   const onFilter =
@@ -81,6 +89,13 @@ export function AuditLogPanel() {
       setter(v);
       setPage(1);
     };
+
+  // People by name, then the named automated paths — one control over two columns
+  // (a person's value is their id, a system path's value is its own name).
+  const actorOptions = [
+    ...(data?.actors ?? []).map((a) => ({ value: String(a.id), label: a.name })),
+    ...(data?.systemActors ?? []).map((s) => ({ value: s, label: `System — ${s}` })),
+  ];
 
   const totalPages = data ? Math.max(1, Math.ceil(data.total / data.pageSize)) : 1;
 
@@ -105,6 +120,24 @@ export function AuditLogPanel() {
           value={table}
           onChange={onFilter(setTable)}
           w={180}
+        />
+        <Select
+          label="Actor"
+          placeholder="Anyone"
+          clearable
+          searchable
+          data={actorOptions}
+          value={actor}
+          onChange={onFilter(setActor)}
+          w={220}
+        />
+        <TextInput
+          label="Entity #"
+          placeholder="id"
+          type="number"
+          value={entityId}
+          onChange={(e) => onFilter(setEntityId)(e.currentTarget.value)}
+          w={100}
         />
         <DateField label="From" value={from} onChange={onFilter(setFrom)} />
         <DateField label="To" value={to} onChange={onFilter(setTo)} />
@@ -155,7 +188,13 @@ export function AuditLogPanel() {
                       {l.secondaryAffectedEntity != null && ` +${l.secondaryAffectedEntity}`}
                     </Table.Td>
                     <Table.Td style={{ whiteSpace: "nowrap" }}>
-                      {l.actorName ?? (l.actorId === 0 ? "System" : `#${l.actorId}`)}
+                      {l.actorSystem ? (
+                        <Text span fz="xs" c="dimmed">
+                          {l.actorSystem}
+                        </Text>
+                      ) : (
+                        (l.actorName ?? (l.actorId === 0 ? "System" : `#${l.actorId}`))
+                      )}
                     </Table.Td>
                     <Table.Td>
                       {l.oldData != null || l.newData != null ? (

--- a/checkin-app/src/lib/__tests__/auditActor.test.ts
+++ b/checkin-app/src/lib/__tests__/auditActor.test.ts
@@ -1,0 +1,27 @@
+import { SYSTEM_ACTOR, SYSTEM_ACTORS, personActor, personOrSystemActor, systemActor } from "@/lib/auditActor";
+
+describe("auditActor", () => {
+    it("names the automated path alongside the sentinel id", () => {
+        expect(systemActor("cron:nightly")).toEqual({ actorId: SYSTEM_ACTOR, actorSystem: "cron:nightly" });
+        expect(systemActor("webhook:shopify-order").actorSystem).not.toBe(systemActor("cron:nightly").actorSystem);
+    });
+
+    it("leaves actorSystem null for a person, so a row is one or the other", () => {
+        expect(personActor(7)).toEqual({ actorId: 7, actorSystem: null });
+    });
+
+    it.each([0, -1, NaN, 1.5])("refuses %p rather than filing a person's action as System", (bad) => {
+        expect(() => personActor(bad)).toThrow(/cannot be filed as System/);
+    });
+
+    it("falls back to the named system actor only when no person is supplied", () => {
+        expect(personOrSystemActor(7, "webhook:shopify-order")).toEqual({ actorId: 7, actorSystem: null });
+        expect(personOrSystemActor(undefined, "webhook:shopify-order")).toEqual({ actorId: SYSTEM_ACTOR, actorSystem: "webhook:shopify-order" });
+        expect(personOrSystemActor(null, "webhook:shopify-order")).toEqual({ actorId: SYSTEM_ACTOR, actorSystem: "webhook:shopify-order" });
+    });
+
+    it("keeps every system actor name distinct and surface-prefixed", () => {
+        expect(new Set(SYSTEM_ACTORS).size).toBe(SYSTEM_ACTORS.length);
+        for (const name of SYSTEM_ACTORS) expect(name).toMatch(/^(cron|system|webhook|kiosk):[a-z0-9-]+$/);
+    });
+});

--- a/checkin-app/src/lib/__tests__/systemStatusNav.test.ts
+++ b/checkin-app/src/lib/__tests__/systemStatusNav.test.ts
@@ -14,13 +14,15 @@ describe("SYSTEM_STATUS_NAV_LINKS", () => {
     expect(new Set(hrefs).size).toBe(hrefs.length);
   });
 
-  it("flags only Audit Log as sysadmin-only", () => {
-    const sysadminOnly = SYSTEM_STATUS_NAV_LINKS.filter((l) => l.sysadminOnly).map((l) => l.name);
-    expect(sysadminOnly).toEqual(["Audit Log"]);
-  });
-
-  it("leaves the other tabs visible to everyone (sysadminOnly unset)", () => {
-    const everyone = SYSTEM_STATUS_NAV_LINKS.filter((l) => !l.sysadminOnly).map((l) => l.name);
-    expect(everyone).toEqual(["System Status", "Link Status", "Lifecycle", "Errors"]);
+  // Every tab, Audit Log included, is open to the whole section audience
+  // (sysadmin + board) — the layout filters nothing.
+  it("exposes every tab to the section audience", () => {
+    expect(SYSTEM_STATUS_NAV_LINKS.map((l) => l.name)).toEqual([
+      "System Status",
+      "Link Status",
+      "Lifecycle",
+      "Errors",
+      "Audit Log",
+    ]);
   });
 });

--- a/checkin-app/src/lib/auditActor.ts
+++ b/checkin-app/src/lib/auditActor.ts
@@ -1,0 +1,64 @@
+/**
+ * Who an AuditLog row is attributed to.
+ *
+ * Two rules from `docs/rules/principles.md` are enforced here rather than at 85
+ * scattered `auditLog.create` call sites:
+ *
+ * - *Accountability — a system actor names itself.* `actorId: 0` alone cannot
+ *   tell the nightly sweep from the renewal sweep from a Shopify webhook, so a
+ *   system row carries `actorSystem` as well and the name comes from a closed
+ *   list.
+ * - *Fail closed.* A person's action with a missing actor is refused, never
+ *   quietly filed as System.
+ */
+
+/** Sentinel actorId for every non-person write; `actorSystem` says which one. */
+export const SYSTEM_ACTOR = 0;
+
+/**
+ * Every automated path that writes audit rows, named `surface:path` — `cron:` for
+ * a scheduled route, `webhook:` for an inbound call, `system:` for a library path
+ * more than one surface can wake, `kiosk:` for the check-in station.
+ */
+export const SYSTEM_ACTORS = [
+    "cron:nightly",
+    "cron:scholarship-grace-expiry",
+    "cron:trusted-adult-expiry",
+    "cron:lifecycle-reconcile",
+    "system:renewal-open",
+    "system:membership-renewal-advance",
+    "system:membership-external-advance",
+    "system:person-bg-open",
+    "system:person-agreement-open",
+    "webhook:zoho-contract",
+    "webhook:shopify-order",
+    "webhook:shopify-receipt",
+    "kiosk:two-deep",
+] as const;
+
+export type SystemActorName = (typeof SYSTEM_ACTORS)[number];
+
+/** The actor half of an `auditLog.create` payload. Spread into `data`. */
+export type AuditActor = { actorId: number; actorSystem: string | null };
+
+/** Attribute a row to a named automated path. */
+export function systemActor(name: SystemActorName): AuditActor {
+    return { actorId: SYSTEM_ACTOR, actorSystem: name };
+}
+
+/**
+ * Attribute a row to a person. Throws on a missing/zero actor rather than
+ * letting it fall through to System — an unattributable decision is a bug at
+ * the call site, and a row that blames the system for it is worse than none.
+ */
+export function personActor(actorId: number): AuditActor {
+    if (!Number.isInteger(actorId) || actorId <= 0) {
+        throw new Error(`Audit actor missing (got ${actorId}): a person's action cannot be filed as System.`);
+    }
+    return { actorId, actorSystem: null };
+}
+
+/** For paths a person OR an automated path can take (e.g. board certify vs. Shopify webhook). */
+export function personOrSystemActor(actorId: number | null | undefined, name: SystemActorName): AuditActor {
+    return actorId ? personActor(actorId) : systemActor(name);
+}

--- a/checkin-app/src/lib/lifecycleDrift.ts
+++ b/checkin-app/src/lib/lifecycleDrift.ts
@@ -18,6 +18,7 @@ import {
     validate as validateEnrollment,
 } from "@/lib/programs/enrollmentState";
 import { validate as validateMembership } from "@/lib/membership/lifecycle";
+import { systemActor } from "@/lib/auditActor";
 import { adjustProgramInventory, reportShopifyFailure } from "@/lib/shopify";
 
 export type LifecycleModel = "ProgramParticipant" | "OrgMembershipProcess";
@@ -151,7 +152,7 @@ async function healEnrollmentI1(): Promise<number> {
 
             await prisma.auditLog.create({
                 data: {
-                    actorId: 0, // system — no session behind a cron sweep
+                    ...systemActor("cron:lifecycle-reconcile"),
                     action: "EDIT",
                     tableName: "ProgramParticipant",
                     affectedEntityId: row.personId,

--- a/checkin-app/src/lib/membership/archive.ts
+++ b/checkin-app/src/lib/membership/archive.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { ReviewError } from "@/lib/membership/review";
 import { normalizeAuditData } from "@/lib/auditPayload";
 import { fromWhere } from "@/lib/membership/lifecycle";
+import { personActor } from "@/lib/auditActor";
 
 /**
  * Board disposal of an abandoned application. Transitions the process to the
@@ -23,7 +24,7 @@ export async function archiveApplication(processId: number, actorId: number) {
         prisma.orgMembershipProcess.update({ where: { id: processId }, data: { status: "ARCHIVED", stageEnteredAt: new Date() } }),
         prisma.auditLog.create({
             data: {
-                actorId: actorId || 0,
+                ...personActor(actorId),
                 action: "EDIT",
                 tableName: "OrgMembershipProcess",
                 affectedEntityId: processId,
@@ -91,7 +92,7 @@ export async function unarchiveApplication(processId: number, actorId: number) {
             if (count !== 1) return;
             await tx.auditLog.create({
                 data: {
-                    actorId: actorId || 0,
+                    ...personActor(actorId),
                     action: "EDIT",
                     tableName: "OrgMembershipProcess",
                     affectedEntityId: processId,

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -10,6 +10,7 @@ import { loadAgreementPdf, stampWatermark, AGREEMENT_FILENAME, AgreementUnavaila
 import { latestPendingExternal } from "@/lib/membership/phases";
 import { findOpenPersonAgreement } from "@/lib/membership/personAgreementTriggers";
 import { fromWhere } from "@/lib/membership/lifecycle";
+import { systemActor, personOrSystemActor } from "@/lib/auditActor";
 
 /**
  * EXTERNAL-phase service — the actions an applicant completes after intake:
@@ -25,9 +26,9 @@ import { fromWhere } from "@/lib/membership/lifecycle";
  * mark-bg-consent action as the backstop. The system never sees contract content
  * or check results.
  *
- * actorId 0 denotes a system actor (e.g. the Zoho webhook) in the audit log.
+ * A contract signature with no session behind it (the Zoho webhook) is attributed
+ * to the `webhook:zoho-contract` system actor in the audit log.
  */
-const SYSTEM_ACTOR = 0;
 
 export type ExternalErrorCode =
     | "not_found"
@@ -131,7 +132,7 @@ export async function advanceExternalIfComplete(processId: number) {
         if (membership) await applyVolunteerStatus(tx, process.orgMembershipId!, membership.householdId, false);
         await tx.auditLog.create({
             data: {
-                actorId: SYSTEM_ACTOR,
+                ...systemActor("system:membership-external-advance"),
                 action: "EDIT",
                 tableName: "OrgMembershipProcess",
                 affectedEntityId: processId,
@@ -157,7 +158,7 @@ export async function advanceExternalIfComplete(processId: number) {
  * conditional write and skips advanceExternalIfComplete entirely (which would deref a
  * null orgMembershipId).
  */
-export async function markContractSigned(processId: number, actorId: number = SYSTEM_ACTOR) {
+export async function markContractSigned(processId: number, actorId?: number) {
     const process = await prisma.orgMembershipProcess.findUnique({ where: { id: processId } });
     if (!process) throw new ExternalError("not_found", "Application not found.");
     const isPersonAgreement = process.kind === "PERSON_AGREEMENT";
@@ -175,7 +176,7 @@ export async function markContractSigned(processId: number, actorId: number = SY
         if (count !== 1) return;
         await tx.auditLog.create({
             data: {
-                actorId,
+                ...personOrSystemActor(actorId, "webhook:zoho-contract"),
                 action: "EDIT",
                 tableName: "OrgMembershipProcess",
                 affectedEntityId: processId,

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -6,6 +6,7 @@ import { notifyBoardPaidReject } from "@/lib/membership/boardAlerts";
 import { openPersonBgForNewMember } from "@/lib/membership/personBgTriggers";
 import { openPersonAgreementForNewMember } from "@/lib/membership/personAgreementTriggers";
 import { config } from "@/lib/config";
+import { systemActor, personOrSystemActor } from "@/lib/auditActor";
 
 /**
  * Payment phase (PENDING_PAYMENT -> ACTIVE).
@@ -20,7 +21,6 @@ import { config } from "@/lib/config";
  * that flips the membership ACTIVE, records how, and sends one congrats email.
  */
 
-const SYSTEM_ACTOR = 0;
 
 export class PaymentError extends Error {
     constructor(public readonly code: "not_found" | "wrong_phase" | "forbidden", message: string) {
@@ -150,7 +150,7 @@ export async function activate(
             await tx.orgMembershipProcess.update({ where: { id: processId }, data: { paidAt: now, ...payMeta } });
             await tx.auditLog.create({
                 data: {
-                    actorId: opts.actorId ?? SYSTEM_ACTOR,
+                    ...personOrSystemActor(opts.actorId, "webhook:shopify-order"),
                     action: "EDIT",
                     tableName: "OrgMembershipProcess",
                     affectedEntityId: processId,
@@ -189,7 +189,7 @@ export async function activate(
             // still not a silent no-op though: audit it and alert the board.
             await tx.auditLog.create({
                 data: {
-                    actorId: SYSTEM_ACTOR,
+                    ...systemActor("webhook:shopify-order"),
                     action: "EDIT",
                     tableName: "OrgMembershipProcess",
                     affectedEntityId: processId,
@@ -216,7 +216,7 @@ export async function activate(
         }
         await tx.auditLog.create({
             data: {
-                actorId: opts.actorId ?? SYSTEM_ACTOR,
+                ...personOrSystemActor(opts.actorId, "webhook:shopify-order"),
                 action: "EDIT",
                 tableName: "OrgMembershipProcess",
                 affectedEntityId: processId,

--- a/checkin-app/src/lib/membership/personAgreementTriggers.ts
+++ b/checkin-app/src/lib/membership/personAgreementTriggers.ts
@@ -2,6 +2,7 @@ import prisma from "@/lib/prisma";
 import { calculateAge } from "@/lib/time";
 import { renewalWindow } from "@/lib/membership/renewal";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import { personOrSystemActor } from "@/lib/auditActor";
 
 /**
  * Triggers that OPEN a per-person membership-agreement obligation (PERSON_AGREEMENT).
@@ -13,7 +14,6 @@ import { LIVE_PERSON } from "@/lib/person/filters";
  * NIGHTLY (not annually). Both are load-bearing; see below.
  */
 
-const SYSTEM_ACTOR = 0;
 
 /**
  * Automatic-population age rule: a DOB on file and 18–25 as of `now`.
@@ -100,7 +100,7 @@ export async function openPersonAgreement(
     personId: number,
     now: Date,
     floor: Date,
-    { manual = false, actorId = SYSTEM_ACTOR }: { manual?: boolean; actorId?: number } = {},
+    { manual = false, actorId }: { manual?: boolean; actorId?: number } = {},
 ) {
     return prisma.$transaction(async (tx) => {
         await tx.$queryRaw`SELECT id FROM "Person" WHERE id = ${personId} FOR UPDATE`;
@@ -128,7 +128,7 @@ export async function openPersonAgreement(
         });
         await tx.auditLog.create({
             data: {
-                actorId,
+                ...personOrSystemActor(actorId, "system:person-agreement-open"),
                 action: "CREATE",
                 tableName: "OrgMembershipProcess",
                 affectedEntityId: created.id,

--- a/checkin-app/src/lib/membership/personBgTriggers.ts
+++ b/checkin-app/src/lib/membership/personBgTriggers.ts
@@ -3,6 +3,7 @@ import { bgFreshThreshold, personBgVerdict } from "@/lib/membership/personBgChec
 import { nextBoundary } from "@/lib/membership/renewal";
 import { personBgOpen } from "@/lib/membership/lifecycle";
 import { LIVE_PERSON, PROGRAM_ATTACHED_WHERE } from "@/lib/person/filters";
+import { systemActor } from "@/lib/auditActor";
 
 /**
  * Triggers that OPEN a per-person background-check obligation (PERSON_BG process,
@@ -14,7 +15,6 @@ import { LIVE_PERSON, PROGRAM_ATTACHED_WHERE } from "@/lib/person/filters";
  * annual run, not when they take a role.
  */
 
-const SYSTEM_ACTOR = 0;
 
 /**
  * Open one PERSON_BG obligation for `personId`, evaluated as of `asOf` (the annual
@@ -53,7 +53,7 @@ export async function openPersonBg(personId: number, asOf: Date, threshold: Date
         });
         await tx.auditLog.create({
             data: {
-                actorId: SYSTEM_ACTOR,
+                ...systemActor("system:person-bg-open"),
                 action: "CREATE",
                 tableName: "OrgMembershipProcess",
                 affectedEntityId: created.id,

--- a/checkin-app/src/lib/membership/renewal.ts
+++ b/checkin-app/src/lib/membership/renewal.ts
@@ -4,6 +4,7 @@ import { logger } from "@/lib/logger";
 import { certifyPaymentPlan, PaymentError } from "./payment";
 import { IN_FLIGHT_RENEWAL, grantableRenewalWhere, settledThisCycleWhere, fromWhere } from "@/lib/membership/lifecycle";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import { systemActor } from "@/lib/auditActor";
 
 /**
  * Annual renewal. A common membership-year boundary (BoardSettings) drives every
@@ -21,7 +22,6 @@ import { LIVE_PERSON } from "@/lib/person/filters";
  * nothing writes it anymore (a migration moved open rows to the request flow).
  */
 
-const SYSTEM_ACTOR = 0;
 const RENEWAL_LEAD_MONTHS = 2;
 
 // The in-flight-renewal status list now lives ONCE in lib/membership/lifecycle
@@ -211,7 +211,7 @@ export async function beginRenewal(processId: number) {
     });
     if (count === 1) {
         await prisma.auditLog.create({
-            data: { actorId: SYSTEM_ACTOR, action: "EDIT", tableName: "OrgMembershipProcess", affectedEntityId: processId, oldData: { status: "PENDING_RENEWAL" }, newData: { status: "PENDING_EXTERNAL_ACTION", ...(clearNow ? { bgClearedAt: true } : {}) } },
+            data: { ...systemActor("system:membership-renewal-advance"), action: "EDIT", tableName: "OrgMembershipProcess", affectedEntityId: processId, oldData: { status: "PENDING_RENEWAL" }, newData: { status: "PENDING_EXTERNAL_ACTION", ...(clearNow ? { bgClearedAt: true } : {}) } },
         });
     }
     return prisma.orgMembershipProcess.findUniqueOrThrow({ where: { id: processId } });
@@ -249,7 +249,7 @@ export async function createRenewalProcess(orgMembershipId: number) {
                 data: { orgMembershipId, kind: "RENEWAL", status: "PENDING_RENEWAL" },
             });
             await tx.auditLog.create({
-                data: { actorId: SYSTEM_ACTOR, action: "CREATE", tableName: "OrgMembershipProcess", affectedEntityId: created.id, newData: { kind: "RENEWAL", status: "PENDING_RENEWAL" } },
+                data: { ...systemActor("system:renewal-open"), action: "CREATE", tableName: "OrgMembershipProcess", affectedEntityId: created.id, newData: { kind: "RENEWAL", status: "PENDING_RENEWAL" } },
             });
             return created;
         });

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -9,6 +9,7 @@ import { config } from "@/lib/config";
 import { canonicalizeEmail } from "@/lib/emailNormalize";
 import { openPersonBgForNewMember } from "@/lib/membership/personBgTriggers";
 import { openPersonAgreementForNewMember } from "@/lib/membership/personAgreementTriggers";
+import { personActor, type AuditActor } from "@/lib/auditActor";
 import { hasHouseholdConflict, sharesHousehold } from "@/lib/conflictOfInterest";
 import { type DbClient, type TxClient } from "@/lib/db-client";
 import { awaitingBgReview } from "@/lib/membership/lifecycle";
@@ -35,7 +36,6 @@ import { LIVE_PERSON } from "@/lib/person/filters";
  * The system never sees the check itself — only the attestations.
  */
 
-const SYSTEM_ACTOR = 0;
 const REQUIRED_APPROVALS = 2;
 
 /**
@@ -231,7 +231,7 @@ export async function attest(
 
         if (input.result === "REJECT") {
             await tx.orgMembershipProcess.update({ where: { id: processId }, data: { status: "BLOCKED", stageEnteredAt: new Date() } });
-            await audit(tx, reviewerId, processId, { status: process.status }, { status: "BLOCKED", reason: "reviewer reject", ...(input.note ? { note: input.note } : {}) });
+            await audit(tx, personActor(reviewerId), processId, { status: process.status }, { status: "BLOCKED", reason: "reviewer reject", ...(input.note ? { note: input.note } : {}) });
             // A paid household that fails review needs a manual refund — flag the board (post-tx).
             return { status: "BLOCKED" as const, notifyPaidReject: !!process.paidAt };
         }
@@ -292,7 +292,7 @@ async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: nu
         const now = new Date();
         await tx.person.update({ where: { id: process.subjectPersonId }, data: { lastBackgroundCheck: now } });
         await tx.orgMembershipProcess.update({ where: { id: processId }, data: { bgClearedAt: now, status: "ACTIVE", stageEnteredAt: now } });
-        await audit(tx, actorId, processId, { status: process.status }, { status: "ACTIVE", bgCleared: true, subjectPersonId: process.subjectPersonId });
+        await audit(tx, personActor(actorId), processId, { status: process.status }, { status: "ACTIVE", bgCleared: true, subjectPersonId: process.subjectPersonId });
         return { activated: false, householdId: null, isInitial: false };
     }
 
@@ -316,7 +316,7 @@ async function clearBackgroundCheck(tx: TxClient, processId: number, actorId: nu
         await tx.orgMembership.update({ where: { id: process.orgMembershipId! }, data: { status: "ACTIVE" } });
     }
 
-    await audit(tx, actorId, processId, { status: process.status }, { status: paid ? "ACTIVE" : "PENDING_PAYMENT", bgCleared: true });
+    await audit(tx, personActor(actorId), processId, { status: process.status }, { status: paid ? "ACTIVE" : "PENDING_PAYMENT", bgCleared: true });
     return { activated: paid, householdId, isInitial: process.kind === "INITIAL" };
 }
 
@@ -397,7 +397,7 @@ export async function overrideBlocked(processId: number, actorId: number, action
             const reviewStatus = blocked ? blockedResetStatus(process) : fresh.status;
             await tx.backgroundCheckAttestation.deleteMany({ where: { processId } });
             await tx.orgMembershipProcess.update({ where: { id: processId }, data: { status: reviewStatus, bgClearedAt: null, stageEnteredAt: new Date() } });
-            await audit(tx, actorId, processId, { status: fresh.status }, { status: reviewStatus, action: "board reset" });
+            await audit(tx, personActor(actorId), processId, { status: fresh.status }, { status: reviewStatus, action: "board reset" });
             return reviewStatus;
         });
         await notifyReviewers();
@@ -470,10 +470,10 @@ async function notifyPaymentOpen(householdId: number) {
     );
 }
 
-function audit(db: DbClient, actorId: number, processId: number, oldData: object, newData: object) {
+function audit(db: DbClient, actor: AuditActor, processId: number, oldData: object, newData: object) {
     return db.auditLog.create({
         data: {
-            actorId: actorId || SYSTEM_ACTOR,
+            ...actor,
             action: "EDIT",
             tableName: "OrgMembershipProcess",
             affectedEntityId: processId,

--- a/checkin-app/src/lib/nav/types.ts
+++ b/checkin-app/src/lib/nav/types.ts
@@ -3,7 +3,7 @@
  * keeps its own data array (FACILITY_NAV_LINKS etc.) — only the link type is shared.
  *
  * Sections that gate tabs extend this with their own field: shopNav adds a
- * required `visible` predicate, systemStatusNav adds an optional `sysadminOnly`.
+ * required `visible` predicate.
  */
 export interface NavLink {
   name: string;

--- a/checkin-app/src/lib/shopifyWebhookReceipt.ts
+++ b/checkin-app/src/lib/shopifyWebhookReceipt.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
+import { systemActor } from "@/lib/auditActor";
 
 /**
  * Delivery log for the inbound Shopify webhook, surfaced on the "Shopify
@@ -92,7 +93,7 @@ export async function recordShopifyWebhookReceipt(
         };
         await prisma.auditLog.create({
             data: {
-                actorId: 0, // system — no session behind an inbound webhook
+                ...systemActor("webhook:shopify-receipt"),
                 action: "CREATE",
                 tableName: SHOPIFY_WEBHOOK_RECEIPT_TABLE,
                 affectedEntityId: 0, // no entity row backs a receipt; newData IS the record

--- a/checkin-app/src/lib/systemStatusNav.ts
+++ b/checkin-app/src/lib/systemStatusNav.ts
@@ -4,15 +4,10 @@
  */
 import type { NavLink } from "@/lib/nav/types";
 
-export interface SystemStatusNavLink extends NavLink {
-  /** Tab visible only to sysadmins (e.g. the Audit Log). */
-  sysadminOnly?: boolean;
-}
-
-export const SYSTEM_STATUS_NAV_LINKS: SystemStatusNavLink[] = [
+export const SYSTEM_STATUS_NAV_LINKS: NavLink[] = [
   { name: "System Status", href: "/system-status/health", icon: "💚" },
   { name: "Link Status", href: "/system-status/links", icon: "🔗" },
   { name: "Lifecycle", href: "/system-status/lifecycle", icon: "🔄" },
   { name: "Errors", href: "/system-status/errors", icon: "🚨" },
-  { name: "Audit Log", href: "/system-status/audit-log", icon: "📜", sysadminOnly: true },
+  { name: "Audit Log", href: "/system-status/audit-log", icon: "📜" },
 ];

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prisma";
+import { personActor, systemActor, type AuditActor } from "@/lib/auditActor";
 import { escapeHtml } from "@/lib/email-templates/base";
 import { emailBoardMembers, emailHouseholdLeads } from "@/lib/emailRecipients";
 import { isTrustedAdultConflict } from "@/lib/trusted-adult/conflict";
@@ -39,7 +40,6 @@ function lockTrustedAdult(tx: TxClient, taId: number) {
  *   any non-terminal ──(household withdraws / board override)──► REVOKED
  */
 
-const SYSTEM_ACTOR = 0;
 const APPROVAL_VALID_DAYS = 365;
 const WARN_LEAD_DAYS = 30;
 
@@ -106,14 +106,14 @@ export async function createTrustedAdult(input: CreateInput) {
                 trustedAdultEmail: contact.email,
                 familyContext: input.familyContext.trim(),
                 origin: input.origin ?? "SELF_DISCLOSED",
-                disclosedById: input.disclosedById || SYSTEM_ACTOR,
+                disclosedById: input.disclosedById,
                 reviews: {
                     create: { householdId: input.householdId, kind: "INITIAL", status: "PENDING_BOARD_REVIEW" },
                 },
             },
             include: { reviews: true },
         });
-        await audit(tx, input.disclosedById, created.id, {}, { created: true, status: "PENDING_BOARD_REVIEW" }, "CREATE");
+        await audit(tx, personActor(input.disclosedById), created.id, {}, { created: true, status: "PENDING_BOARD_REVIEW" }, "CREATE");
         return created;
     });
 
@@ -142,7 +142,7 @@ export async function renewTrustedAdult(id: number, actorId: number) {
         const created = await tx.trustedAdultReview.create({
             data: { trustedAdultId: ta.id, householdId: ta.householdId, kind: "RENEWAL", status: "PENDING_BOARD_REVIEW" },
         });
-        await audit(tx, actorId, ta.id, {}, { renewal: created.id, status: "PENDING_BOARD_REVIEW" }, "CREATE");
+        await audit(tx, personActor(actorId), ta.id, {}, { renewal: created.id, status: "PENDING_BOARD_REVIEW" }, "CREATE");
         return created;
     });
     await notifyBoard();
@@ -200,7 +200,7 @@ export async function resubmitWithChanges(id: number, actorId: number, input: Re
                 proposedContext: input.familyContext.trim(),
             },
         });
-        await audit(tx, actorId, ta.id, {}, { modified: created.id, status: "PENDING_BOARD_REVIEW" }, "CREATE");
+        await audit(tx, personActor(actorId), ta.id, {}, { modified: created.id, status: "PENDING_BOARD_REVIEW" }, "CREATE");
         return created;
     });
     await notifyBoard();
@@ -247,7 +247,7 @@ export async function hideTrustedAdult(id: number, actorId: number) {
             throw new TrustedAdultError("wrong_phase", "Only a withdrawn trusted adult can be hidden.");
         }
         const updated = await tx.trustedAdult.update({ where: { id: ta.id }, data: { hiddenAt: new Date() } });
-        await audit(tx, actorId, ta.id, { hiddenAt: null }, { hiddenAt: updated.hiddenAt });
+        await audit(tx, personActor(actorId), ta.id, { hiddenAt: null }, { hiddenAt: updated.hiddenAt });
         return updated;
     });
 }
@@ -276,7 +276,7 @@ export async function withdrawTrustedAdult(id: number, actorId: number, opts?: {
                 throw new TrustedAdultError("wrong_phase", "No pending change to cancel.");
             }
             await tx.trustedAdultReview.update({ where: { id: latest.id }, data: { status: "REVOKED" } });
-            await audit(tx, actorId, ta.id, { status: latest.status }, { status: "REVOKED" });
+            await audit(tx, personActor(actorId), ta.id, { status: latest.status }, { status: "REVOKED" });
             return { ...latest, status: "REVOKED" as const };
         });
     }
@@ -294,7 +294,7 @@ export async function withdrawTrustedAdult(id: number, actorId: number, opts?: {
             data: { status: "REVOKED" },
         });
         for (const r of live) {
-            await audit(tx, actorId, ta.id, { status: r.status }, { status: "REVOKED" });
+            await audit(tx, personActor(actorId), ta.id, { status: r.status }, { status: "REVOKED" });
         }
         return { ...live[0], status: "REVOKED" as const };
     });
@@ -395,7 +395,7 @@ export async function decideReview(reviewId: number, boardMemberId: number, inpu
         const updated = await tx.trustedAdultReview.update({ where: { id: reviewId }, data });
         // Approving a MODIFIED review is the moment its proposed edits become fact.
         if (input.decision === "APPROVE") await promoteProposal(tx, review);
-        await audit(tx, boardMemberId, review.trustedAdultId, { status: review.status }, { status, decision: input.decision });
+        await audit(tx, personActor(boardMemberId), review.trustedAdultId, { status: review.status }, { status, decision: input.decision });
         // "Deny & Revoke": reject the adult outright. Revoke EVERY live approval, not
         // just one — /operational shows a TA while ANY review is APPROVED, so leaving
         // one live would keep the adult on the pickup list after a full rejection.
@@ -410,7 +410,7 @@ export async function decideReview(reviewId: number, boardMemberId: number, inpu
                     data: { status: "REVOKED" },
                 });
                 for (const r of live) {
-                    await audit(tx, boardMemberId, review.trustedAdultId, { status: r.status }, { status: "REVOKED", revokedWithDenial: reviewId });
+                    await audit(tx, personActor(boardMemberId), review.trustedAdultId, { status: r.status }, { status: "REVOKED", revokedWithDenial: reviewId });
                 }
             }
         }
@@ -509,7 +509,7 @@ export async function overrideReview(
     const updated = await prisma.$transaction(async (tx) => {
         const u = await tx.trustedAdultReview.update({ where: { id: reviewId }, data });
         if (action === "approve") await promoteProposal(tx, review);
-        await audit(tx, actorId, review.trustedAdultId, { status: review.status }, { status: data.status, override: action });
+        await audit(tx, personActor(actorId), review.trustedAdultId, { status: review.status }, { status: data.status, override: action });
         return u;
     });
     // A forced denial/revocation notifies the family, like the ordinary deny path.
@@ -556,7 +556,7 @@ export async function runExpirySweep(now: Date) {
     for (const r of lapsed) {
         await prisma.$transaction(async (tx) => {
             await tx.trustedAdultReview.update({ where: { id: r.id }, data: { status: "EXPIRED" } });
-            await audit(tx, SYSTEM_ACTOR, r.trustedAdultId, { status: r.status }, { status: "EXPIRED" });
+            await audit(tx, systemActor("cron:trusted-adult-expiry"), r.trustedAdultId, { status: r.status }, { status: "EXPIRED" });
         });
         expired++;
     }
@@ -592,7 +592,7 @@ async function notifyHouseholdFamily(householdId: number, subject: string, body?
 
 function audit(
     db: TxClient | typeof prisma,
-    actorId: number,
+    actor: AuditActor,
     taId: number,
     oldData: object,
     newData: object,
@@ -600,7 +600,7 @@ function audit(
 ) {
     return db.auditLog.create({
         data: {
-            actorId: actorId || SYSTEM_ACTOR,
+            ...actor,
             action,
             tableName: "TrustedAdult",
             affectedEntityId: taId,

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -290,6 +290,7 @@ export const classifications = {
         id: 'internal',
         timestamp: 'internal',
         actorId: 'internal',
+        actorSystem: 'internal',
         action: 'internal',
         tableName: 'internal',
         affectedEntityId: 'internal',


### PR DESCRIPTION
Addresses **B16** and **B17** of the Class B audit register (#1529). Both are
about the accountability machinery not being able to answer its own questions:
one about what the trail records, one about who may read it.

## B16 — a system actor names itself

`SYSTEM_ACTOR = 0` was declared in seven files, with four more bare `actorId: 0`
literals alongside. A row could therefore say only "not a person" — never
whether it was the nightly sweep, the renewal sweep, or a Shopify webhook. The
register's own phrasing: *"the system did it" is only an answer if the trail
says which part of it.*

- `AuditLog` gains a nullable `actorSystem`, plus indexes on `actorId` and
  `actorSystem` (the two columns the viewer now filters on).
- New `checkin-app/src/lib/auditActor.ts` is the single place that names the
  automated paths — `cron:` for a scheduled route, `webhook:` for an inbound
  call, `system:` for a library path more than one surface can wake, `kiosk:`
  for the check-in station — and builds the actor half of an audit payload.
- Twelve write sites now carry a name: `cron:nightly`,
  `cron:lifecycle-reconcile`, `cron:scholarship-grace-expiry`,
  `cron:trusted-adult-expiry`, `system:renewal-open`,
  `system:membership-renewal-advance`, `system:membership-external-advance`,
  `system:person-bg-open`, `webhook:zoho-contract`, `webhook:shopify-order`,
  `webhook:shopify-receipt`, `kiosk:two-deep`.

The fail-open half of the finding is closed by the same module. All four
`actorId: actorId || 0` sites go through `personActor()`, which throws rather
than filing a board decision that arrived with a falsy id as System — *fail
closed*, where the tell is exactly the `|| 0` default. Making that stick meant
changing the shape of the two internal `audit()` helpers
(`membership/review.ts`, `trusted-adult/service.ts`) from a bare `actorId:
number` to an `AuditActor`, so no call site can reach the system branch by
accident.

`TrustedAdult.disclosedById` loses the same `|| SYSTEM_ACTOR` fallback while
we're in the file. It is a required FK to `Person`, so the fallback could only
ever have produced a constraint violation — dead fail-open, not a behaviour
change.

## B17 — a trail nobody can read is not a trail

Both layers were `isSysadmin`-only, so the board — the people who answer for the
decisions recorded there — could not read the log at all. The route, page and
nav tab now admit `isSysadmin | isBoardMember`. Audit Log was the last user of
the `sysadminOnly` nav mechanism, so that field, its filter in the
`/system-status` layout, and its mention in `lib/nav/types.ts` are deleted
rather than left behind with no users. The page's own gate goes too: the layout
already gates the section, and the page added nothing on top of it.

`pageRegistry.ts` had already listed `/system-status/audit-log` as `BOARD`
visible — the registry and the gate disagreed, and this is the side that was
wrong.

Two filters join action / entity type / date range:

- **Actor** — one Select over both actor columns. A person's option value is
  their id; a system path's is its own name, which never parses as a number, so
  the route can tell them apart without a second parameter. Options come back as
  `actors` / `systemActors` distincts.
- **Entity #** — matches `affectedEntityId` **or** `secondaryAffectedEntity`, so
  a merge or an enrollment surfaces from either slot rather than only the one
  the writer happened to use.

Rows written by a system actor render the path name in place of a bare
"System".

## Migration

`20260806140000_audit_log_actor_system` — one transaction, additive and
nullable, no backfill. During the rolling-deploy drain window, old code writing
`actorId: 0` with no `actorSystem` leaves the column null, which reads as
today's "some system actor". Nothing reads the column until the new viewer is
serving.

## Not in scope

`beginRenewal` records a **member's** renewal confirmation under a system actor
— misattribution rather than indistinguishability, and a different fix (a
signature change, ~12 test call sites, and one pinned expectation reversed).
Filed as #1538. It now logs as `system:membership-renewal-advance`, which at
least makes the wrong attribution legible.

## Verification

- `tsc --noEmit` and `npm run lint` clean.
- `npm run test:ci` — 2550 tests, 269 suites, green.
- `npm run test:integration` — 1349 tests, 131 suites, green, against a real
  Postgres provisioned with `prisma migrate deploy` (not `db push`, so the
  partial unique indexes are present).

New coverage: `lib/__tests__/auditActor.test.ts` pins the fail-closed guard and
the name grammar; `adminAuditAPI.integration.test.ts` gains a board-member 200
and both new filters, including an entity that appears only in the secondary
slot; the layout, nav and page tests that asserted the sysadmin-only tab now
assert the opposite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
