### PR TITLE
feat(system-status): make a missed cron run visible to the board

### DIFF
--- a/checkin-app/prisma/migrations/20260806170000_cron_run_log/migration.sql
+++ b/checkin-app/prisma/migrations/20260806170000_cron_run_log/migration.sql
@@ -1,0 +1,23 @@
+-- Cron run ledger: one row per completed run of a /api/cron/* sweep, written by
+-- withCron. Purely additive (new table, no FKs, nothing reads it yet), so it is
+-- safe for old code serving traffic during the deploy drain window.
+--
+-- Two statements that must land together — the table is useless without the
+-- index the staleness groupBy scans — so BEGIN/COMMIT (prisma migrate deploy
+-- does not wrap a migration file in a transaction).
+BEGIN;
+
+CREATE TABLE "CronRunLog" (
+    "id" SERIAL NOT NULL,
+    "job" TEXT NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL,
+    "finishedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "success" BOOLEAN NOT NULL,
+    "error" TEXT,
+
+    CONSTRAINT "CronRunLog_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "CronRunLog_job_success_finishedAt_idx" ON "CronRunLog"("job", "success", "finishedAt");
+
+COMMIT;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -1278,6 +1278,31 @@ model IntegrationErrorLog {
   @@index([resolvedAt, timestamp])
 }
 
+/// One completed run of a cron sweep, written by `withCron` (src/lib/cronAuth.ts) for every
+/// route under /api/cron. The schedule and the caller live in a separate infra repo, so the
+/// app cannot know when a job is *due* — it can only observe that a run happened. This table
+/// is that observation: it feeds the System Status cron panel and the stale-job nav badge,
+/// which is the only in-app signal that a sweep silently stopped firing. Rolling log: rows
+/// auto-purge after 90 days.
+model CronRunLog {
+  /// @sensitivity:internal
+  id         Int      @id @default(autoincrement())
+  /// Route slug — the last path segment of /api/cron/<job>.
+  /// @sensitivity:internal
+  job        String
+  /// @sensitivity:internal
+  startedAt  DateTime
+  /// @sensitivity:internal
+  finishedAt DateTime @default(now())
+  /// @sensitivity:internal
+  success    Boolean
+  /// Message from the throw that failed the run; null on success.
+  /// @sensitivity:internal
+  error      String?
+
+  @@index([job, success, finishedAt])
+}
+
 /// Dev-instance activity ledger (docs/ops/dev-instance.md, "The ledger"). Lives only in checkin_dev; records
 /// the last login / impersonate / macro / reset by REAL human identity so a shared dev instance
 /// shows who tested/reset last (no accidental clobbering). Never written in prod by construction;

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -15,6 +15,7 @@
 import { GET } from '@/app/api/nav/todo-counts/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
+import { CRON_STALE_AFTER_MS } from '@/lib/cronRuns';
 
 jest.mock('next-auth/next', () => ({
     getServerSession: jest.fn(),
@@ -291,5 +292,71 @@ describe('Nav todo-counts API', () => {
 
         await prisma.orgMembershipProcess.deleteMany({ where: { id: { in: [...reviewerProcs.map((p) => p.id), blocked.id] } } });
         await prisma.orgMembership.delete({ where: { id: reviewerMembership.id } });
+    });
+
+    // Nothing in this repo schedules the crons, so a sweep that stops firing is
+    // invisible until the ledger goes cold. That staleness has to reach the board's
+    // red System Status pill — and only the board's.
+    describe('stale cron jobs', () => {
+        const JOB = `nav-badge-${TAG}`;
+
+        const staleCount = async (user: object) => {
+            const res = await callAs(user);
+            const data = await res.json();
+            return data.configHealth?.staleCronJobs as number | undefined;
+        };
+
+        // Functions, not constants: the ids are assigned in beforeAll, which runs
+        // after this describe body is evaluated.
+        const board = () => ({ id: boardId, householdId: householdBId, isBoardMember: true });
+        const nonAdmin = () => ({ id: leadId, householdId: householdAId });
+
+        afterEach(async () => {
+            await prisma.cronRunLog.deleteMany({ where: { job: JOB } });
+        });
+
+        it('a recent success does not count', async () => {
+            const before = (await staleCount(board()))!;
+            await prisma.cronRunLog.create({
+                data: { job: JOB, startedAt: new Date(), finishedAt: new Date(), success: true },
+            });
+
+            expect(await staleCount(board())).toBe(before);
+        });
+
+        it('a job whose last success is older than the threshold raises the count', async () => {
+            const before = (await staleCount(board()))!;
+            const long = new Date(Date.now() - (CRON_STALE_AFTER_MS + 60 * 60 * 1000));
+            await prisma.cronRunLog.create({
+                data: { job: JOB, startedAt: long, finishedAt: long, success: true },
+            });
+
+            expect(await staleCount(board())).toBe(before + 1);
+        });
+
+        it('failed runs do not refresh a stale job — only a success clears it', async () => {
+            const before = (await staleCount(board()))!;
+            const long = new Date(Date.now() - (CRON_STALE_AFTER_MS + 60 * 60 * 1000));
+            await prisma.cronRunLog.createMany({
+                data: [
+                    { job: JOB, startedAt: long, finishedAt: long, success: true },
+                    { job: JOB, startedAt: new Date(), finishedAt: new Date(), success: false, error: 'boom' },
+                ],
+            });
+
+            expect(await staleCount(board())).toBe(before + 1);
+        });
+
+        it('a non-board, non-admin caller gets no count at all', async () => {
+            const long = new Date(Date.now() - (CRON_STALE_AFTER_MS + 60 * 60 * 1000));
+            await prisma.cronRunLog.create({
+                data: { job: JOB, startedAt: long, finishedAt: long, success: true },
+            });
+
+            const res = await callAs(nonAdmin());
+            const data = await res.json();
+            expect(data.configHealth).toBeUndefined();
+            expect(await staleCount(board())).toBeGreaterThanOrEqual(1);
+        });
     });
 });

--- a/checkin-app/src/app/api/cron/trusted-adult-expiry/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/cron/trusted-adult-expiry/__tests__/route.test.ts
@@ -8,8 +8,15 @@
  * the ROUTE's `requireCronSecret` gate or its success envelope. The service is
  * mocked here so this is a pure unit test (no DB): we only assert the gate
  * (missing / wrong secret → 401) and the 200 envelope when authorized.
+ *
+ * withCron also stamps the run into CronRunLog, so prisma.cronRunLog is stubbed
+ * below. It is stubbed rather than allowlisted in jest.setup.js on purpose: the
+ * default prisma mock REJECTS an unstubbed call, recordCronRun swallows that, and
+ * a global console.error allowlist would let the write fail unnoticed in every
+ * cron route test. Stubbing keeps the failure loud and lets us assert the stamp.
  */
 import { GET } from '../route';
