### PR TITLE
fix(emergency-contacts): a partial save can't destroy a household's valid contact (B11)

### DIFF
--- a/checkin-app/src/lib/emergencyContacts/__tests__/service.integration.test.ts
+++ b/checkin-app/src/lib/emergencyContacts/__tests__/service.integration.test.ts
@@ -138,6 +138,50 @@ describe("upsertPrimaryContact — partial tolerance + member rejection", () => 
     });
 });
 
+describe("upsertPrimaryContact — a partial save can't degrade a stored contact", () => {
+    it("refuses a blank name and leaves the stored contact untouched", async () => {
+        const hh = await makeHousehold("upsert-degrade-name");
+        const before = await createContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000", email: "may@example.com" });
+
+        await expect(upsertPrimaryContact(prisma, hh, { name: "", phone: "555-555-2000" })).rejects.toMatchObject({ code: "incomplete" });
+
+        const after = await prisma.emergencyContact.findUnique({ where: { id: before.id } });
+        expect(after).toMatchObject({ name: "Aunt May", phone: "555-555-2000", email: "may@example.com" });
+        expect(await householdHasValidContact(prisma, hh)).toBe(true);
+    });
+
+    it("refuses a blank phone, and an email-only payload can't strip name+phone", async () => {
+        const hh = await makeHousehold("upsert-degrade-phone");
+        const before = await createContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000" });
+
+        await expect(upsertPrimaryContact(prisma, hh, { name: "Aunt May", phone: "" })).rejects.toMatchObject({ code: "incomplete" });
+        // Name and phone absent entirely: the stored values carry, so this is a
+        // plain email edit rather than a wipe.
+        const updated = await upsertPrimaryContact(prisma, hh, { email: "may@example.com" });
+        expect(updated).toMatchObject({ id: before.id, name: "Aunt May", phone: "555-555-2000", email: "may@example.com" });
+        expect(await householdHasValidContact(prisma, hh)).toBe(true);
+    });
+
+    it("keeps a stored email when the caller collects no email field", async () => {
+        const hh = await makeHousehold("upsert-keep-email");
+        await upsertPrimaryContact(prisma, hh, { name: "Aunt May", phone: "555-555-2000", email: "may@example.com" });
+
+        const updated = await upsertPrimaryContact(prisma, hh, { name: "Uncle Ben", phone: "555-555-3000" });
+        expect(updated).toMatchObject({ name: "Uncle Ben", phone: "555-555-3000", email: "may@example.com", emailNorm: "may@example.com" });
+    });
+
+    it("still lets a resumable form build up a partial contact from nothing", async () => {
+        const hh = await makeHousehold("upsert-build-up");
+        const first = await upsertPrimaryContact(prisma, hh, { name: "Aunt May", phone: "" });
+        expect(first).toMatchObject({ name: "Aunt May", phone: "" });
+        expect(await householdHasValidContact(prisma, hh)).toBe(false);
+
+        const second = await upsertPrimaryContact(prisma, hh, { phone: "555-555-2000" });
+        expect(second).toMatchObject({ id: first!.id, name: "Aunt May", phone: "555-555-2000" });
+        expect(await householdHasValidContact(prisma, hh)).toBe(true);
+    });
+});
+
 describe("getPrimaryValidContact", () => {
     it("returns the valid contact, skipping a flagged one, ordered by priority", async () => {
         const hh = await makeHousehold("primary-valid");

--- a/checkin-app/src/lib/emergencyContacts/service.ts
+++ b/checkin-app/src/lib/emergencyContacts/service.ts
@@ -174,21 +174,32 @@ export async function deleteContact(db: Db, householdId: number, contactId: numb
  * household settings, membership intake). Upserts the primary (lowest-priority)
  * contact.
  *
- * Tolerant of partial input so resumable forms can save a half-filled contact:
- * blank name+phone is a no-op; a partial contact is persisted as-is without the
- * member check. Direction A is enforced only once BOTH name and phone are
- * present (a "real" contact), at which point a successful check also clears any
- * stale conflict flag. The submit-time floor ({@link householdHasValidContact})
- * is what guarantees a complete, valid contact before a household advances.
+ * Tolerant of partial input so resumable forms can save a half-filled contact,
+ * but never at the expense of one already stored: a field the caller omits keeps
+ * its stored value, and a save that would leave a stored name+phone contact
+ * without one of them is refused. Removing a contact is {@link deleteContact}.
+ * Direction A is enforced only once the merged contact has BOTH name and phone
+ * (a "real" contact), at which point a successful check also clears any stale
+ * conflict flag. The submit-time floor ({@link householdHasValidContact}) is
+ * what guarantees a complete, valid contact before a household advances.
  */
 export async function upsertPrimaryContact(
     db: Db,
     householdId: number,
     fields: { name?: string | null; phone?: string | null; email?: string | null },
 ): Promise<EmergencyContact | null> {
-    const name = (fields.name ?? "").trim();
-    const phone = (fields.phone ?? "").trim();
-    const email = (fields.email ?? "").trim() || null;
+    const primary = await db.emergencyContact.findFirst({
+        where: { householdId },
+        orderBy: [{ priority: "asc" }, { id: "asc" }],
+    });
+
+    // A field the caller never sent is not an instruction to clear it: absent
+    // keys fall back to what is stored, so a form that collects a subset of the
+    // contact can't blank the rest.
+    const sent = (v: string | null | undefined) => (v == null ? undefined : v.trim());
+    const name = sent(fields.name) ?? primary?.name.trim() ?? "";
+    const phone = sent(fields.phone) ?? primary?.phone.trim() ?? "";
+    const email = (sent(fields.email) ?? primary?.email ?? "") || null;
     if (!name && !phone && !email) return null;
 
     if (phone && !isValidPhone(phone)) {
@@ -196,6 +207,15 @@ export async function upsertPrimaryContact(
     }
 
     const complete = !!name && !!phone;
+    // Blanking a field is not a delete path: refuse a save that would strip the
+    // name or phone off a contact that has both.
+    if (!complete && primary?.name.trim() && primary.phone.trim()) {
+        throw new EmergencyContactError(
+            "incomplete",
+            "An emergency contact needs both a name and a phone number. To take this contact off the household, remove it instead of clearing it.",
+        );
+    }
+
     if (complete) await assertExternal(db, householdId, { name, phone, email });
 
     const data = {
@@ -207,10 +227,6 @@ export async function upsertPrimaryContact(
         ...(complete && { conflictParticipantId: null, conflictedAt: null }),
     };
 
-    const primary = await db.emergencyContact.findFirst({
-        where: { householdId },
-        orderBy: [{ priority: "asc" }, { id: "asc" }],
-    });
     if (primary) return db.emergencyContact.update({ where: { id: primary.id }, data });
     return db.emergencyContact.create({ data: { householdId, priority: 0, ...data } });
 }


### PR DESCRIPTION
Addresses finding **B11** of the Class-B domain-register audit, #1529.

**No closing keyword on purpose.** #1529 is the register for all 28 Class-B findings; 27 of them are untouched by this PR and the issue must stay open after this merges. Close B11 by striking it from the register, not by merging this.

## The defect

`upsertPrimaryContact` guarded only the all-blank input case. A **partial** payload passed that guard, reached `update`, and overwrote the household's stored contact with empty `name`/`phone`:

```ts
const name = (fields.name ?? "").trim();
const phone = (fields.phone ?? "").trim();
const email = (fields.email ?? "").trim() || null;
if (!name && !phone && !email) return null;   // all-blank only
```

`{ name: "", phone: "", email: "x@y.com" }` or `{ name: "Jo", phone: "" }` cleared the household's only valid emergency contact through the ordinary save path — no delete, no confirmation, and a 200 back to the lead.

A second instance of the same class sat in the `data` object: `email` was written unconditionally, so the two callers that never collect an email (`membership-ops/households/[id]` and `household/settings`) silently nulled an email captured at intake on every edit.

## The fix

Both parts are one change in the shared service function, so all four callers are covered at once. No migration, no caller edits.

1. **An omitted field is no longer read as an intentional blank.** `findFirst` moves above the field read; `undefined`/`null` falls back to the stored value instead of coalescing to `""`. A form that collects a subset of the contact can no longer blank the rest. This is what fixes the email case.
2. **Degrade guard.** If the merged result lacks a name or phone *and* the stored row has both, throw `EmergencyContactError("incomplete", ...)`. Nothing is written.

Downstream of the merge, direction A (`assertExternal`) and the conflict-flag clear now evaluate the *merged* contact — which is what actually gets stored, so that is the correct input for both.

Creating a partial contact from nothing is unchanged: the docstring's tolerance was about letting a resumable form build up a half-filled contact, and that still works. It was never meant to let a partial save degrade a complete one.

## Caller behaviour changes

| Caller | Change |
|---|---|
| `api/membership-ops/households/[id]/route.ts:100` | Stored email survives an ops edit (previously nulled on every edit). Blank name or phone → 400 instead of destroying the contact. |
| `api/household/settings/route.ts:52` | Same on both counts. |
| `api/profile/onboarding/route.ts:42` | Sends all three keys, so only the degrade guard applies: clearing name/phone on a complete contact → 400. |
| `lib/membership/intake.ts:262` | Same. `intakeResponse.ts` already maps `EmergencyContactError` to a 400 against the `emergencyContact` field, so the form highlights it like any other validation failure. |

All four already catch `EmergencyContactError` and return 400, so no caller needed editing.

## Why throw rather than silently no-op

A silent no-op returns 200 while the form still displays fields that were not saved — the lead believes they cleared the contact and it is still there. Throwing matches what `createContact`/`updateContact` already do for the same input shape, reuses the existing `"incomplete"` code, and the message names the real path: remove the contact rather than clearing it. Clearing a contact is what `deleteContact` is for, so the guard does not widen to accommodate a caller that wants one.

## Reviewer notes

- The guard checks the stored row's `name`+`phone` only, not `conflictParticipantId`. A conflict-flagged contact still holds real contact data, and the remediation path is entering a different complete person, not blanking the row.
- `null` is treated the same as `undefined` (not provided). A client that means "clear" sends `""`, and clearing to incomplete is refused anyway.
- `householdHasValidContact`/`getPrimaryValidContact` are untouched — they are the submit-time floor and gate advancement; they never stopped the destructive write.

## Tests

Four new cases in `service.integration.test.ts`: degrade-by-blank-name (asserts the stored row is unchanged), degrade-by-blank-phone plus an email-only edit that must succeed, email preservation when the caller collects no email, and a control that partial *creation* from nothing still works.

- Pre-fix (service.ts reverted): **4 failed**, 24 passed
- Post-fix EC service suite: **28 passed**
- EC route-guard integration: **4 passed**
- 6 related integration suites: **72 passed**
- Full unit run: **2543 passed**, 268 suites
- `tsc --noEmit`: clean

Integration runs were serial against a throwaway Postgres provisioned with `migrate deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
