### PR TITLE
fix(attendance): render an unknown supervision state when the roster fails to load (B6/B5)

### DIFF
--- a/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
+++ b/checkin-app/src/app/attendance/current/__tests__/page.test.tsx
@@ -37,6 +37,11 @@ function mockRoutes(overrides: Record<string, unknown | (() => unknown)> = {}) {
   });
 }
 
+// A roster column is the element wrapping its header label and its card grid.
+function columnFor(label: string) {
+  return screen.getByText(label).closest("div")!.parentElement!.parentElement!;
+}
+
 // The admin (id 1, sysadmin + keyholder) is not checked in and has a household,
 // so both the self check-in button and the household check-in row render.
 function setAdminSession() {
@@ -230,6 +235,62 @@ describe("attendance/current page", () => {
         expect.objectContaining({ color: "red", message: "Network error", autoClose: false }),
       ),
     );
+    expect(await screen.findByText("Network error occurred.")).toBeInTheDocument();
+  });
+
+  it("reports an unknown supervision state instead of an empty facility when the initial load throws", async () => {
+    setAdminSession();
+    global.fetch = jest.fn(async () => { throw new Error("down"); }) as unknown as typeof fetch;
+    renderWithProviders(<KioskDisplay />);
+
+    expect(await screen.findByText("Supervision status unknown")).toBeInTheDocument();
+    expect(screen.queryByText("The facility is currently empty.")).not.toBeInTheDocument();
+    expect(screen.queryByText("People Present: 0")).not.toBeInTheDocument();
+    expect(screen.getByText("People Present: —")).toBeInTheDocument();
+  });
+
+  it("reports an unknown supervision state when the initial load returns a server error", async () => {
+    setAdminSession();
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/api/attendance")) return { ok: false, json: async () => ({ error: "Server exploded" }) } as Response;
+      return { ok: true, json: async () => ({}) } as Response;
+    }) as unknown as typeof fetch;
+    renderWithProviders(<KioskDisplay />);
+
+    expect(await screen.findByText("Supervision status unknown")).toBeInTheDocument();
+    expect(screen.queryByText("The facility is currently empty.")).not.toBeInTheDocument();
+    expect(screen.getByText("People Present: —")).toBeInTheDocument();
+  });
+
+  it("reports an unknown supervision state when the response payload is unrecognized", async () => {
+    setAdminSession();
+    mockFetchJson({ "/api/attendance": { access: "something-else" } });
+    renderWithProviders(<KioskDisplay />);
+
+    expect(await screen.findByText("Supervision status unknown")).toBeInTheDocument();
+    expect(screen.getByText("Attendance is unavailable — the roster could not be loaded.")).toBeInTheDocument();
+    expect(screen.queryByText("The facility is currently empty.")).not.toBeInTheDocument();
+  });
+
+  it("counts a visitor with no recorded birth date as youth, not as a supervising adult", async () => {
+    setAdminSession();
+    mockFetchJson({
+      "/api/household": householdData,
+      "/api/attendance": {
+        access: "full",
+        attendance: [
+          // No server-computed isYouth and no birth date — the client fallback decides.
+          { id: 204, arrivedAt: "2026-07-01T14:15:00.000Z", participant: { id: 80, email: "dob@example.com", name: "No Dob", isKeyholder: false, isSysadmin: false, dateOfBirth: null, householdId: 11 } },
+        ],
+        counts: { keyholders: 0, volunteers: 0, youth: 1, total: 1 },
+        safety: { isLastKeyholder: false, isTwoDeepViolation: true },
+      },
+    });
+    renderWithProviders(<KioskDisplay />);
+    await screen.findByText("People Present: 1");
+
+    expect(within(columnFor("Students")).getByText("No Dob")).toBeInTheDocument();
+    expect(within(columnFor("Volunteers/Adults")).queryByText("No Dob")).not.toBeInTheDocument();
   });
 
   it("switches to kiosk mode automatically when the server flags a signed request", async () => {

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -77,12 +77,16 @@ function KioskDisplayInner() {
   const canCheckInHousehold = Boolean(currentUserHouseholdId);
 
   const isFull = data?.access === "full";
+  // Absent attendance is UNKNOWN, never "empty and compliant": every count and
+  // safety flag below is only meaningful while `data` is non-null, so each one is
+  // rendered behind that check.
   const counts = data?.counts || { keyholders: 0, volunteers: 0, youth: 0, total: 0 };
   const safety = data?.safety || { isLastKeyholder: false, isTwoDeepViolation: false };
 
   // Prefer the server-computed flag (the only youth signal the kiosk payload carries),
-  // fall back to the birth date the privileged payload still ships.
-  const visitIsYouth = (v: Visit) => v.participant.isYouth ?? isYouth(v.participant.dateOfBirth);
+  // fall back to the birth date the privileged payload still ships. This feeds the
+  // supervision columns, so an unknown birth date fails closed as youth.
+  const visitIsYouth = (v: Visit) => v.participant.isYouth ?? isYouth(v.participant.dateOfBirth, { unknownIs: "youth" });
 
   const fullAttendance = isFull ? (data as FullResponse).attendance : [];
   const keyholderList = fullAttendance.filter(v => v.participant.isKeyholder);
@@ -143,6 +147,7 @@ function KioskDisplayInner() {
       }
     } catch (error) {
       console.error("Failed to fetch attendance:", error);
+      setError("Network error occurred.");
       notifications.show({ color: "red", message: "Network error", autoClose: false });
     } finally {
       setLoading(false);
@@ -378,7 +383,7 @@ function KioskDisplayInner() {
                 Sign out a user
               </Button>
             )}
-            <CountBadge intent="info" size="lg">People Present: {counts.total}</CountBadge>
+            <CountBadge intent="info" size="lg">People Present: {data ? counts.total : "—"}</CountBadge>
           </Group>
         </Group>
 
@@ -425,14 +430,20 @@ function KioskDisplayInner() {
           </Box>
         )}
 
-        {/* Safety warnings */}
-        {safety.isTwoDeepViolation && (
+        {/* Safety warnings — a missing roster reads as unknown, not as all-clear */}
+        {!loading && !data && (
+          <Alert color="orange" icon="⚠️" title="Supervision status unknown" mb="lg">
+            Attendance could not be loaded, so Two-Deep Compliance and keyholder coverage
+            cannot be checked. Verify supervision in the building.
+          </Alert>
+        )}
+        {data && safety.isTwoDeepViolation && (
           <Alert color="red" icon="🚨" title="Critical Warning" mb="lg">
             Two-Deep Compliance is failing! An unaccompanied youth is present without sufficient
             adult supervision.
           </Alert>
         )}
-        {!safety.isTwoDeepViolation && safety.isLastKeyholder && (
+        {data && !safety.isTwoDeepViolation && safety.isLastKeyholder && (
           <Alert color="yellow" icon="⚠️" title="Warning" mb="lg">
             Only one isKeyholder is currently in the building.
           </Alert>
@@ -443,6 +454,8 @@ function KioskDisplayInner() {
           <Center py="xl"><Loader /></Center>
         ) : error ? (
           <Alert color="red">{error === "Unauthorized" ? "Access Denied: Please sign in to view attendance." : error}</Alert>
+        ) : !data ? (
+          <Alert color="red">Attendance is unavailable — the roster could not be loaded.</Alert>
         ) : counts.total === 0 ? (
           <Center py="xl"><Text c="dimmed">The facility is currently empty.</Text></Center>
         ) : (


### PR DESCRIPTION
Class-B audit findings **B6** and **B5** from #1529. B5 is carried here because its only safety-critical call site is in the same file.

## The defect (B6)

`/attendance/current` derived two values from a possibly-null `data`, with all-zero and all-false fallbacks:

```ts
const counts = data?.counts || { keyholders: 0, volunteers: 0, youth: 0, total: 0 };
const safety = data?.safety || { isLastKeyholder: false, isTwoDeepViolation: false };
```

Both were rendered **above** the branch that reports the error. So a failed load asserted a headcount of zero and suppressed both safety banners, regardless of what the error branch below said.

The two failure paths were not equally bad:

- A non-ok HTTP response called `setError`, so the red alert did render. The header still lied, but the operator saw a failure.
- A **network throw** only raised a `notifications.show` toast and never called `setError`. `data` stayed null, so `error` was null, `counts.total` was 0, and the body fell through to `counts.total === 0` and rendered "The facility is currently empty." Once the toast was dismissed, that screen was indistinguishable from a genuinely empty, compliant building.

A **third** silent path turned up while fixing this: `res.ok` with an unrecognized `access` value hit neither branch — no `setData`, no `setError` — and landed on the same "empty facility" text.

## What changed

- **Safety banners and the headcount are gated on `data !== null`.** Absent data renders an explicit orange "Supervision status unknown" alert and an em dash in place of a count, rather than reading as all-clear.
- **New `!data` branch in the main content**, above the `counts.total === 0` branch, so the unrecognized-payload path no longer claims the facility is empty.
- **The network-throw path now sets the error state as well as raising the toast**, matching the convention in `attendance/my-visits`. The two failure paths behave the same way now; the asymmetry looked unintentional rather than designed.

### Why explicit-unknown rather than suppression

Suppressing the two-deep banner on unknown data is the same failure in a quieter form — an operator glancing at a kiosk still sees no warning, and a missing banner is indistinguishable from a passing check. The fix has to occupy the banner slot, not vacate it. Orange rather than red: this is not a confirmed violation, and reusing red would train operators to discount the real one.

The gate is `data !== null` rather than `error !== null` deliberately, so the invariant also holds on the kiosk `postMessage` path, which calls `setData` directly and never touches `error`.

### Polling behaviour is unchanged

`usePolling` means a failed *refresh* still leaves the previous `data` in place, so the roster goes stale rather than dropping to zero. Nothing here clears `data` on error. The zeroed state was only ever an initial-load failure.

## B5 — one call site, not the default

`isYouth` resolves an unknown DOB to `'adult'` by default, so a visitor with no recorded birth date was counted as an adult on the very screen that computes supervision. Fixed at the single safety-gating call site by passing `{ unknownIs: 'youth' }`, matching what `getFullAttendance` already does server-side.

**The default in `time.ts` is deliberately left alone.** Two other call sites depend on `'adult'` by documented decision — `AdminEditHouseholdModal` (a null-DOB member stays promotable to household lead) and `participants/new` (a blank form does not render youth fields). Flipping the default would silently change who can be promoted to household lead. Reasoning: https://github.com/innovationtreehouse/checkin/issues/1529#issuecomment-5209277782

## Scope

Client page only. No schema change, no migration. The server-side two-deep math already fails closed and is untouched.

## Tests

Four new cases plus one extended assertion in the existing suite. Verified they fail against the unfixed page (`page.tsx` stashed, tests kept):

```
✕ shows a network-error message when the attendance request throws
✕ reports an unknown supervision state instead of an empty facility when the initial load throws
✕ reports an unknown supervision state when the initial load returns a server error
✕ reports an unknown supervision state when the response payload is unrecognized
✕ counts a visitor with no recorded birth date as youth, not as a supervising adult
Tests: 5 failed, 26 passed, 31 total
```

With the fix, all 31 pass. Full unit suite: **268 suites, 2547 tests, all green**. `tsc --noEmit` and `eslint` clean.

## Reviewer note

One thing deliberately left as-is: when a *refresh* fails while a roster is already on screen, the error alert still replaces the roster rather than sitting above it. That is pre-existing behaviour on the HTTP path and out of scope here — worth a follow-up if the roster vanishing mid-shift turns out to bother anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)