+import prisma from '@/lib/prisma';
 
 jest.mock('@/lib/trusted-adult/service', () => ({
     runExpirySweep: jest.fn(),
@@ -29,10 +36,14 @@ function req(authHeader?: string) {
 
 describe('GET /api/cron/trusted-adult-expiry — auth gate', () => {
     const prev = process.env.CRON_SECRET;
+    let recordRun: jest.Mock;
 
     beforeEach(() => {
         jest.clearAllMocks();
         process.env.CRON_SECRET = SECRET;
+        recordRun = jest.fn().mockResolvedValue({});
+        prisma.cronRunLog.create = recordRun;
+        prisma.cronRunLog.deleteMany = jest.fn().mockResolvedValue({ count: 0 });
     });
 
     afterAll(() => {
@@ -44,6 +55,8 @@ describe('GET /api/cron/trusted-adult-expiry — auth gate', () => {
         const res = await GET(req());
         expect(res.status).toBe(401);
         expect(runExpirySweep).not.toHaveBeenCalled();
+        // A rejected call is not a run.
+        expect(recordRun).not.toHaveBeenCalled();
     });
 
     it('401 when the bearer secret is wrong', async () => {
@@ -60,5 +73,8 @@ describe('GET /api/cron/trusted-adult-expiry — auth gate', () => {
         const body = await res.json();
         expect(body).toEqual({ success: true, warned: 2, expired: 1 });
         expect(runExpirySweep).toHaveBeenCalledTimes(1);
+        // The run is stamped for the System Status panel / stale-job badge.
+        expect(recordRun).toHaveBeenCalledTimes(1);
+        expect(recordRun.mock.calls[0][0].data).toMatchObject({ job: 'trusted-adult-expiry', success: true });
     });
 });

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -7,6 +7,7 @@ import { canReviewBackgroundChecks, reviewQueueCounts } from "@/lib/membership/r
 import { getLeadConflicts } from "@/lib/attendanceConflicts";
 import { pickAddress, validateAddress } from "@/lib/address";
 import { openConfigIssues } from "@/lib/configHealth";
+import { countStaleCronJobs } from "@/lib/cronRuns";
 import { PROGRAM_CHECKOUT_BROKEN_WHERE } from "@/lib/programCheckout";
 import { apiError } from "@/lib/api-response";
 import { BROKEN_HOUSEHOLD_WHERE, UNCLAIMED_OR_BROKEN_HOUSEHOLD_WHERE } from "@/lib/household/filters";
@@ -78,10 +79,14 @@ export type TodoCounts = {
     // ACKNOWLEDGED) awaiting board action — green pill on the Finance Ops Payment
     // problems tab. Same count as getMembershipNotifications.openPaymentExceptions.
     admin?: { membership: number; applicationsTotal: number; paymentPlanPending: number; membershipPaymentPlanPending: number; trustedAdults: number; householdsMissingContact: number; unclaimedHouseholds: number; brokenHouseholds: number; brokenEmails: number; settingsMisconfig: number; programsMisconfig: number; openPaymentExceptions: number };
-    // Config-health gaps (admins + board only): number of failing system-config checks
-    // (e.g. Zoho e-sign unconfigured). Drives the red System Status nav badge; the full
-    // list lives at /api/system-status/config-health. See lib/configHealth.ts.
-    configHealth?: { openIssues: number };
+    // Infra-health gaps (admins + board only). Both halves drive the ONE red System
+    // Status nav badge; the full detail lives at /api/system-status/config-health.
+    // `openIssues` = failing system-config checks (e.g. Zoho e-sign unconfigured) —
+    // synchronous env presence checks, see lib/configHealth.ts.
+    // `staleCronJobs` = cron sweeps with no successful run inside CRON_STALE_AFTER_MS.
+    // Computed here rather than in getConfigHealth() because it needs a DB read and
+    // that function is deliberately synchronous. See lib/cronRuns.ts.
+    configHealth?: { openIssues: number; staleCronJobs: number };
     // Background-check reviewer surface (reviewers + board, per-viewer). `canActOn`
     // = applications this reviewer may attest now (green). `approvedAwaitingSecond`
     // = ones they approved that still need a second reviewer (gray).
@@ -365,7 +370,7 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     // ---- Admin surface (board's own queue) — only for board/isSysadmin ----
     if (user.isSysadmin || user.isBoardMember) {
-        const [membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, programsMisconfig, openPaymentExceptions, boardSettings] = await Promise.all([
+        const [membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, programsMisconfig, openPaymentExceptions, boardSettings, staleCronJobs] = await Promise.all([
             prisma.orgMembershipProcess.count({
                 where: { status: { in: BOARD_ACTIONABLE_MEMBERSHIP } },
             }),
@@ -421,6 +426,10 @@ export const GET = withAuth({}, async (_req, auth) => {
                 where: { id: 1 },
                 select: { orgMembershipVariantId: true, volunteerDiscountCode: true, bgRecheckMonths: true, orgMembershipYearBoundary: true },
             }),
+            // Cron sweeps with no successful run in the last CRON_STALE_AFTER_MS. The
+            // schedule lives in a separate infra repo, so this is the app's only way to
+            // notice its own nightly sweep stopped firing. See lib/cronRuns.ts.
+            countStaleCronJobs(),
         ]);
         const settingsMisconfig =
             (boardSettings?.orgMembershipVariantId ? 0 : 1) +
@@ -428,9 +437,10 @@ export const GET = withAuth({}, async (_req, auth) => {
             ((boardSettings?.bgRecheckMonths ?? 0) > 0 ? 0 : 1) +
             (boardSettings?.orgMembershipYearBoundary ? 0 : 1);
         result.admin = { membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, settingsMisconfig, programsMisconfig, openPaymentExceptions };
-        // System-config health (env-var/deploy gaps). Synchronous, no DB — just presence
-        // checks. Same admin+board gate as the rest of this block.
-        result.configHealth = { openIssues: openConfigIssues() };
+        // Infra health: env-var/deploy gaps (synchronous presence checks) plus cron
+        // sweeps that have stopped running. Same admin+board gate as the rest of this
+        // block — both fold into the single red System Status pill.
+        result.configHealth = { openIssues: openConfigIssues(), staleCronJobs };
     }
 
     // ---- Reviewer surface (per-viewer background-check queue) ----

--- a/checkin-app/src/app/api/system-status/config-health/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/system-status/config-health/__tests__/route.test.ts
@@ -13,6 +13,16 @@ jest.mock('@/lib/auth', () => ({
 }));
 
 import { GET } from '../route';
+import prisma from '@/lib/prisma';
+
+const LAST_SUCCESS = new Date('2026-08-06T09:00:00.000Z');
+
+beforeEach(() => {
+    prisma.cronRunLog.groupBy = jest.fn().mockResolvedValue([
+        { job: 'nightly', _max: { finishedAt: LAST_SUCCESS } },
+    ]);
+    prisma.cronRunLog.findMany = jest.fn().mockResolvedValue([]);
+});
 
 const req = () => new Request('http://localhost/api/system-status/config-health');
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -45,5 +55,13 @@ describe('GET /api/system-status/config-health — auth gate', () => {
     it('200 for a sysadmin', async () => {
         const res = await call({ type: 'session', user: { isSysadmin: true, isBoardMember: false } });
         expect(res.status).toBe(200);
+    });
+
+    it('carries the cron run ledger alongside the config checks', async () => {
+        const res = await call({ type: 'session', user: { isSysadmin: false, isBoardMember: true } });
+        const body = await res.json();
+        expect(body.cronJobs).toEqual([
+            { job: 'nightly', lastSuccessAt: LAST_SUCCESS.toISOString(), stale: expect.any(Boolean) },
+        ]);
     });
 });

--- a/checkin-app/src/app/api/system-status/config-health/route.ts
+++ b/checkin-app/src/app/api/system-status/config-health/route.ts
@@ -2,17 +2,24 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import { apiError } from "@/lib/api-response";
 import { getConfigHealth } from "@/lib/configHealth";
+import { getCronJobStatuses } from "@/lib/cronRuns";
 
 export const dynamic = "force-dynamic";
 
 /**
- * GET /api/system-status/config-health — the full per-check config-health list for the
- * System Status page. Admins + board only; returns booleans + human detail, never secret
- * values. The nav badge reads only the failing-count from /api/nav/todo-counts; this is
- * the detail view. See lib/configHealth.ts.
+ * GET /api/system-status/config-health — the "is the infrastructure wired and alive"
+ * payload for the System Status page. Admins + board only; returns booleans, timestamps
+ * and human detail, never secret values.
+ *
+ * Two halves, both feeding the same red nav badge via /api/nav/todo-counts (which reads
+ * only the counts; this is the detail view):
+ *   - `checks`   — static env/config presence (lib/configHealth.ts).
+ *   - `cronJobs` — last successful run per cron sweep (lib/cronRuns.ts). Rides on this
+ *                  route rather than its own: same page, same gate, same question, and a
+ *                  new registered route would need its registry entry landed separately.
  */
 export const GET = withAuth({}, async (_req, auth) => {
     if (auth.type !== "session") return apiError("Unauthorized", 401);
     if (!(auth.user.isSysadmin || auth.user.isBoardMember)) return apiError("Forbidden", 403);
-    return NextResponse.json({ checks: getConfigHealth() });
+    return NextResponse.json({ checks: getConfigHealth(), cronJobs: await getCronJobStatuses() });
 });

--- a/checkin-app/src/app/system-status/health/page.tsx
+++ b/checkin-app/src/app/system-status/health/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Card, Group, List, SimpleGrid, Stack, Text, Title } from "@mantine/core";
-import { BadgeScanChart, ConfigHealthBox, SReadDiagnosticsBox, SystemVersionBox } from "@/components/admin/SystemHealthPanels";
+import { BadgeScanChart, ConfigHealthBox, CronRunsBox, SReadDiagnosticsBox, SystemVersionBox } from "@/components/admin/SystemHealthPanels";
 
 export default function SystemStatusHealthPage() {
   return (
@@ -50,6 +50,8 @@ export default function SystemStatusHealthPage() {
       </SimpleGrid>
 
       <ConfigHealthBox />
+
+      <CronRunsBox />
 
       <SReadDiagnosticsBox />
 

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -299,20 +299,31 @@ describe('finance-ops nav ↔ tab agreement', () => {
 
 // The /membership-audit section badge is a roll-up of its tabs; keep them in lockstep.
 // Red section total == broken tab; gray section total == emergency + unclaimed tabs.
-describe('system-status config-health badge', () => {
+describe('system-status infra-health badge', () => {
   it('no badge when the payload has no configHealth (non-admin) or zero issues', () => {
     expect(navBadgeFor('/system-status', base)).toEqual([]);
-    expect(navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 0 } })).toEqual([]);
+    expect(navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 0, staleCronJobs: 0 } })).toEqual([]);
   });
 
   it('red alert badge counting open config issues', () => {
-    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 2 } });
+    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 2, staleCronJobs: 0 } });
     expect(badges).toEqual([{ count: 2, color: 'red', label: '2 config issues' }]);
   });
 
   it('singularizes the label at one issue', () => {
-    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 1 } });
+    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 1, staleCronJobs: 0 } });
     expect(badges[0].label).toBe('1 config issue');
+  });
+
+  it('a stale cron job alone raises the red pill', () => {
+    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 0, staleCronJobs: 1 } });
+    expect(badges).toEqual([{ count: 1, color: 'red', label: '1 cron job not running' }]);
+  });
+
+  // One pill, not two: both halves are "infra broken" on the same page.
+  it('folds stale cron jobs into the same count as config issues', () => {
+    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 2, staleCronJobs: 3 } });
+    expect(badges).toEqual([{ count: 5, color: 'red', label: '2 config issues, 3 cron jobs not running' }]);
   });
 });
 

