### PR TITLE
fix(attendance): program-less events are board/sysadmin only (B10)

### DIFF
--- a/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventAttendanceAPI.integration.test.ts
@@ -25,6 +25,10 @@ describe('Event Attendance API Integration Tests', () => {
     // Cross-tenant attacker: lead of a DIFFERENT program (IDOR boundary).
     let foreignLeadId: number;
     let foreignProgramId: number;
+    // Keyholder who is neither board nor sysadmin, plus a standalone
+    // (program-less) event — the unfenced-target boundary.
+    let keyholderId: number;
+    let standaloneEventId: number;
 
     beforeAll(async () => {
         // Clean up any leaked state
@@ -32,7 +36,7 @@ describe('Event Attendance API Integration Tests', () => {
             where: { person: { email: { contains: 'event-attendance-test' } } }
         });
         await prisma.event.deleteMany({
-            where: { name: 'Attendance Test Event' }
+            where: { name: { in: ['Attendance Test Event', 'Attendance Test Standalone Event'] } }
         });
         await prisma.program.deleteMany({
             where: { name: 'Attendance Test Program' }
@@ -89,6 +93,11 @@ describe('Event Attendance API Integration Tests', () => {
         });
         foreignProgramId = foreignProgram.id;
 
+        const keyholder = await prisma.person.create({
+            data: { email: 'keyholder-event-attendance-test@example.com', name: 'Keyholder Att Test', isKeyholder: true, household: { create: { name: "Test HH" } } }
+        });
+        keyholderId = keyholder.id;
+
         const now = new Date();
         const pastStart = new Date(now.getTime() - 2 * 60 * 60 * 1000); // 2 hours ago
         const pastEnd = new Date(now.getTime() - 1 * 60 * 60 * 1000); // 1 hour ago
@@ -102,6 +111,16 @@ describe('Event Attendance API Integration Tests', () => {
             }
         });
         testEventId = event.id;
+
+        const standaloneEvent = await prisma.event.create({
+            data: {
+                name: 'Attendance Test Standalone Event',
+                programId: null,
+                startAt: pastStart,
+                endAt: pastEnd
+            }
+        });
+        standaloneEventId = standaloneEvent.id;
 
         // Attendance can only be written for participants enrolled (or volunteering)
         // in the event's program — enroll the two targets so the happy-path writes
@@ -117,10 +136,10 @@ describe('Event Attendance API Integration Tests', () => {
     afterAll(async () => {
         // Clean up
         await prisma.visit.deleteMany({
-            where: { personId: { in: [testParticipant1Id, testParticipant2Id] } }
+            where: { personId: { in: [testParticipant1Id, testParticipant2Id, testUserId] } }
         });
         await prisma.event.deleteMany({
-            where: { id: testEventId }
+            where: { id: { in: [testEventId, standaloneEventId] } }
         });
         // FK: enrollments reference the program — clear before deleting it.
         await prisma.programParticipant.deleteMany({
@@ -129,7 +148,7 @@ describe('Event Attendance API Integration Tests', () => {
         await prisma.program.deleteMany({
             where: { id: { in: [testProgramId, foreignProgramId] } }
         });
-        const participantIds = [testAdminId, testUserId, testLeadMentorId, testParticipant1Id, testParticipant2Id, foreignLeadId];
+        const participantIds = [testAdminId, testUserId, testLeadMentorId, testParticipant1Id, testParticipant2Id, foreignLeadId, keyholderId];
 
         // RESTRICT: delete participants before their (auto-created) households.
         const householdIds = (await prisma.person.findMany({
@@ -148,13 +167,13 @@ describe('Event Attendance API Integration Tests', () => {
     afterEach(async () => {
         // Clear visits created during tests
         await prisma.visit.deleteMany({
-            where: { personId: { in: [testParticipant1Id, testParticipant2Id] } }
+            where: { personId: { in: [testParticipant1Id, testParticipant2Id, testUserId] } }
         });
         // Clear audit rows so each test asserts exactly its own write. A Visit
         // audit row carries the SUBJECT in secondaryAffectedEntity, so scope by
         // this suite's participants — fresh ids per run, so still leak-proof.
         await prisma.auditLog.deleteMany({
-            where: { tableName: 'Visit', secondaryAffectedEntity: { in: [testParticipant1Id, testParticipant2Id] } }
+            where: { tableName: 'Visit', secondaryAffectedEntity: { in: [testParticipant1Id, testParticipant2Id, testUserId] } }
         });
     });
 
@@ -356,6 +375,74 @@ describe('Event Attendance API Integration Tests', () => {
             expect(res.status).toBe(400);
             const after = await prisma.visit.count({ where: { personId: testUserId, associatedEventId: testEventId } });
             expect(after).toBe(before);
+        });
+
+        // A program-less event has no enrollment set, so the target filter never
+        // runs — the actor gate is the only authz on participantIds there. It must
+        // therefore admit board/sysadmin alone, who may record a visit for anyone.
+        describe('program-less (standalone) event', () => {
+            async function standaloneWriteCount() {
+                const visits = await prisma.visit.count({
+                    where: { personId: testUserId }
+                });
+                const audits = await prisma.auditLog.count({
+                    where: { tableName: 'Visit', secondaryAffectedEntity: testUserId }
+                });
+                return { visits, audits };
+            }
+
+            it('IDOR: a keyholder who is neither board nor sysadmin cannot mark attendance (403, no Visit written)', async () => {
+                (getServerSession as jest.Mock).mockResolvedValue({
+                    user: { id: keyholderId, isSysadmin: false, isBoardMember: false, isKeyholder: true }
+                });
+                const before = await standaloneWriteCount();
+
+                // testUserId is enrolled in nothing and unrelated to this event.
+                const req = new Request(`http://localhost:4000/api/events/${standaloneEventId}/attendance`, {
+                    method: 'POST',
+                    body: JSON.stringify({ participantIds: [testUserId] })
+                });
+                const res = await POST(req as unknown as import("next/server").NextRequest, { params: Promise.resolve({ id: String(standaloneEventId) }) });
+
+                expect(res.status).toBe(403);
+                expect(await standaloneWriteCount()).toEqual(before);
+            });
+
+            it('a board member can mark attendance for anyone', async () => {
+                (getServerSession as jest.Mock).mockResolvedValue({
+                    user: { id: testAdminId, isSysadmin: false, isBoardMember: true, isKeyholder: false }
+                });
+
+                const req = new Request(`http://localhost:4000/api/events/${standaloneEventId}/attendance`, {
+                    method: 'POST',
+                    body: JSON.stringify({ participantIds: [testUserId] })
+                });
+                const res = await POST(req as unknown as import("next/server").NextRequest, { params: Promise.resolve({ id: String(standaloneEventId) }) });
+
+                expect(res.status).toBe(200);
+                expect(await res.json()).toEqual({ success: true, processed: 1 });
+                expect(await prisma.visit.count({
+                    where: { personId: testUserId, associatedEventId: standaloneEventId }
+                })).toBe(1);
+            });
+        });
+
+        it('a keyholder can still mark an enrolled participant on a program event', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: keyholderId, isSysadmin: false, isBoardMember: false, isKeyholder: true }
+            });
+
+            const req = new Request(`http://localhost:4000/api/events/${testEventId}/attendance`, {
+                method: 'POST',
+                body: JSON.stringify({ participantIds: [testParticipant1Id] })
+            });
+            const res = await POST(req as unknown as import("next/server").NextRequest, { params: Promise.resolve({ id: String(testEventId) }) });
+
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual({ success: true, processed: 1 });
+            expect(await prisma.visit.count({
+                where: { personId: testParticipant1Id, associatedEventId: testEventId }
+            })).toBe(1);
         });
     });
 });

--- a/checkin-app/src/app/api/events/[id]/attendance/route.ts
+++ b/checkin-app/src/app/api/events/[id]/attendance/route.ts
@@ -26,9 +26,13 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
 
         const currentUserId = auth.user.id;
         const isLeadMentor = event.program?.leadMentorId === currentUserId;
-        const isSysAdminOrBoardOrKeyholder = auth.user.isSysadmin || auth.user.isBoardMember || auth.user.isKeyholder;
+        // A keyholder marks a program's roster, where the enrollment filter below
+        // bounds their targets. A program-less event has no such bound, so it is
+        // board/sysadmin only — they alone may record a visit for anyone.
+        const isPrivileged = auth.user.isSysadmin || auth.user.isBoardMember
+            || (event.programId != null && !!auth.user.isKeyholder);
 
-        if (!isLeadMentor && !isSysAdminOrBoardOrKeyholder) {
+        if (!isLeadMentor && !isPrivileged) {
             return apiError("Forbidden: Not authorized to validate attendance", 403);
         }
 
@@ -45,9 +49,8 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         // system (other households/programs). Enrollment/volunteer membership —
         // not an existing overlapping Visit — is the authority; unknown ids are
         // rejected (a genuine unenrolled walk-in needs a separate manual step).
-        // A program-less event is reachable only by admin/board (the lead/core-vol
-        // gate above requires a program), so there is no cross-program IDOR there
-        // and no enrollment set to check — skip the filter in that case.
+        // A program-less event has no enrollment set to filter against; the gate
+        // above narrows it to board/sysadmin, who may record a visit for anyone.
         const programId = event.programId;
         if (programId != null) {
             const [enrolled, volunteering] = await Promise.all([


### PR DESCRIPTION
Addresses finding **B10** of the Class-B domain-register audit, #1529. That issue tracks many findings, so no closing keyword here — it stays open for the rest.

## The defect

`POST /api/events/[id]/attendance` applies its only authz on `participantIds` inside the `if (programId != null)` branch: the enrollment/volunteer filter that rejects targets not on the program's roster. Nothing else in the handler validates them.

The actor gate admitted keyholders alongside admin/board:

```ts
const isSysAdminOrBoardOrKeyholder = auth.user.isSysadmin || auth.user.isBoardMember || auth.user.isKeyholder;
```

On a program-less event the target filter is skipped, so for those events `participantIds` was entirely unvalidated. The transaction then adopts an overlapping unassociated visit into the event or creates a synthetic one — meaning any keyholder could fabricate attendance and presence records for **any person in the system**.

The skip's comment asserted such events were "reachable only by admin/board". That was true of the lead-mentor branch (`event.program` is null, so `isLeadMentor` is false) but not of keyholders, who are neither admin nor board.

## The fix

Narrow the actor rather than adding a target filter:

```ts
const isPrivileged = auth.user.isSysadmin || auth.user.isBoardMember
    || (event.programId != null && !!auth.user.isKeyholder);
```

Keyholders keep everything they can do today on program events, where the enrollment filter already bounds their targets to that program's roster. Board and sysadmin keep the unfenced path, which they already hold by written rule — `docs/rules/attendance-checkin.md:116`: "The board and sysadmins edit or delete any visit, and record one for someone else at any past time — the walk-in nobody badged in." No new rule is invented; the actor set is narrowed to the population the rule already grants it to.

The misleading comment at the filter is replaced with the present-tense constraint.

No schema change, no migration, nothing under `src/security/`.

## Why program-less events are an admin/board surface

- `GET /api/events`, whose only job is listing standalone events, is already `withAuth({ roles: ['isSysadmin', 'isBoardMember'] })`.
- `GET /api/events/mine` filters `programId: { in: [...] }`, so a null-program event can never appear there. A keyholder reaching one was API-only, not a UI workflow.
- `POST /api/events` cannot be used by a keyholder to create one: `isLeadMentor` is only set inside `if (programId)` after confirming the caller leads *that* program, so a falsy `programId` leaves the gate demanding `isSysadmin || isBoardMember`.

## For the reviewer

**The same assumption exists one file over and is correct there.** `PATCH /api/events/[id]` (`manualEditAttendance`) carries the same `programId != null` skip and nearly the same comment, but its gate is `isSysAdminOrBoard || isLeadMentor || isCoreVolunteer` — no keyholder — so the parenthetical holds. Deliberately not touched. `GET /api/events/[id]` likewise has no keyholder. The attendance POST was the only `isKeyholder` under `src/app/api/events/`.

`src/lib/attendanceConflicts.ts` and `src/app/api/nav/todo-counts/route.ts` both scope to led programs via `leadMentorId`; neither depends on keyholders being able to POST here.

## Tests

Added to `src/app/__tests__/eventAttendanceAPI.integration.test.ts`: a standalone (`programId: null`) event and a keyholder who is neither board nor sysadmin.

- **Fails without the fix** — verified by reverting the route: `Expected: 403, Received: 200`. The keyholder wrote the visit for an unrelated person.
- **Passes with it** — 403, with `{visits, audits}` counts re-queried and unchanged, so the guard is proven to run *before* the write rather than after.
- Companions: the same keyholder still succeeds on a program event for an enrolled target; a board member still succeeds on the program-less event.

```
Unit         (npm run test:ci):              268 suites, 2543 passed
Integration  (npm run test:integration):     131 suites, 1343 passed, 6 skipped
tsc --noEmit:                                no new errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)