### PR TITLE
fix(membership): store volunteer designations under the canonical inbox key

### DIFF
--- a/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
@@ -151,6 +151,33 @@ describe('Membership settings + volunteer designations API', () => {
         expect(data.warning).toBeTruthy();
     });
 
+    it('treats inbox variants of a designated email as already designated', async () => {
+        asBoard(boardId);
+        const base = `voldedupe-${TAG}@gmail.com`;
+        const first = await DESIG_POST(jsonReq('POST', { email: base }));
+        expect(first.status).toBe(201);
+        const { designation } = await first.json();
+
+        for (const variant of [`voldedupe-${TAG}+treehouse@gmail.com`, `vol.dedupe-${TAG}@googlemail.com`, ` VolDedupe-${TAG}@gmail.com `]) {
+            const res = await DESIG_POST(jsonReq('POST', { email: variant }));
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            expect(data.warning).toBe('This email is already designated.');
+            expect(data.designation.id).toBe(designation.id);
+        }
+
+        expect(await prisma.volunteerDesignation.count({ where: { email: { contains: `voldedupe-${TAG}` } } })).toBe(1);
+    });
+
+    it('dedupes against a row stored before canonicalization', async () => {
+        asBoard(boardId);
+        const legacy = await prisma.volunteerDesignation.create({ data: { email: `legacyvol-${TAG}+tag@gmail.com` } });
+        const res = await DESIG_POST(jsonReq('POST', { email: `legacy.vol-${TAG}@gmail.com` }));
+        expect(res.status).toBe(200);
+        expect((await res.json()).designation.id).toBe(legacy.id);
+        expect(await prisma.volunteerDesignation.count({ where: { email: { contains: `legacyvol-${TAG}` } } })).toBe(1);
+    });
+
     it('rejects an invalid email', async () => {
         asBoard(boardId);
         const res = await DESIG_POST(jsonReq('POST', { email: 'not-an-email' }));

--- a/checkin-app/src/app/api/settings/membership/volunteer-designations/route.ts
+++ b/checkin-app/src/app/api/settings/membership/volunteer-designations/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { apiError } from "@/lib/api-response";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import { canonicalizeEmail } from "@/lib/emailNormalize";
 
 export const dynamic = "force-dynamic";
 
@@ -26,12 +27,17 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
     } catch {
         return apiError("Invalid JSON", 400);
     }
-    const email = body.email?.trim().toLowerCase();
+    // Store the canonical inbox key, the same key matchesVolunteerDesignation
+    // matches on — otherwise the @unique column guards a key nobody reads and
+    // variants of one inbox (plus-tag, Gmail dots) become separate designations.
+    const email = body.email ? canonicalizeEmail(body.email) : undefined;
     if (!email || !emailRegex.test(email)) {
         return apiError("A valid email is required", 400);
     }
 
-    const existing = await prisma.volunteerDesignation.findUnique({ where: { email } });
+    // Canonicalize both sides: rows stored before canonicalization still dedupe.
+    const all = await prisma.volunteerDesignation.findMany();
+    const existing = all.find((d) => canonicalizeEmail(d.email) === email);
     if (existing) return NextResponse.json({ designation: existing, warning: "This email is already designated." });
 
     // Non-blocking warning: is this email already an active full-price member?


### PR DESCRIPTION
Fixes finding **B25** ("Volunteer designation writes raw email") of the Class-B domain-register audit, #1529. No closing keyword — #1529 tracks the whole register, not this one finding.

## The defect

The register line undersells it. The write was not raw — it was `.trim().toLowerCase()`. The real problem is that **the write and the read normalized to different keys.**

`VolunteerDesignation.email` is `@unique`. The POST route stored `trim().toLowerCase()`, but `matchesVolunteerDesignation` (`src/lib/membership/review.ts`) runs *both* sides through `canonicalizeEmail` — which additionally strips plus-tags everywhere and, on Gmail, drops dots and folds `googlemail.com`.

So the unique constraint guarded a key nothing ever read:

- `foo+treehouse@gmail.com`, `f.oo@gmail.com` and `foo@gmail.com` were three distinct rows that all matched the same household.
- The "This email is already designated" check missed every variant, so the board could silently create duplicate designations for one inbox, and the settings list showed all three.
- The constraint — the thing meant to make a designation idempotent — was enforced on the wrong column value.

Secondary: the inline `.trim().toLowerCase()` was a hand-rolled copy of `normalizeEmail` (`src/lib/prismaEmailNormalize.ts`), whose docstring names per-route lowercasing as exactly the drift it exists to prevent. Its Prisma extension only intercepts `person.*` writes, so `volunteerDesignation` had no choke point at all.

## The change

POST now canonicalizes through the shared `canonicalizeEmail` before both the duplicate check and the write:

```ts
const email = body.email ? canonicalizeEmail(body.email) : undefined;
...
const all = await prisma.volunteerDesignation.findMany();
const existing = all.find((d) => canonicalizeEmail(d.email) === email);
```

Two consequences worth naming:

1. The `@unique` column now holds the same key matching reads, so read and write cannot drift apart again — one shared function governs both.
2. The duplicate check canonicalizes the **stored** side too, rather than a `findUnique` on the incoming key. That is what lets rows written before this change dedupe against new writes with no backfill. The table is a board allowlist, so the `findMany` is cheap.

## Why this option, and not the others

- **Rejected — add a canonical key column and move the unique constraint onto it, keeping `email` as typed.** Its only gain is displaying the typed plus-tag back to the board. It costs a migration plus a backfill of live rows, and the new unique constraint can fail outright on existing collapsed variants. The list is an allowlist of inboxes; showing the key that actually decides dues is the more honest display, not a regression.
- **Rejected — canonicalize only in the duplicate check, leave storage alone.** Cheapest, but the constraint still guards a key nobody matches on, so a race or any direct write reintroduces duplicates. That is the defect, not a fix for it.

## Migration

**None, and none needed.** Matching already canonicalized at read time, so every existing row keeps matching exactly the households it matched before. Nothing about stored rows changes, and the dedupe path handles pre-canonicalization rows directly.

## Also checked

- `GET` returns the raw list; `DELETE` keys off `id`. Neither assumes the stored string is what was typed. The settings UI (`membership-ops/volunteer-memberships/page.tsx`) only renders `d.email`.
- `applyVolunteerStatus` — the only consumer — is untouched. For a plainly-typed address `canonicalizeEmail` is byte-identical to `trim().toLowerCase()`, so behaviour before and after is the same; the two integration suites that exercise volunteer matching confirm it.
- Nothing under `src/security/` is touched.

## Tests

New cases in `membershipSettingsAPI.integration.test.ts`: designate an address, then attempt the plus-tag variant, the Gmail-dot/googlemail variant, and a whitespace/case variant — each must come back as already designated with the original row id, with the row count still 1. Plus a case that dedupes against a row stored before canonicalization. Seeded data has zero `VolunteerDesignation` rows, so the tests insert their own.

With the route change stashed, both new tests fail (`Expected 200, Received 201` — a second row created); everything else stays green.

```
membershipSettingsAPI.integration                            12 passed
membershipReviewAPI + membershipBgNonBlocking integration    37 passed
test:ci (volunteer|membership|emailNormalize|authzRegistry)  390 passed, 41 suites
tsc --noEmit                                                 clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)