### PR TITLE
fix(email): refuse to send when no From address is configured (B23)

### DIFF
--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -580,9 +580,10 @@ model BoardSettings {
   /// prod and local never consult it.
   /// @sensitivity:internal
   devSigningTarget           String?
-  /// Overrides the EMAIL_FROM env default as the Resend sender on every outbound
+  /// Overrides the EMAIL_FROM env value as the Resend sender on every outbound
   /// email when set. Must be on a Resend-verified domain or all mail bounces —
-  /// hence the confirm-to-edit guard in the settings UI. Null = use the env default.
+  /// hence the confirm-to-edit guard in the settings UI. Null = fall back to
+  /// EMAIL_FROM; with that unset too, sendEmail refuses to send.
   /// @sensitivity:public
   emailFromAddress           String?
   /// Reply-To header set on every outbound email when set (the From address is a

--- a/checkin-app/src/app/settings/email/page.tsx
+++ b/checkin-app/src/app/settings/email/page.tsx
@@ -131,7 +131,8 @@ export default function EmailSettingsPage() {
           <Title order={3} mb="xs">Email sender identity</Title>
           <Text size="sm" c="dimmed" mb="md">
             Controls the sender on <strong>every</strong> outbound email (check-in receipts, membership
-            notices, board alerts). Leave blank to use the environment default sender.
+            notices, board alerts). Leave blank to use the sender configured in the environment —
+            with neither set, outbound email is disabled.
           </Text>
 
           <Alert color={wasSet ? "yellow" : "blue"} variant="light" mb="md">
@@ -161,7 +162,7 @@ export default function EmailSettingsPage() {
           <Stack gap="md">
             <TextInput
               label="From address"
-              description={'Bare address or "Name <addr@domain>". Blank = environment default.'}
+              description={'Bare address or "Name <addr@domain>". Blank = the environment sender.'}
               placeholder="Innovation Treehouse <noreply@updates.innovationtreehouse.org>"
               w={440}
               value={emailFrom}

--- a/checkin-app/src/lib/__tests__/config.test.ts
+++ b/checkin-app/src/lib/__tests__/config.test.ts
@@ -339,9 +339,9 @@ describe("simple optional getters (env-set vs default)", () => {
         process.env.RESEND_API_KEY = "resend-1";
         expect(config.resendApiKey()).toBe("resend-1");
     });
-    it("emailFrom default", () => {
+    it("emailFrom is null when unset (no hardcoded sender to mask a gap)", () => {
         delete process.env.EMAIL_FROM;
-        expect(config.emailFrom()).toBe("CheckMeIn <onboarding@resend.dev>");
+        expect(config.emailFrom()).toBeNull();
         process.env.EMAIL_FROM = "a@b.com";
         expect(config.emailFrom()).toBe("a@b.com");
     });

--- a/checkin-app/src/lib/__tests__/email.test.ts
+++ b/checkin-app/src/lib/__tests__/email.test.ts
@@ -1,6 +1,7 @@
 let mockDevToolsActive = false;
 const mockCapture = jest.fn();
-let mockIdentity: { from: string; replyTo?: string[] } = { from: 'test@test.com' };
+const mockLogIntegrationError = jest.fn();
+let mockIdentity: { from: string | null; replyTo?: string[] } = { from: 'test@test.com' };
 
 jest.mock('resend');
 jest.mock('../config.ts', () => ({
@@ -15,6 +16,9 @@ jest.mock('../dev/sentMail', () => ({
 }));
 jest.mock('../emailIdentity', () => ({
     getEmailSenderIdentity: () => Promise.resolve(mockIdentity),
+}));
+jest.mock('../logger', () => ({
+    logIntegrationError: (...args: unknown[]) => mockLogIntegrationError(...args),
 }));
 
 import { sendEmail } from '../email';
@@ -35,6 +39,7 @@ describe('sendEmail no-key logging + capture', () => {
         originalEnv = process.env.NODE_ENV;
         mockDevToolsActive = false;
         mockCapture.mockReset();
+        mockLogIntegrationError.mockReset();
         mockIdentity = { from: 'test@test.com' };
     });
 
@@ -99,6 +104,20 @@ describe('sendEmail no-key logging + capture', () => {
         expect(result).toBe(false);
         expect(mockCapture).not.toHaveBeenCalled();
     });
+
+    it('still captures on a dev instance when no From is configured either', async () => {
+        // The no-key path runs first, so a dev box with neither an API key nor a
+        // sender keeps working exactly as before.
+        mockDevToolsActive = true;
+        mockIdentity = { from: null };
+        mockCapture.mockResolvedValue(true);
+
+        const result = await sendEmail('to@test.com', 'Subj', '<p>hi</p>');
+
+        expect(result).toBe(true);
+        expect(mockCapture).toHaveBeenCalledWith('(no From configured)', 'to@test.com', 'Subj', '<p>hi</p>');
+        expect(mockLogIntegrationError).not.toHaveBeenCalled();
+    });
 });
 
 // The describe above mocks resendApiKey to null, so `resend` is null and only the
@@ -107,7 +126,8 @@ describe('sendEmail no-key logging + capture', () => {
 // can't reach: Resend returning `{ error }`, and Resend throwing. Both must → false.
 describe('sendEmail send-failure contract (Resend configured)', () => {
     const sendMock = jest.fn();
-    let doMockIdentity: { from: string; replyTo?: string[] } = { from: 'test@test.com' };
+    let doMockIdentity: { from: string | null; replyTo?: string[] } = { from: 'test@test.com' };
+    let doMockDevToolsActive = false;
     const logIntegrationErrorMock = jest.fn();
     let errorSpy: jest.SpyInstance;
     let logSpy: jest.SpyInstance;
@@ -116,10 +136,16 @@ describe('sendEmail send-failure contract (Resend configured)', () => {
         jest.resetModules();
         sendMock.mockReset();
         doMockIdentity = { from: 'test@test.com' };
+        doMockDevToolsActive = false;
         logIntegrationErrorMock.mockReset();
         // Re-mock the module's deps for the fresh module instance loaded below.
         jest.doMock('../config.ts', () => ({
-            config: { resendApiKey: () => 'test-key', emailFrom: () => 'test@test.com', isDevInstance: () => false },
+            config: {
+                resendApiKey: () => 'test-key',
+                emailFrom: () => 'test@test.com',
+                isDevInstance: () => false,
+                devToolsActive: () => doMockDevToolsActive,
+            },
         }));
         jest.doMock('../dev/sentMail', () => ({ captureSentEmail: jest.fn() }));
         jest.doMock('../emailIdentity', () => ({ getEmailSenderIdentity: () => Promise.resolve(doMockIdentity) }));
@@ -200,6 +226,46 @@ describe('sendEmail send-failure contract (Resend configured)', () => {
         await send('to@test.com', 'Subject', '<p>hi</p>');
         expect(sendMock).toHaveBeenCalledTimes(1);
         expect(sendMock.mock.calls[0][0]).not.toHaveProperty('replyTo');
+    });
+
+    it('refuses to call Resend and returns false when neither source configures a From', async () => {
+        doMockIdentity = { from: null };
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendEmail: send } = require('../email');
+
+        const result = await send('to@org.test', 'Subject', '<p>hi</p>');
+
+        expect(result).toBe(false);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('logs the missing sender as an integration error (to+subject, no body)', async () => {
+        doMockIdentity = { from: null };
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendEmail: send } = require('../email');
+        const html = 'Sensitive body <a href="reset">Link</a>';
+
+        await send('to@org.test', 'Subject', html);
+
+        expect(logIntegrationErrorMock).toHaveBeenCalledTimes(1);
+        const [source, error, context] = logIntegrationErrorMock.mock.calls[0];
+        expect(source).toBe('email');
+        expect(String(error)).toContain('No From address configured');
+        expect(context).toEqual({ to: 'to@org.test', subject: 'Subject' });
+        expect(JSON.stringify(context)).not.toContain(html);
+    });
+
+    it('sends normally once a From is configured (the board override reaches Resend)', async () => {
+        doMockIdentity = { from: 'Org <no-reply@org.test>' };
+        sendMock.mockResolvedValue({ data: { id: '1' }, error: null });
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { sendEmail: send } = require('../email');
+
+        const result = await send('to@org.test', 'Subject', '<p>hi</p>');
+
+        expect(result).toBe(true);
+        expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({ from: 'Org <no-reply@org.test>' }));
+        expect(logIntegrationErrorMock).not.toHaveBeenCalled();
     });
 
     it('persists an IntegrationErrorLog (to+subject, no body) when Resend responds with an { error }', async () => {

--- a/checkin-app/src/lib/__tests__/emailIdentity.test.ts
+++ b/checkin-app/src/lib/__tests__/emailIdentity.test.ts
@@ -1,11 +1,15 @@
 const mockFindUnique = jest.fn();
+let mockEnvFrom: string | null = 'env-default@example.com';
 jest.mock('../prisma', () => ({ __esModule: true, default: { boardSettings: { findUnique: (...a: unknown[]) => mockFindUnique(...a) } } }));
-jest.mock('../config', () => ({ config: { emailFrom: () => 'env-default@example.com' } }));
+jest.mock('../config', () => ({ config: { emailFrom: () => mockEnvFrom } }));
 
 import { getEmailSenderIdentity } from '../emailIdentity';
 
 describe('getEmailSenderIdentity', () => {
-    beforeEach(() => mockFindUnique.mockReset());
+    beforeEach(() => {
+        mockFindUnique.mockReset();
+        mockEnvFrom = 'env-default@example.com';
+    });
 
     it('falls back to the env From with no Reply-To when nothing is configured', async () => {
         mockFindUnique.mockResolvedValue(null);
@@ -35,5 +39,17 @@ describe('getEmailSenderIdentity', () => {
     it('never blocks mail: falls back to the env From if the settings read throws', async () => {
         mockFindUnique.mockRejectedValue(new Error('db down'));
         expect(await getEmailSenderIdentity()).toEqual({ from: 'env-default@example.com' });
+    });
+
+    it('reports a null From when neither the board nor the env configures a sender', async () => {
+        mockEnvFrom = null;
+        mockFindUnique.mockResolvedValue({ emailFromAddress: null, emailReplyToAddress: null });
+        expect(await getEmailSenderIdentity()).toEqual({ from: null, replyTo: undefined });
+    });
+
+    it('uses the board From when the env has none', async () => {
+        mockEnvFrom = null;
+        mockFindUnique.mockResolvedValue({ emailFromAddress: 'Org <no-reply@org.test>', emailReplyToAddress: null });
+        expect(await getEmailSenderIdentity()).toEqual({ from: 'Org <no-reply@org.test>', replyTo: undefined });
     });
 });

--- a/checkin-app/src/lib/config.ts
+++ b/checkin-app/src/lib/config.ts
@@ -209,7 +209,12 @@ export const config = {
 
     // Email
     resendApiKey: (): string | null => process.env.RESEND_API_KEY || null,
-    emailFrom: () => process.env.EMAIL_FROM || 'CheckMeIn <onboarding@resend.dev>',
+    // The env-level From. Null when unset so an unconfigured instance is
+    // distinguishable from a configured one: getEmailSenderIdentity prefers
+    // BoardSettings.emailFromAddress and falls back here, and sendEmail refuses to
+    // send when neither supplies an address. A hardcoded default would be a sender
+    // no domain has verified, so every send would be attempted and rejected.
+    emailFrom: (): string | null => process.env.EMAIL_FROM || null,
     // Resend's inbound bounce/complaint webhook signs with Svix under this shared
     // secret (Resend dashboard → Webhooks → signing secret, "whsec_..."). Null when
     // unset — the webhook route's verify fn fails closed with a 500 config error,

--- a/checkin-app/src/lib/email.ts
+++ b/checkin-app/src/lib/email.ts
@@ -8,23 +8,37 @@ const resend = config.resendApiKey()
     ? new Resend(config.resendApiKey()!)
     : null;
 
+/** Stand-in shown on /dev/sent-mail when no sender is configured. */
+const UNCONFIGURED_FROM = '(no From configured)';
+
 /**
  * Send an email via Resend. Falls back to console.log if no API key is configured.
  *
  * The From (and optional Reply-To) come from getEmailSenderIdentity(): the board
- * can override the EMAIL_FROM env default and set a Reply-To in Settings → Email.
+ * can override the EMAIL_FROM env value and set a Reply-To in Settings → Email.
  */
 export async function sendEmail(to: string, subject: string, html: string): Promise<boolean> {
     const { from, replyTo } = await getEmailSenderIdentity();
 
-    if (!resend) {
-        console.log(`[Email (no RESEND_API_KEY)] To: ${to} | Subject: ${subject}`);
+    // Nothing can be delivered without a key, and nothing may be sent without a
+    // sender — an unverified From is rejected by Resend for every recipient.
+    if (!resend || !from) {
+        console.log(`[Email (${resend ? 'no From address' : 'no RESEND_API_KEY'})] To: ${to} | Subject: ${subject}`);
         // Dev/local: capture the email so link/token flows are retrievable at /dev/sent-mail,
         // and report success so gating callers follow the prod happy-path. devToolsActive
         // fails safe to prod, so a prod box that somehow lost its key still falls through
         // to `return false` (fail loud, not fake success).
         if (config.devToolsActive()) {
-            return captureSentEmail(from, to, subject, html);
+            return captureSentEmail(from ?? UNCONFIGURED_FROM, to, subject, html);
+        }
+        if (!from) {
+            // A missing key is reported by the config-health check; a missing sender is
+            // not, so put it on System Status > Link Status instead of dropping silently.
+            await logIntegrationError(
+                'email',
+                'No From address configured — set EMAIL_FROM or the From address in Settings → Email.',
+                { to, subject },
+            );
         }
         return false;
     }

--- a/checkin-app/src/lib/emailIdentity.ts
+++ b/checkin-app/src/lib/emailIdentity.ts
@@ -3,17 +3,20 @@ import { config } from "./config";
 import { parseEmailHeaderList } from "./emailHeader";
 
 export interface EmailSenderIdentity {
-    /** The Resend `from`. BoardSettings.emailFromAddress overrides the EMAIL_FROM env default. */
-    from: string;
+    /**
+     * The Resend `from`. BoardSettings.emailFromAddress wins over the EMAIL_FROM env
+     * value; null when neither is configured, which sendEmail treats as "cannot send".
+     */
+    from: string | null;
     /** The Resend `replyTo` addresses (one or more), or undefined when the board hasn't configured any. */
     replyTo?: string[];
 }
 
 /**
  * Resolve the effective sender identity for outbound mail: the board can override
- * the EMAIL_FROM env default and add a Reply-To via Settings → Membership. Falls
- * back to the env-only identity on any DB error so a settings-table hiccup never
- * blocks mail delivery.
+ * the EMAIL_FROM env value and add a Reply-To via Settings → Email. Falls back to
+ * the env-only identity on any DB error so a settings-table hiccup never blocks
+ * mail delivery. A null `from` means no sender is configured at either layer.
  *
  * ponytail: one findUnique on the single-row BoardSettings PK per send. Fan-outs
  * (e.g. notifyNewProgramAnnounced) pay it per recipient; the lookup is a cached


### PR DESCRIPTION
Fixes **B23** from the Class-B domain-register audit (#1529). One finding of 28 — no closing keyword, the umbrella issue stays open.

## Net behaviour change

An instance with no sender configured moves from **"silently sends from an undeliverable address"** to **"refuses to send and reports it"**.

The reporting surface is **System Status › Link Status** (`IntegrationErrorLog`, source `email`) — the same tab that already carries the Resend rejections this replaces. `src/app/api/system-status/links/route.ts` filters nothing by source, so the row surfaces alongside the existing email failures.

## The defect

`config.emailFrom()` returned a hardcoded `CheckMeIn <onboarding@resend.dev>` when `EMAIL_FROM` was unset. That is Resend's shared onboarding sender, which only delivers to the Resend account owner's own verified address — so on an instance with `RESEND_API_KEY` set and no From configured, every family-facing email was attempted for real and rejected.

The resend.dev string is the symptom. The defect is the layer. There are two configuration sources for the sender — the `EMAIL_FROM` env var and `BoardSettings.emailFromAddress` (Settings › Email) — and `getEmailSenderIdentity()` is written to prefer the board's and fall back to the env's. Because the env getter always answered with a string, that chain could never observe *"nobody configured a sender"*, and an unconfigured instance was indistinguishable from a configured one.

The same block of `config.ts` gets this right three times over: `resendApiKey`, `kioskPublicKey` and `resendWebhookSecret` all return null when unset, and the comment on `resendWebhookSecret` describes failing closed as the deliberate shared pattern.

## Changes

- **`config.emailFrom()`** now returns `string | null` — `process.env.EMAIL_FROM || null`, matching its neighbours.
- **`EmailSenderIdentity.from`** widens to `string | null`. Its only consumer is `sendEmail` (grepped repo-wide; nothing else reads `.from` or calls `config.emailFrom()`). The resolver body is unchanged — `settings?.emailFromAddress?.trim() || envFrom` already yields null correctly.
- **`sendEmail`** folds the missing sender into the branch it already had for a missing API key — `if (!resend)` becomes `if (!resend || !from)`: log, capture under `devToolsActive()`, return false. That branch was already written to "fail loud, not fake success", which is the semantics wanted here. On a real instance the refusal additionally calls `logIntegrationError('email', ...)`; without it the fix would *remove* the only prod signal that exists today, since Resend's rejection currently logs there.
- `captureSentEmail(from ?? '(no From configured)', …)` — `sentMail`'s signature is untouched.

**Dev boxes are unaffected.** With no `RESEND_API_KEY` the `!resend` half already short-circuits first, and the console line keeps the exact `[Email (no RESEND_API_KEY)]` literal. Verified rather than assumed — pinned by a new test.

Two stale-copy fixes came along: the Settings › Email description said "Blank = environment default", which was about to become a lie, and the `emailFromAddress` doc comment in `schema.prisma`. Comment only — `prisma generate` reproduces `src/security/generated/classifications.ts` byte-identical, and nothing under `src/security/` is in this diff.

## Why no configHealth entry

`getConfigHealth()` is synchronous and reads only `process.env`; `openConfigIssues()` is called synchronously from `/api/nav/todo-counts` to feed a nav badge.

- **Env-only entry** — loses because the setting has two sources and the DB one is the self-serve path the Settings › Email UI exists to serve. A board that configures it there gets a permanent red badge for a working instance. That is not a corner case, it is the recommended configuration, and a health panel that cries wolf gets ignored.
- **Async conversion** — loses on price. Both functions and the nav-badge path go async for one boolean.
- **Keep sync, inject the board value** (todo-counts already loads `boardSettings` a few lines above) — considered and rejected: a signature change, a select addition, and a DB read in the config-health route, to duplicate a signal that now fires on first send.

What a health entry would have bought is the window between deploy and the first send attempt. After that the refusal reports itself, and on a misconfigured instance the first attempt happens the moment anyone triggers an email.

## Known blind spots

Both are pre-existing patterns rather than anything new here, but a reviewer should see them named:

- The refusal is **silent on a dev-flagged instance that has a real Resend key** — `devToolsActive()` captures to `/dev/sent-mail` and returns before the log, because capture *is* delivery there. Prod is unaffected; `devToolsActive` fails safe to prod.
- `logIntegrationError` swallows its own DB write failure. DB down means console only.

## Tests

Six new. Against unfixed sources, four fail:

```
● sendEmail no-key logging + capture › still captures on a dev instance when no From is configured either
● sendEmail send-failure contract (Resend configured) › refuses to call Resend and returns false when neither source configures a From
● sendEmail send-failure contract (Resend configured) › logs the missing sender as an integration error (to+subject, no body)
● simple optional getters (env-set vs default) › emailFrom is null when unset (no hardcoded sender to mask a gap)
```

The other two — board-From-with-env-unset precedence, in `emailIdentity.test.ts` — pass pre-fix, because that file mocks `config` directly. They guard the type widening and the precedence contract the old default hid, not the defect itself.

The log-hygiene contract in `email.test.ts` is preserved and extended: the new integration-error assertion checks `context` is exactly `{ to, subject }` and that the body does not appear in it.

Full suite green: **268 suites, 2549 tests**. `tsc --noEmit` clean, eslint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