--- a/checkin-app/src/components/admin/SystemHealthPanels.tsx
+++ b/checkin-app/src/components/admin/SystemHealthPanels.tsx
@@ -134,6 +134,77 @@ export function ConfigHealthBox() {
   );
 }
 
+// Mirrors CronJobStatus in lib/cronRuns.ts (lastSuccessAt arrives JSON-serialized).
+type CronJob = { job: string; lastSuccessAt: string; stale: boolean; lastError?: string };
+
+/** "3 hours ago" / "2 days ago" — coarse on purpose; the exact stamp is the title text. */
+function timeAgo(iso: string): string {
+  const minutes = Math.round((Date.now() - new Date(iso).getTime()) / 60000);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} days ago`;
+}
+
+/**
+ * Last successful run of each cron sweep, from GET /api/system-status/config-health
+ * (admins + board only). Nothing in this repo schedules the crons — the schedule and
+ * the caller live in a separate infra repo — so this panel is the app's only view of
+ * whether its own nightly sweeps are still firing. A job past the staleness window is
+ * red here and adds to the red System Status nav pill. See lib/cronRuns.ts.
+ */
+export function CronRunsBox() {
+  const [jobs, setJobs] = useState<CronJob[] | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/system-status/config-health')
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => setJobs(data.cronJobs as CronJob[]))
+      .catch(() => setFailed(true));
+  }, []);
+
+  const staleCount = jobs?.filter((j) => j.stale).length ?? 0;
+
+  return (
+    <Card withBorder radius="md" padding="lg">
+      <Group gap="sm" mb="xs">
+        <Title order={4}>Scheduled Jobs</Title>
+        {staleCount > 0 && <Badge color="red" circle title={`${staleCount} job(s) not running`} />}
+      </Group>
+      <Text size="sm" c="dimmed" mb="md">
+        Last successful run of each nightly sweep. A job listed in red has not succeeded in
+        over 48 hours — treat it as stopped and check the scheduler.
+      </Text>
+
+      {failed ? (
+        <Text c="yellow">Unable to load scheduled-job status.</Text>
+      ) : !jobs ? (
+        <Text c="dimmed">Checking scheduled jobs…</Text>
+      ) : jobs.length === 0 ? (
+        <Text c="dimmed">No cron run has been recorded yet.</Text>
+      ) : (
+        <List spacing="sm" listStyleType="none">
+          {jobs.map((j) => (
+            <List.Item key={j.job}>
+              <Group justify="space-between" wrap="nowrap" align="flex-start">
+                <Code>{j.job}</Code>
+                <Text c={j.stale ? 'red' : 'green'} fw={j.stale ? 700 : undefined} ta="right" title={j.lastSuccessAt}>
+                  ● {timeAgo(j.lastSuccessAt)}
+                </Text>
+              </Group>
+              {j.lastError && (
+                <Text size="xs" c="red">Failing since: {j.lastError}</Text>
+              )}
+            </List.Item>
+          ))}
+        </List>
+      )}
+    </Card>
+  );
+}
+
 // Mirrors DiagStep in api/finance-ops/s-read/diagnose/route.ts.
 type DiagStep = { id: string; ok: boolean | null; detail: string; code?: string };
 

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -179,15 +179,26 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
       return b ? [b] : [];
     }
     case '/system-status': {
-      // Red alert: number of failing system-config checks (env-var/deploy gaps,
-      // e.g. Zoho e-sign unconfigured). Distinct from the green/gray queue badges —
-      // this is "infra broken," not "you have a task." Admins + board only (the
-      // count is absent from the payload for everyone else). Links to the page,
-      // where the full per-check list lives. See lib/configHealth.ts.
-      const n = counts.configHealth?.openIssues ?? 0;
-      return n > 0
-        ? [{ count: n, color: 'red', label: `${n} config ${n === 1 ? 'issue' : 'issues'}` }]
-        : [];
+      // Red alert: things broken about the deployment itself — failing system-config
+      // checks (env-var/deploy gaps, e.g. Zoho e-sign unconfigured) plus cron sweeps
+      // with no successful run inside the staleness window. Distinct from the
+      // green/gray queue badges — this is "infra broken," not "you have a task."
+      // Admins + board only (the counts are absent from the payload for everyone else).
+      //
+      // ONE pill, not two: both halves mean "go look at System Status", they land on
+      // the same page and the same audience fixes them, and a second red pill on the
+      // same nav item would just be a second number pointing at the same link. The
+      // label keeps them itemized so the pill is still specific. See lib/configHealth.ts
+      // and lib/cronRuns.ts.
+      const config = counts.configHealth?.openIssues ?? 0;
+      const stale = counts.configHealth?.staleCronJobs ?? 0;
+      const n = config + stale;
+      if (n === 0) return [];
+      const parts = [
+        ...(config > 0 ? [`${config} config ${config === 1 ? 'issue' : 'issues'}`] : []),
+        ...(stale > 0 ? [`${stale} cron job${plural(stale, '', 's')} not running`] : []),
+      ];
+      return [{ count: n, color: 'red', label: parts.join(', ') }];
     }
     // Other admin roll-ups have no badge here: every queue count belongs to another
     // nav item that already badges it, so a roll-up would just duplicate numbers.

--- a/checkin-app/src/lib/__tests__/cronAuth.test.ts
+++ b/checkin-app/src/lib/__tests__/cronAuth.test.ts
@@ -2,16 +2,19 @@
  * @jest-environment node
  */
 /**
- * Unit tests for requireCronSecret — the shared auth gate for all cron routes.
- * No DB: Request objects are constructed directly. This is the primary coverage
- * for cron auth; per-route tests only smoke the valid-token path.
+ * Unit tests for requireCronSecret — the shared auth gate for all cron routes —
+ * and for withCron's run ledger. No DB: Request objects are constructed directly
+ * and prisma.cronRunLog is stubbed. This is the primary coverage for cron auth;
+ * per-route tests only smoke the valid-token path.
  */
-import { requireCronSecret } from '@/lib/cronAuth';
+import { NextResponse } from 'next/server';
+import { requireCronSecret, withCron } from '@/lib/cronAuth';
+import prisma from '@/lib/prisma';
 
 const SECRET = 'unit-cron-secret';
 
-function req(authHeader?: string) {
-    return new Request('http://localhost/api/cron/anything', {
+function req(authHeader?: string, url = 'http://localhost/api/cron/anything') {
+    return new Request(url, {
         method: 'GET',
         headers: authHeader ? { authorization: authHeader } : {},
     });
@@ -56,5 +59,103 @@ describe('requireCronSecret', () => {
     it('returns null (authorized) for the valid secret', () => {
         const res = requireCronSecret(req(`Bearer ${SECRET}`));
         expect(res).toBeNull();
+    });
+});
+
+/**
+ * The run ledger. The contract that matters is that recording is INVISIBLE to the
+ * job: it must not change what the handler returns, and it must not be able to
+ * fail the job. A run that threw has to land as a failure, not go unrecorded.
+ */
+describe('withCron run ledger', () => {
+    const prev = process.env.CRON_SECRET;
+    let create: jest.Mock;
+
+    beforeEach(() => {
+        process.env.CRON_SECRET = SECRET;
+        create = jest.fn().mockResolvedValue({});
+        prisma.cronRunLog.create = create;
+        prisma.cronRunLog.deleteMany = jest.fn().mockResolvedValue({ count: 0 });
+    });
+
+    afterAll(() => {
+        if (prev === undefined) delete process.env.CRON_SECRET;
+        else process.env.CRON_SECRET = prev;
+    });
+
+    const authed = (url?: string) => req(`Bearer ${SECRET}`, url);
+
+    it('records a success and returns the handler response untouched', async () => {
+        const handler = jest.fn().mockResolvedValue(NextResponse.json({ success: true, checkedOutCount: 3 }));
+        const res = await withCron(handler)(authed('http://localhost/api/cron/nightly'));
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ success: true, checkedOutCount: 3 });
+        expect(create).toHaveBeenCalledTimes(1);
+        const { data } = create.mock.calls[0][0];
+        expect(data).toMatchObject({ job: 'nightly', success: true, error: null });
+        expect(data.startedAt).toBeInstanceOf(Date);
+    });
+
+    it('derives the job name from the route path, so every cron route is covered', async () => {
+        const handler = jest.fn().mockResolvedValue(NextResponse.json({ success: true }));
+        await withCron(handler)(authed('http://localhost/api/cron/reconcile-shopify?force=1'));
+
+        expect(create.mock.calls[0][0].data.job).toBe('reconcile-shopify');
+    });
+
+    // A handler that returns its own error envelope has not had a healthy run, even
+    // though nothing was thrown. No cron route does this today — the ledger just must
+    // not start lying the day one does.
+    it('records an error-envelope response as a failure, not a success', async () => {
+        const handler = jest.fn().mockResolvedValue(NextResponse.json({ error: 'mirror unreachable' }, { status: 503 }));
+        const res = await withCron(handler)(authed('http://localhost/api/cron/reconcile-shopify'));
+
+        expect(res.status).toBe(503);
+        expect(await res.json()).toEqual({ error: 'mirror unreachable' });
+        expect(create.mock.calls[0][0].data).toMatchObject({ job: 'reconcile-shopify', success: false, error: 'HTTP 503' });
+    });
+
+    it('records a failure and still returns the 500 when the handler throws', async () => {
+        // Suppressed locally, NOT via jest.setup.js's global allowlist: a global entry
+        // for the wrapper's own logs would silence them in every other cron test too.
+        const logged = jest.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            const handler = jest.fn().mockRejectedValue(new Error('sweep exploded'));
+            const res = await withCron(handler)(authed('http://localhost/api/cron/nightly'));
+
+            expect(res.status).toBe(500);
+            expect(await res.json()).toEqual({ error: 'Internal Server Error' });
+            expect(create.mock.calls[0][0].data).toMatchObject({ job: 'nightly', success: false, error: 'sweep exploded' });
+            expect(logged).toHaveBeenCalled();
+        } finally {
+            logged.mockRestore();
+        }
+    });
+
+    it('does not fail the job when the ledger write itself fails', async () => {
+        const logged = jest.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            prisma.cronRunLog.create = jest.fn().mockRejectedValue(new Error('db down'));
+            const handler = jest.fn().mockResolvedValue(NextResponse.json({ success: true, adultDobPurged: 0 }));
+
+            const res = await withCron(handler)(authed('http://localhost/api/cron/nightly'));
+
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual({ success: true, adultDobPurged: 0 });
+            // The write really did fail — otherwise this test proves nothing.
+            expect(logged).toHaveBeenCalledWith('Failed to record cron run:', expect.any(Error));
+        } finally {
+            logged.mockRestore();
+        }
+    });
+
+    it('records nothing for an unauthorized call — a 401 is not a run', async () => {
+        const handler = jest.fn();
+        const res = await withCron(handler)(req('Bearer wrong'));
+
+        expect(res.status).toBe(401);
+        expect(handler).not.toHaveBeenCalled();
+        expect(create).not.toHaveBeenCalled();
     });
 });

--- a/checkin-app/src/lib/__tests__/cronRuns.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/cronRuns.integration.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * The cron run ledger against a real Postgres. The unit tests stub the two reads;
+ * what only a real database proves is that the migration's columns match the Prisma
+ * model, and that the latest-failure-per-job read (`distinct` over an ordered scan)
+ * actually returns one row per job rather than the whole table.
+ *
+ * Also covers the write path end to end through withCron — the same wrapper all nine
+ * /api/cron routes go through.
+ */
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { withCron } from '@/lib/cronAuth';
+import { CRON_STALE_AFTER_MS, getCronJobStatuses, recordCronRun } from '@/lib/cronRuns';
+
+const TAG = 'cron-runs-int';
+const JOB_A = `${TAG}-alpha`;
+const JOB_B = `${TAG}-beta`;
+const SECRET = 'integration-cron-secret';
+
+const HOUR = 60 * 60 * 1000;
+const ago = (ms: number) => new Date(Date.now() - ms);
+
+/** Statuses for this suite's jobs only — the DB may hold rows from other suites. */
+const mine = async () => (await getCronJobStatuses()).filter((s) => s.job.startsWith(TAG));
+
+describe('cron run ledger (real DB)', () => {
+    const prevSecret = process.env.CRON_SECRET;
+
+    beforeAll(() => {
+        process.env.CRON_SECRET = SECRET;
+    });
+
+    afterAll(async () => {
+        if (prevSecret === undefined) delete process.env.CRON_SECRET;
+        else process.env.CRON_SECRET = prevSecret;
+        await prisma.cronRunLog.deleteMany({ where: { job: { startsWith: TAG } } });
+    });
+
+    afterEach(async () => {
+        await prisma.cronRunLog.deleteMany({ where: { job: { startsWith: TAG } } });
+    });
+
+    it('withCron writes a success row the status read can see', async () => {
+        const handler = async () => NextResponse.json({ success: true, checkedOutCount: 0 });
+        const req = new Request(`http://localhost/api/cron/${JOB_A}`, { headers: { authorization: `Bearer ${SECRET}` } });
+
+        const res = await withCron(handler)(req);
+        expect(res.status).toBe(200);
+
+        const [status] = await mine();
+        expect(status.job).toBe(JOB_A);
+        expect(status.stale).toBe(false);
+        expect(status.lastError).toBeUndefined();
+    });
+
+    it('withCron records a failure and still returns the 500', async () => {
+        // Local suppression of the wrapper's own catch log — deliberately not a global
+        // jest.setup.js allowlist entry, which would silence it in every cron test.
+        const logged = jest.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            const handler = async (): Promise<NextResponse> => { throw new Error('sweep exploded'); };
+            const req = new Request(`http://localhost/api/cron/${JOB_A}`, { headers: { authorization: `Bearer ${SECRET}` } });
+
+            const res = await withCron(handler)(req);
+            expect(res.status).toBe(500);
+
+            const row = await prisma.cronRunLog.findFirstOrThrow({ where: { job: JOB_A } });
+            expect(row).toMatchObject({ success: false, error: 'sweep exploded' });
+        } finally {
+            logged.mockRestore();
+        }
+    });
+
+    it('reports only the newest failure per job, and only while it is unresolved', async () => {
+        await prisma.cronRunLog.createMany({
+            data: [
+                // JOB_A: stale, and broken since — two failures, only the newest is reported.
+                { job: JOB_A, startedAt: ago(CRON_STALE_AFTER_MS + 5 * HOUR), finishedAt: ago(CRON_STALE_AFTER_MS + 5 * HOUR), success: true },
+                { job: JOB_A, startedAt: ago(3 * HOUR), finishedAt: ago(3 * HOUR), success: false, error: 'older failure' },
+                { job: JOB_A, startedAt: ago(HOUR), finishedAt: ago(HOUR), success: false, error: 'newest failure' },
+                // JOB_B: failed, then recovered — healthy, no error surfaced.
+                { job: JOB_B, startedAt: ago(4 * HOUR), finishedAt: ago(4 * HOUR), success: false, error: 'recovered since' },
+                { job: JOB_B, startedAt: ago(HOUR), finishedAt: ago(HOUR), success: true },
+            ],
+        });
+
+        // Stalest first.
+        expect(await mine()).toEqual([
+            { job: JOB_A, lastSuccessAt: expect.any(Date), stale: true, lastError: 'newest failure' },
+            { job: JOB_B, lastSuccessAt: expect.any(Date), stale: false },
+        ]);
+    });
+
+    it('purges rows past the 90-day TTL on write', async () => {
+        const ancient = ago(91 * 24 * HOUR);
+        await prisma.cronRunLog.create({ data: { job: JOB_B, startedAt: ancient, finishedAt: ancient, success: true } });
+
+        await recordCronRun(JOB_A, new Date(), true);
+
+        expect(await prisma.cronRunLog.count({ where: { job: JOB_B } })).toBe(0);
+        expect(await prisma.cronRunLog.count({ where: { job: JOB_A } })).toBe(1);
+    });
+});

