### PR TITLE
fix(roles): refuse granting BOARD into a DENIED household

### DIFF
--- a/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminRolesAPI.integration.test.ts
@@ -340,6 +340,60 @@ describe('Admin Roles API Integration Tests', () => {
         });
     });
 
+    describe('PATCH /api/roles — board grant into a DENIED household', () => {
+        let deniedPersonId: number;
+        let deniedHouseholdId: number;
+
+        beforeAll(async () => {
+            const person = await prisma.person.create({
+                data: { email: `denied-target-${TAG}@example.com`, name: 'Denied Target', household: { create: { name: "Test HH" } } },
+            });
+            deniedPersonId = person.id;
+            deniedHouseholdId = person.householdId;
+            await prisma.orgMembership.create({ data: { householdId: deniedHouseholdId, status: 'DENIED' } });
+        });
+
+        afterAll(async () => {
+            if (deniedPersonId === undefined) return;
+            await prisma.auditLog.deleteMany({ where: { affectedEntityId: deniedPersonId } });
+            await prisma.orgMembership.deleteMany({ where: { householdId: deniedHouseholdId } });
+            await prisma.person.deleteMany({ where: { id: deniedPersonId } });
+        });
+
+        it('refuses the grant (409) and writes neither the PersonRole row nor the mirror', async () => {
+            asSession({ id: testSysAdminId, isSysadmin: true });
+            const res = await PATCH(patchReq({ targetUserId: deniedPersonId, isBoardMember: true }));
+            expect(res.status).toBe(409);
+            const data = await res.json();
+            expect(data.error).toContain('denied membership');
+
+            expect(await prisma.personRole.findUnique({
+                where: { personId_role: { personId: deniedPersonId, role: 'BOARD' } },
+            })).toBeNull();
+            const row = await prisma.person.findUnique({ where: { id: deniedPersonId } });
+            expect(row?.isBoardMember).toBe(false);
+        });
+
+        it('still allows a non-board flag on the same person (the guard is BOARD-only)', async () => {
+            asSession({ id: testSysAdminId, isSysadmin: true });
+            const res = await PATCH(patchReq({ targetUserId: deniedPersonId, isOperations: true }));
+            expect(res.status).toBe(200);
+            expect(await hasOperationsRow(deniedPersonId)).toBe(true);
+        });
+
+        it('allows the grant once the household is restored', async () => {
+            await prisma.orgMembership.update({ where: { householdId: deniedHouseholdId }, data: { status: 'NONE' } });
+            asSession({ id: testSysAdminId, isSysadmin: true });
+            const res = await PATCH(patchReq({ targetUserId: deniedPersonId, isBoardMember: true }));
+            expect(res.status).toBe(200);
+
+            // Leave no BOARD row behind: the last-board describes below assert a zero
+            // ambient board count.
+            await prisma.personRole.deleteMany({ where: { personId: deniedPersonId, role: 'BOARD' } });
+            await prisma.person.update({ where: { id: deniedPersonId }, data: { isBoardMember: false } });
+        });
+    });
+
     describe('PATCH /api/roles — canAccessStaging (ops-stg gate escape hatch, sysadmin-only, NOT board-symmetric)', () => {
         let stagingTargetId: number;
         let stagingBoardActorId: number;

--- a/checkin-app/src/app/api/roles/route.ts
+++ b/checkin-app/src/app/api/roles/route.ts
@@ -10,6 +10,7 @@ import {
     setRoleFlag,
     RoleMatrixError,
     LastBoardMemberError,
+    DeniedHouseholdBoardError,
 } from "@/lib/roles";
 import { LIVE_PERSON } from "@/lib/person/filters";
 import { isYouth } from "@/lib/time";
@@ -199,6 +200,9 @@ export const PATCH = withAuth(
             }
             if (error instanceof LastBoardMemberError) {
                 return apiError("Cannot remove the last board member", 409);
+            }
+            if (error instanceof DeniedHouseholdBoardError) {
+                return apiError("This person's household has been denied membership. Restore the household's membership before granting the board role.", 409);
             }
             logger.error("Error updating role:", error);
             return apiError("Internal server error", 500);

--- a/checkin-app/src/lib/roles.ts
+++ b/checkin-app/src/lib/roles.ts
@@ -82,6 +82,8 @@ async function applyRoleFlag(
 export class RoleMatrixError extends Error {}
 /** Thrown by `setRoleFlag` when the change would remove the last remaining board member. */
 export class LastBoardMemberError extends Error {}
+/** Thrown by `setRoleFlag` when granting BOARD to a member of a DENIED household. */
+export class DeniedHouseholdBoardError extends Error {}
 
 /**
  * A logged-in actor's authority, for the matrix check below — or the literal
@@ -95,7 +97,7 @@ export type RoleActor = { id: number; isBoardMember: boolean; isSysadmin: boolea
 
 /**
  * THE write choke point for role changes. Grants/revokes one `flag` on
- * `target`, owning both invariants that used to live in the API route:
+ * `target`, owning every invariant a role write has to hold:
  *
  *  - the per-flag authority matrix (§4.3): a board actor may grant/revoke any
  *    of the five flags, including adding/removing isSysadmin and removing
@@ -105,10 +107,13 @@ export type RoleActor = { id: number; isBoardMember: boolean; isSysadmin: boolea
  *  - the last-board-member guard: board membership can never be revoked down
  *    to zero, regardless of actor (including "system" — this protects data
  *    integrity, not authority, so the bypass above does not extend to it).
+ *  - the denied-household guard: BOARD can't be granted to a member of a DENIED
+ *    household, the mirror of the deny-side refusal in
+ *    POST /api/membership-ops/households. Also actor-independent.
  *
  * Every writer that mutates a role — the PATCH /api/roles route, bootstrap
  * self-promotion, dev seeds — routes through here, so a new caller can't
- * accidentally skip either invariant.
+ * accidentally skip any of them.
  *
  * Locks the whole BOARD row set FOR UPDATE before checking or writing.
  * ponytail: FOR UPDATE over the whole set — tiny table (a handful of rows),
@@ -156,6 +161,19 @@ export async function setRoleFlag(
         if (flag === "isBoardMember" && on === false) {
             const boardCount = await tx.personRole.count({ where: { role: "BOARD" } });
             if (boardCount <= 1) throw new LastBoardMemberError();
+        }
+
+        // The other half of the deny guard in POST /api/membership-ops/households: a
+        // denied household holds no authority and every member of it is locked out of
+        // sign-in, so BOARD can't be granted into one from this side either. Like the
+        // last-board guard this protects the data, not authority — "system" doesn't
+        // bypass it.
+        if (flag === "isBoardMember" && on === true) {
+            const target = await tx.person.findUnique({
+                where: { id: personId },
+                select: { household: { select: { orgMembership: { select: { status: true } } } } },
+            });
+            if (target?.household.orgMembership?.status === "DENIED") throw new DeniedHouseholdBoardError();
         }
 
         await applyRoleFlag(tx, personId, flag, on, actor === "system" ? undefined : actor.id);


### PR DESCRIPTION
## What

`PATCH /api/roles` now refuses to grant the BOARD role to a person whose household's `OrgMembership.status` is `DENIED` — 409, with a message naming the fix (restore the household's membership first).

The guard lives in `setRoleFlag` (`src/lib/roles.ts`), not in the route: it is the documented write choke point every role writer routes through (the API route, bootstrap self-promotion, dev seeds), so a future caller can't skip it.

## Why

`docs/rules/membership.md` (Activation) says a household containing a board member cannot be denied — the board role is removed first, as a separate act. It also says a denied household holds no authority anywhere in the app, and that denial locks every member of the household out of sign-in.

Only the deny direction was enforced. `POST /api/membership-ops/households` refuses a denial when the household contains a board member, but nothing stopped BOARD being granted to a member of an already-DENIED household. The end state the deny guard exists to prevent — a board member locked out of sign-in while holding the highest role in the system — was reachable in one move from the other side.

Found by the domain-register audit on #1528 (row A6). That issue covers more than this, so no closing keyword.

## Scope

- BOARD only, DENIED only. `REVOKED`/`LAPSED`/`NONE` are deliberately different — `docs/rules/membership.md` says a revoked household keeps app access — and no other role is touched.
- Actor-independent, like the last-board-member guard: this protects the data, not authority, so the `"system"` actor bypass does not extend to it. No seeded household is DENIED, so seeds are unaffected.
- The deprecated `Person.isBoardMember` mirror is untouched. The new read is `OrgMembership.status` via the target's household; porting the deny side's mirror read is separate migration debt.

## Reviewer notes

- **`findUnique`, not `findFirst`.** The first version used `person.findFirst` and tripped the LIVE_PERSON drift guard (`src/__tests__/livePersonDriftGuard.test.ts`). Adding `...LIVE_PERSON` would have satisfied the guard but opened a hole: a tombstoned target would skip the check entirely. `findUnique` is excluded from that guard by design (unique-key shapes can't leak a tombstone into a list or count) and keeps the check total.
- **A UI disable is not the guard.** Same position the deny branch states in its own comment. No UI change here; the 409 is the enforcement.

## Testing

New describe in `adminRolesAPI.integration.test.ts`:
1. grant BOARD into a DENIED household → 409, no `PersonRole` row written, no mirror flip
2. a non-board flag on the same person still succeeds (the guard is BOARD-only)
3. the grant goes through once the household is restored

Runs:
- negative control — guard block deleted, `adminRolesAPI` → `1 failed, 29 passed`, the one failure being the refusal test
- guard restored — `adminRolesAPI` + `householdsDenyAPI` → 36 passed (the existing deny-side test stays green)
- `npm run test:ci` → 2543 passed; `tsc --noEmit` clean

Unrelated to this diff: four integration suites fail against a stale generated Prisma client (`VisitSource` missing `LEAD_MARKED`/`AUTO_CLOSE`/`FACILITY_CLOSE`). `npx prisma generate` clears them and the matching tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)