### PR TITLE
fix(api): refuse unauthorized attendance writes as 404, not 403 (B13)

### DIFF
--- a/checkin-app/src/app/__tests__/attendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendance.integration.test.ts
@@ -177,10 +177,12 @@ describe('Attendance API Integration Tests', () => {
             });
 
             const res = await DELETE(req as unknown as import("next/server").NextRequest);
-            expect(res.status).toBe(403);
-            
+            // 404, not 403: a visit id the caller may not touch must be
+            // indistinguishable from one that does not exist.
+            expect(res.status).toBe(404);
+
             const data = await res.json();
-            expect(data.error).toContain('Forbidden');
+            expect(data.error).toBe('Visit not found');
         });
     });
 

--- a/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceAPI.integration.test.ts
@@ -325,10 +325,27 @@ describe('General Attendance API Integration Tests', () => {
                  body: JSON.stringify({ type: 'MANUAL_CHECKIN', participantId: adminId })
              });
              const res = await POST(req as unknown as import("next/server").NextRequest) as Response;
-             expect(res.status).toBe(403);
-             
+             // 404, not 403: an id the caller may not check in must be
+             // indistinguishable from one that does not exist.
+             expect(res.status).toBe(404);
+
              const data = await res.json();
-             expect(data.error).toMatch(/Forbidden/);
+             expect(data.error).toBe('Participant not found');
+        });
+
+        it('a blocked check-in is indistinguishable from a nonexistent participant', async () => {
+             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: commonId } });
+
+             const request = (participantId: number) => new Request(`http://localhost:4000/api/attendance`, {
+                 method: 'POST',
+                 body: JSON.stringify({ type: 'MANUAL_CHECKIN', participantId })
+             });
+
+             const blocked = await POST(request(adminId) as unknown as import("next/server").NextRequest) as Response;
+             const missing = await POST(request(99999999) as unknown as import("next/server").NextRequest) as Response;
+
+             expect(blocked.status).toBe(missing.status);
+             expect(await blocked.json()).toEqual(await missing.json());
         });
 
         it('should block checking in a user that is already checked in', async () => {
@@ -455,10 +472,12 @@ describe('General Attendance API Integration Tests', () => {
              });
 
              const res = await DELETE(req as unknown as import("next/server").NextRequest) as Response;
-             expect(res.status).toBe(403);
-             
+             // 404, not 403: a visit id the caller may not touch must be
+             // indistinguishable from one that does not exist.
+             expect(res.status).toBe(404);
+
              const data = await res.json();
-             expect(data.error).toMatch(/Forbidden/);
+             expect(data.error).toBe('Visit not found');
         });
 
         it('should allow a common user to check themselves out', async () => {

--- a/checkin-app/src/app/api/attendance/route.ts
+++ b/checkin-app/src/app/api/attendance/route.ts
@@ -139,8 +139,11 @@ export const DELETE = withAuth({}, async (req, auth) => {
         const isHouseholdCheckOut = Boolean(user.householdId && visit.person.householdId === user.householdId && user.householdLead);
         const isAdmin = user.isSysadmin || user.isKeyholder || user.isBoardMember;
 
+        // Out of scope reads exactly as missing (same status, same message): a
+        // caller not entitled to the visit learns nothing about whether the id
+        // exists. docs/rules/principles.md — no existence oracle.
         if (!isSelf && !isHouseholdCheckOut && !isAdmin) {
-            return apiError("Forbidden: You are not authorized to check out this user.", 403);
+            return apiError("Visit not found", 404);
         }
 
         const finalVisits = await processVisitCheckout(visitId, new Date(), undefined, "WEB");
@@ -183,11 +186,15 @@ export const POST = withAuth({}, async (req, auth) => {
                 return apiError("Participant not found", 404);
             }
 
-            // Check Permissions
+            // Check Permissions. Out of scope reads exactly as missing (same
+            // status, same message), so an id the caller may not check in is
+            // indistinguishable from one that does not exist — otherwise any
+            // signed-in member could walk the person id space.
+            // docs/rules/principles.md — no existence oracle.
             const isSelf = participant.id === Number(user.id);
             const isHouseholdCheckIn = Boolean(user.householdId && participant.householdId === user.householdId && user.householdLead);
             if (!isSelf && !isHouseholdCheckIn && !isAdmin) {
-                return apiError("Forbidden: You are not authorized to check in this user.", 403);
+                return apiError("Participant not found", 404);
             }
 
             const arrivalTime = new Date();


### PR DESCRIPTION
Finding **B13** of the #1529 domain-register audit. (Plain reference, no closing keyword; #1529 carries 27 other findings.)

## The leak

Two handlers loaded a record, returned 404 when it was missing, and only then checked whether the caller was entitled to it, returning 403:

```
findUnique(id) → !row → 404 "… not found"
               → then authz → 403 "Forbidden: …"
```

The two responses differ in status and in message, so a caller who is refused learns what a refused caller should not learn: that the id is real. Both routes are `withAuth({})` with no scope, so the reachable audience is every signed-in member. A member can walk the person and visit id spaces and separate live ids from dead ones. `docs/rules/principles.md` names this under "No existence oracle": a distinct error message or a different status code is itself the disclosure.

No names or PII leak, only existence and cardinality. Ids are autoincrement, so the range is guessable; MED looks right.

## What changed

Out of scope now reads exactly as missing, same status and same body:

| Route | Id space |
|---|---|
| `POST /api/attendance` (`MANUAL_CHECKIN`) | participant id |
| `DELETE /api/attendance` | visit id |

No new helper. `/api/attendance/manual/[id]` already solves this; its `loadEditableVisit` collapses missing, tombstoned and out-of-scope into a single 404, and these two handlers now match it.

## Tests

Three integration tests asserted the 403, so they were the oracle written down as a requirement; they now assert 404 and the exact message. Two files cover `DELETE /api/attendance` with different assertion strings (`attendance.integration.test.ts` and `attendanceAPI.integration.test.ts`), which is why this took two commits. A new test asserts that a blocked check-in and a nonexistent participant return byte-identical responses.

Verified against a local throwaway Postgres, on the rebased branch:

- integration, `attendance` + `attendanceAPI` + `auditLog` — 34 passed
- unit run narrowed to `(attendance|security|livePerson)` — 735 passed, 28 suites
- `tsc --noEmit` — clean

## Reviewer notes

- **A third site went away rather than being fixed.** `POST /api/events/[id]/attendance` had the same shape and was in the first version of this PR. #1553 deleted the route as dead code while this was open, so the rebase takes the deletion and the change is gone from the diff.
- **Frontend is unaffected.** `attendance/current/page.tsx` renders `d.error` verbatim and special-cases only `"User is already checked in"`. Nothing couples to the status.
- **No security-boundary change.** `/api/attendance` is not in `src/security/registry.ts`, so this is app code only; no registry-first split.
- **Two event-id oracles remain open**, same shape, out of scope here: `GET /api/events/[id]` (`notFound` at :84, then `forbidden` at :94) and its `PATCH`. The event id space is still walkable until those move. Two lines each; happy to take them in a follow-up.
- The `LIVE_PERSON` gap I found in the same handler landed separately as #1537 and merged; this branch composes with it cleanly, and the merged-away-person test passes alongside the new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