--- a/checkin-app/src/lib/__tests__/cronRuns.test.ts
+++ b/checkin-app/src/lib/__tests__/cronRuns.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Staleness derivation for the cron run ledger. The DB half is a single groupBy,
+ * stubbed here; what's worth testing is the rule applied to its rows — one coarse
+ * window for every job, and a job that has NEVER run is not reported as stale
+ * (the app can't know whether infra schedules it at all).
+ */
+import prisma from '@/lib/prisma';
+import { CRON_STALE_AFTER_MS, cronJobName, countStaleCronJobs, getCronJobStatuses } from '@/lib/cronRuns';
+
+const NOW = new Date('2026-08-06T12:00:00.000Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+const HOUR = 60 * 60 * 1000;
+
+/** Stub the two reads: the success aggregate, and the latest-failure-per-job scan. */
+function stubGroupBy(
+    rows: { job: string; finishedAt: Date | null }[],
+    failures: { job: string; finishedAt: Date; error: string | null }[] = [],
+) {
+    prisma.cronRunLog.groupBy = jest.fn().mockResolvedValue(
+        rows.map((r) => ({ job: r.job, _max: { finishedAt: r.finishedAt } })),
+    );
+    prisma.cronRunLog.findMany = jest.fn().mockResolvedValue(failures);
+}
+
+describe('cronJobName', () => {
+    it('takes the last path segment and ignores the query string', () => {
+        expect(cronJobName('http://localhost/api/cron/nightly')).toBe('nightly');
+        expect(cronJobName('https://app.example.org/api/cron/post-event?force=1')).toBe('post-event');
+    });
+
+    it('tolerates a trailing slash', () => {
+        expect(cronJobName('http://localhost/api/cron/nightly/')).toBe('nightly');
+    });
+});
+
+describe('getCronJobStatuses', () => {
+    it('marks a job stale once its last success is older than the window', async () => {
+        stubGroupBy([{ job: 'nightly', finishedAt: ago(CRON_STALE_AFTER_MS + HOUR) }]);
+
+        const statuses = await getCronJobStatuses(NOW);
+
+        expect(statuses).toEqual([{ job: 'nightly', lastSuccessAt: ago(CRON_STALE_AFTER_MS + HOUR), stale: true }]);
+    });
+
+    it('leaves a healthy daily job alone — one missed run is inside the window', async () => {
+        // 30h since the last success: a daily job that skipped one run. The window is
+        // deliberately coarse enough that this must NOT alarm.
+        stubGroupBy([{ job: 'nightly', finishedAt: ago(30 * HOUR) }]);
+
+        expect((await getCronJobStatuses(NOW))[0].stale).toBe(false);
+    });
+
+    it('omits a job that has never recorded a successful run', async () => {
+        // A route nothing schedules has no rows at all — absence of evidence is not a
+        // missed run, and this is what stops the badge firing on all nine routes the
+        // day the table ships.
+        stubGroupBy([]);
+
+        expect(await getCronJobStatuses(NOW)).toEqual([]);
+        expect(await countStaleCronJobs(NOW)).toBe(0);
+    });
+
+    it('puts the stalest job first and counts only the stale ones', async () => {
+        stubGroupBy([
+            { job: 'nightly', finishedAt: ago(CRON_STALE_AFTER_MS + HOUR) },
+            { job: 'post-event', finishedAt: ago(2 * HOUR) },
+            { job: 'reconcile-shopify', finishedAt: ago(10 * 24 * HOUR) },
+        ]);
+
+        const statuses = await getCronJobStatuses(NOW);
+
+        expect(statuses.map((s) => s.job)).toEqual(['reconcile-shopify', 'nightly', 'post-event']);
+        expect(statuses.filter((s) => s.stale).map((s) => s.job)).toEqual(['reconcile-shopify', 'nightly']);
+        expect(await countStaleCronJobs(NOW)).toBe(2);
+    });
+
+    it('reports the error of a job that has failed since its last success', async () => {
+        stubGroupBy(
+            [{ job: 'nightly', finishedAt: ago(3 * 24 * HOUR) }],
+            [{ job: 'nightly', finishedAt: ago(2 * HOUR), error: 'connection refused' }],
+        );
+
+        expect(await getCronJobStatuses(NOW)).toEqual([
+            { job: 'nightly', lastSuccessAt: ago(3 * 24 * HOUR), stale: true, lastError: 'connection refused' },
+        ]);
+    });
+
+    it('drops a failure the job has since recovered from', async () => {
+        stubGroupBy(
+            [{ job: 'nightly', finishedAt: ago(2 * HOUR) }],
+            [{ job: 'nightly', finishedAt: ago(3 * 24 * HOUR), error: 'connection refused' }],
+        );
+
+        const [status] = await getCronJobStatuses(NOW);
+        expect(status.lastError).toBeUndefined();
+        expect(status.stale).toBe(false);
+    });
+});

--- a/checkin-app/src/lib/cronAuth.ts
+++ b/checkin-app/src/lib/cronAuth.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import crypto from "crypto";
 import { logger } from "./logger";
 import { config } from "./config";
+import { cronJobName, recordCronRun } from "./cronRuns";
 
 /**
  * Shared auth gate for the cron routes. Checks `Authorization: Bearer $CRON_SECRET`
@@ -44,6 +45,17 @@ export function requireCronSecret(req: Request): NextResponse | null {
  *       const result = await runSweep();
  *       return NextResponse.json({ success: true, ...result });
  *   });
+ *
+ * Every completed run is stamped into CronRunLog — here rather than per-route, so
+ * a cron route added later is covered without touching it. Nothing about the sweep
+ * changes: the job name comes from the request path, the record is written after
+ * the handler has already produced its response, and {@link recordCronRun}
+ * swallows its own failures. Only AUTHORIZED runs are recorded; a 401 never
+ * happened as far as the ledger is concerned.
+ *
+ * Success is the response STATUS, not merely "the handler didn't throw" — a route
+ * that returns its own error envelope has not had a healthy run, and the ledger
+ * must not claim otherwise just because nothing was thrown.
  */
 export function withCron(
     handler: (req: Request) => Promise<NextResponse>,
@@ -52,10 +64,16 @@ export function withCron(
         const denied = requireCronSecret(req);
         if (denied) return denied;
 
+        const job = cronJobName(req.url);
+        const startedAt = new Date();
+
         try {
-            return await handler(req);
+            const res = await handler(req);
+            await recordCronRun(job, startedAt, res.status < 400, res.status < 400 ? undefined : `HTTP ${res.status}`);
+            return res;
         } catch (error) {
             logger.error("Cron handler error:", error);
+            await recordCronRun(job, startedAt, false, error);
             return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
         }
     };

--- a/checkin-app/src/lib/cronRuns.ts
+++ b/checkin-app/src/lib/cronRuns.ts
@@ -1,0 +1,129 @@
+import prisma from "./prisma";
+
+/**
+ * How long a job may go without a successful run before it counts as stale.
+ *
+ * ONE coarse constant for every job, deliberately — there is no per-job schedule
+ * here and there must not be one. The schedule and the caller live in a separate
+ * infra repository (an EventBridge rule invoking a Lambda that calls the route),
+ * so any expected-interval table copied into this repo would rot the moment
+ * someone retimes a job there, and would then either cry wolf or go quiet. 48h is
+ * picked to be unfalsifiable in both directions: generous enough that a daily job
+ * can miss a run, a deploy window, or a clock skew without alarming, and strict
+ * enough that a job which genuinely stopped surfaces within two days.
+ */
+export const CRON_STALE_AFTER_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * Last successful run of one cron job, and whether that is too long ago.
+ * `lastError` is set only when the job has failed SINCE its last success — i.e. when it
+ * is still broken. A failure the job later recovered from is history, not a status.
+ */
+export type CronJobStatus = { job: string; lastSuccessAt: Date; stale: boolean; lastError?: string };
+
+/** Route slug for the run ledger: the last path segment of /api/cron/<job>. */
+export function cronJobName(url: string): string {
+    const path = new URL(url).pathname.replace(/\/+$/, "");
+    return path.slice(path.lastIndexOf("/") + 1) || "unknown";
+}
+
+/**
+ * Records one completed cron run, then purges rows older than 90 days.
+ *
+ * Never throws and never rethrows: recording that a job ran must not change
+ * whether the job ran or what it returned. A failed write degrades the System
+ * Status panel, not the sweep.
+ *
+ * ponytail: the TTL purge runs inline on each write rather than from its own
+ * sweep — writes are ~9/day, and a cron to prune the cron log would be the exact
+ * circularity this table exists to detect. Same pattern as logIntegrationError.
+ */
+export async function recordCronRun(job: string, startedAt: Date, success: boolean, error?: unknown) {
+    try {
+        await prisma.cronRunLog.create({
+            data: {
+                job,
+                startedAt,
+                success,
+                error: error === undefined ? null : error instanceof Error ? error.message : String(error),
+            },
+        });
+
+        const ninetyDaysAgo = new Date();
+        ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+        await prisma.cronRunLog.deleteMany({ where: { finishedAt: { lt: ninetyDaysAgo } } });
+    } catch (writeError) {
+        console.error("Failed to record cron run:", writeError);
+    }
+}
+
+/**
+ * Most recent successful run per job.
+ *
+ * Only jobs with a recorded success appear. A route that has never run is not
+ * reported as stale, because the app has no way to know whether infra schedules
+ * it at all — absence of evidence isn't a missed run, and it also keeps the badge
+ * from firing on all nine routes the moment this table ships. The corollary: a job
+ * that stops and stays stopped drops off the list once the 90-day purge takes its
+ * last success, long after the badge has been red about it.
+ */
+async function lastSuccessByJob(): Promise<Map<string, Date>> {
+    const rows = await prisma.cronRunLog.groupBy({
+        by: ["job"],
+        where: { success: true },
+        _max: { finishedAt: true },
+    });
+
+    const out = new Map<string, Date>();
+    for (const r of rows) if (r._max.finishedAt) out.set(r.job, r._max.finishedAt);
+    return out;
+}
+
+/**
+ * Every job that has ever succeeded, most-stale first so the problems are at the
+ * top of the panel. Carries the failure message when the job has thrown since its
+ * last success — a red row that names what broke is actionable; one that only says
+ * "stopped" sends the reader to CloudWatch.
+ */
+export async function getCronJobStatuses(now: Date = new Date()): Promise<CronJobStatus[]> {
+    const [successes, failures] = await Promise.all([
+        lastSuccessByJob(),
+        // Latest failure per job. `distinct` after an ordered scan rather than a
+        // correlated subquery: the table is ~one row per job per day under a 90-day
+        // TTL, so there is nothing here worth optimising.
+        prisma.cronRunLog.findMany({
+            where: { success: false },
+            orderBy: [{ job: "asc" }, { finishedAt: "desc" }],
+            distinct: ["job"],
+            select: { job: true, finishedAt: true, error: true },
+        }),
+    ]);
+
+    const latestFailure = new Map(failures.map((f) => [f.job, f]));
+
+    return [...successes.entries()]
+        .map(([job, lastSuccessAt]) => {
+            const failure = latestFailure.get(job);
+            return {
+                job,
+                lastSuccessAt,
+                stale: now.getTime() - lastSuccessAt.getTime() > CRON_STALE_AFTER_MS,
+                // A failure the job has since recovered from is history, not status.
+                ...(failure && failure.finishedAt > lastSuccessAt ? { lastError: failure.error ?? "unknown error" } : {}),
+            };
+        })
+        .sort((a, b) => a.lastSuccessAt.getTime() - b.lastSuccessAt.getTime());
+}
+
+/**
+ * Count of jobs past {@link CRON_STALE_AFTER_MS} — the nav-badge number. Reads only
+ * the success aggregate: this runs on the hot nav-poll path, where the panel's
+ * failure detail would be dead weight.
+ */
+export async function countStaleCronJobs(now: Date = new Date()): Promise<number> {
+    let stale = 0;
+    for (const lastSuccessAt of (await lastSuccessByJob()).values()) {
+        if (now.getTime() - lastSuccessAt.getTime() > CRON_STALE_AFTER_MS) stale += 1;
+    }
+    return stale;
+}

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -348,6 +348,14 @@ export const classifications = {
         timestamp: 'internal',
         resolvedAt: 'internal',
     },
+    CronRunLog: {
+        id: 'internal',
+        job: 'internal',
+        startedAt: 'internal',
+        finishedAt: 'internal',
+        success: 'internal',
+        error: 'internal',
+    },
     DevLedger: {
         id: 'internal',
         action: 'internal',
@@ -541,6 +549,8 @@ export const relations = {
     SystemMetricLog: {
     },
     IntegrationErrorLog: {
+    },
+    CronRunLog: {
     },
     DevLedger: {
     },


### PR DESCRIPTION
Came out of analysis on #1529 — not from the Class-B register, new work.

## The problem

The app serves nine cron endpoints under `checkin-app/src/app/api/cron/*`, all gated by `withCron`. Nothing in this repo schedules them: the EventBridge schedule and the Lambda that reads `CRON_SECRET` and calls the route live in a separate infra repository.

So checkin cannot tell whether its own sweeps ran. `/api/cron/nightly` is the safety-critical one — it force-closes abandoned visits, raises the keyholder "facility left Open" alert, flushes post-event email and purges DoB for members over 25. If it silently stops firing the app emits no signal at all, and the failure surfaces days later as stale open visits and an alert nobody received.

`IntegrationErrorLog` cannot represent this. It is error-driven (`logIntegrationError`), and a run that never happens produces no error. A success record is required.

## What this adds

**1. `CronRunLog`** — `job`, `startedAt`, `finishedAt`, `success`, `error?`. New table, no FKs, nothing else reads it: purely additive and safe for old code serving traffic during the deploy drain window (rule 1 of `DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md`). Growth is bounded by a 90-day inline TTL purge on write — the same pattern as `logIntegrationError`, and a cron to prune the cron log would be the exact circularity this table exists to detect.

**2. The stamp lives in `withCron`**, not in the routes. The wrapper already owns the auth gate and the top-level catch, so both outcomes are already in hand; the job name comes from the request path, so a tenth cron route is covered without touching it. Only authorized runs are recorded — a 401 is not a run.

Recording is invisible to the job by construction: `recordCronRun` swallows its own failures, the write happens after the handler has produced its response, and the existing catch records a failure before returning its 500.

**3. A "Scheduled Jobs" panel** on System Status — last successful run per job, how long ago, and the failure message when the job has thrown *since* that success. It rides on the existing `/api/system-status/config-health` route (same gate, same page, same question) rather than a new registered route, which would need its registry entry landed separately.

**4. The stale count feeds the red `/system-status` nav pill the board already sees**, described in code as "infra broken, not 'you have a task'" — exactly the semantics of a missed sweep.

## Decisions worth reviewing

**No handler summary is persisted.** Capturing one means `res.clone().json()` in the wrapper — parsing a body it otherwise never touches — and six of the nine routes return `{ success: true, ...result }` spread from a service function whose shape is not fixed here (`runReconcile`, `runLifecycleReconcile`). That is an unbounded, uninspected blob persisted outside the response stripper's view, to answer a question nobody asked. "Did the sweep run" is job + timestamps + success. If someone later wants "how many did it close", that is named columns, not a JSON bag.

`error` is kept because it is free at write time (the wrapper already holds the caught error) and it is displayed: a red row that names what broke is actionable, one that only says "stopped" sends the reader to CloudWatch.

**One badge, not two.** Count is `openIssues + staleCronJobs`, label itemizes ("2 config issues, 1 cron job not running"). Both halves mean "infra broken", land on the same page, and are fixed by the same people — a second red pill on the same nav item would be a second number pointing at the same link. The payload keeps the fields separate (`configHealth: { openIssues, staleCronJobs }`); the fold happens at render.

**The count is computed in `todo-counts`, not in `getConfigHealth()`.** A staleness check needs a DB read; `getConfigHealth` is synchronous and env-only, and making it async ripples into `openConfigIssues()` and the nav path. `todo-counts` is already async, already does substantial DB work, and already assembles the payload the badge reads.

**Threshold: one coarse 48h constant for every job.** A per-job schedule model is deliberately not built — the schedule lives in the infra repo and any copy here rots the moment someone retimes a job. 48h is generous enough that a daily job can miss a run, a deploy window or clock skew without alarming, and strict enough to catch one that genuinely stopped.

One consequence that fell out of that and is worth a reviewer's eye: **a job with no recorded success is not reported stale.** Otherwise all nine routes go red the day this ships. It is also the honest answer — the app has no way to know whether infra schedules a given route at all, so absence of evidence is not a missed run. The corollary is that a job which stops and stays stopped drops off the panel once the 90-day purge takes its last success, roughly 88 days after the badge first went red about it.

## Authorization

Matches the existing shape exactly: `config-health` gates on `isSysadmin || isBoardMember`, and `todo-counts` omits the `configHealth` key entirely for everyone else. Both are covered by tests.

## Security boundary

Inside the lines. The new model's `@sensitivity` annotations regenerated `classifications.ts` purely additively, which `security-boundary-isolation.yml` explicitly exempts. No registry, scope-binding, stripper or re-tier changes; no new route; no new page (so no `pageRegistry` entry needed).

## Tests

```
Unit:        269 suites, 2559 tests   PASS
Integration: 132 suites, 1348 tests   PASS
tsc --noEmit: clean      eslint --max-warnings 0: clean
prisma migrate diff --from-config-datasource: No difference detected
```

New coverage: a successful call records a run; a throwing handler records a failure and still returns its 500; a failed ledger write leaves the handler's response untouched; a job whose last success is older than the threshold raises the count; a board member receives that count while a non-board non-admin session does not. `cronRuns.integration.test.ts` runs against real Postgres, which is what proves the migration's columns match the Prisma model and that `distinct: ['job']` really returns one row per job.

## Note for the reviewer

A dev reset truncates `CronRunLog` — `src/lib/dev/actions.ts` enumerates `pg_tables` and excludes only `_prisma_migrations` and `DevLedger`. Left as-is: after a reset the panel says "No cron run has been recorded yet", which is true. Easy to exclude it like `DevLedger` if the run history should survive a reset instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)