### PR TITLE
docs(rules): correct sixteen stale register rules and retire the appendices

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -9,7 +9,7 @@ CheckMeIn is a member check-in and program management system for makerspaces, co
 3. **Reliability in Kiosk Environments**: The system is often deployed unattended on physical kiosks (such as a Raspberry Pi). The UI must remain clean, stable, self-recovering, and optimized for these displays.
 4. **Maintainability**: The codebase uses Next.js, Prisma, and PostgreSQL. Keep dependencies minimal and adhere to existing architectural patterns (Next Auth for sessions, Prisma ORM for data access).
 
-## Guidelines for AI Agents (Jules)
+## Guidelines for AI Agents
 As an AI agent contributing to CheckMeIn, you must:
 - **Read and understand** this Constitution before starting work on any issue.
 - **Reject** feature requests that compromise security, such as disabling authentication checks, bypassing tool certification requirements, or altering the core RBAC (Role-Based Access Control) mechanisms.

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -738,7 +738,10 @@ model TrustedAdult {
   updatedAt                 DateTime           @updatedAt
   /// When the household chose to permanently hide a withdrawn trusted adult from
   /// their own view. The row is KEPT (board history / audit); the member-facing
-  /// /mine list filters it out. Board & sysadmin views still see it.
+  /// /mine list filters it out. No board view lists it either — the review queue
+  /// selects links carrying a pending or expired review and the operational list
+  /// selects approved ones, so a withdrawn link is outside both whatever this
+  /// column says.
   /// @sensitivity:internal
   hiddenAt                  DateTime?
 

--- a/docs/DOCUMENTATION_STANDARD.md
+++ b/docs/DOCUMENTATION_STANDARD.md
@@ -178,21 +178,35 @@ share one tag.
 | `[Decision — *Policy: …*]` | The app's specific expression of a policy stated generally above — a threshold picked, a proxy chosen, need-to-know made concrete for one field. Sometimes **stricter** than the policy requires, in which case say so: the risk is someone relaxing it while believing they are aligning to policy. |
 | `[Decision — *Principle: …*]` | The domain's application of a cross-cutting rule. States only what the domain adds. |
 | `[Decision — deliberate limit]` | The **absence** is chosen. The one most likely to be "fixed" by someone helpful. |
+| `[Short of policy — *Policy: …*]` | The app models this and models it **weaker** than the cited policy. Not renegotiable in review and not a target to build toward casually: what closes it is the policy. Tracked as work as well as stated (§3.7). |
 | `[Unsettled — …]` | Genuinely not agreed. **Do not cite as precedent.** |
+
+`[Decision — deliberate limit]` and `[Short of policy — …]` are the pair most
+easily confused, and they demand opposite actions. A deliberate limit says *do
+not fix this* — the absence was chosen, and closing it would undo something. A
+shortfall says *do fix this, but not casually* — the board has already decided
+and the app has not caught up. Reading one as the other is how a deliberate limit
+gets "closed" by a helpful change, or a real shortfall gets defended as
+intentional.
 
 ### 3.7 Recording a divergence
 
-A domain file may end with a section for board rules the app does not implement,
-or implements more loosely than the policy states. Four things are **not**
-divergences, and putting them there is the failure mode this section exists to
-prevent:
+A divergence is a board rule the app implements more loosely than the policy
+states. Four things are **not** divergences, and calling one a divergence is the
+failure mode this section exists to prevent:
 
 - **A policy value held in configuration.** The app is built to be configurable;
   keeping a setting aligned to policy is operational work.
 - **A rule the data model already guarantees.** One price column rather than a
   per-person amount means "the same for everyone" needs no assertion. The
   absence of a check is not the absence of the constraint.
-- **Anything handled outside the app.** That is an assumption (§3.2).
+- **Anything handled outside the app.** That is an assumption (§3.2), and the
+  distinction is the whole test: an assumption says the job is being done
+  somewhere else, a divergence says the job is not being done. Writing a
+  deficiency as an assumption — "we assume leads check this" — is the easiest way
+  to make a gap read as settled, and it is more tempting now that there is no
+  section to collect gaps in. If nothing outside the app actually does the job,
+  it is not an assumption.
 - **A deliberate balance.** Choosing not to block someone at the door for an
   obligation better chased in conversation is a decision, and belongs in
   Procedure as a deliberate limit.
@@ -202,11 +216,31 @@ than the policy — a supervision check counting bare adults where policy requir
 two unrelated non-student volunteers. Before recording one, read the enforcement
 path, not just the write path that creates the value.
 
-**Recording it is not the end of it.** A divergence stays in the domain file,
-where it qualifies the rules around it, and is also tracked as work. It is not a
-feature request: what closes it is the policy, not a judgement about what is
-worth building, and the app meanwhile reports as acceptable something the board
-has said is not.
+**Where it goes: at the rule it qualifies, never in a list of its own.** State it
+on the Procedure line a reader would otherwise take as enforced — one sentence
+saying what the app actually does and how that falls short — tagged
+`[Short of policy — *Policy: …*]` per §3.6. A reader who finds
+their answer stops reading, so a rule stated in one place and qualified in
+another is read as unqualified.
+
+Domain files used to end with a section collecting these. That section is gone,
+and it is not to be reintroduced: it sat a hundred lines from the rules it
+contradicted, and every entry in it was eventually found to be one of four things
+— shipped and stale, never a divergence at all, a gap the tracker should own, or
+a question nobody had answered. None of those needed a list.
+
+**Recording it is not the end of it.** A divergence is tracked as work as well as
+stated. It is not a feature request: what closes it is the policy, not a
+judgement about what is worth building, and the app meanwhile reports as
+acceptable something the board has said is not. Two consequences worth stating,
+because both have already bitten:
+
+- **The work that closes a divergence updates the rule in the same change.** An
+  implementation PR that fixes the behaviour and leaves the register describing
+  the old one has moved the error rather than fixed it.
+- **A gap the app does not model at all is not a divergence** — there is no rule
+  to qualify. It belongs to the tracker alone, with enough detail on the issue to
+  say which register file gains rules when it is built.
 
 ### 3.8 Format
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -21,14 +21,19 @@ several rules here are narrower than the discussion that produced them.
 
 ## Divergences
 
-Each file may end with a section naming board rules the app implements more
-loosely than the policy states. Those stay here, where they qualify the rules
-they sit under — **and** they are tracked as work, because a divergence from
-board policy is not something a domain file can resolve by describing it.
+Where the app implements a board rule more loosely than the policy states, that
+is stated **on the rule it qualifies** — not collected into a section of its own.
+A reader who finds their answer stops reading, so a rule qualified somewhere else
+is read as unqualified.
 
-Recording one is therefore not the end of it. It is not a feature request
-either: what closes it is the policy, not a judgement about what is worth
-building.
+It is also tracked as work, because a divergence from board policy is not
+something a domain file can resolve by describing it. Recording one is therefore
+not the end of it, and it is not a feature request either: what closes it is the
+policy, not a judgement about what is worth building.
+
+A gap the app does not model at all is not a divergence — there is no rule to
+qualify, and it belongs to the tracker alone. See `docs/DOCUMENTATION_STANDARD.md`
+§3.7 for the full test.
 
 ## Files
 

--- a/docs/rules/attendance-checkin.md
+++ b/docs/rules/attendance-checkin.md
@@ -102,8 +102,13 @@ Things the app takes as true because they are handled outside it.
 ### The visit record
 
 - A member inserts their own past visit, backdated as far as they need — there is
-  no limit on how far, and the audit trail stands in for one. They cannot edit it
-  once it is in.  [Decision]
+  no limit on how far, and the audit trail stands in for one.  [Decision]
+
+- A member corrects or removes a visit of their own once it is in. The correction
+  always applies: the only bars are validity — the times parse, departure follows
+  arrival, the visit runs no longer than 24 hours, and a closed one is never
+  reopened — and whose record it is. Integrity is after the fact rather than a
+  gate: every change is audited, and a significant one is flagged to the board.  [Decision — *Principle: self-scope and repair*]
 
 - A household lead corrects a recorded visit for anyone in their household —
   inserting a past one, changing its times, or removing it — on the same terms as
@@ -133,29 +138,8 @@ program. This is a record of who was at one session of one program.
   having been in the building at the time proves nothing — a walk-in who is not
   enrolled needs enrolling first.  [Decision — *Principle: identity is not authorisation*]
 
-- Who attended is for the people running it — the program's leader, keyholders,
-  the board and sysadmins. Anyone else is refused outright rather than handed a
-  trimmed version, because the names are the part that matters and they survive
-  any trimming.  [Decision — *Principle: least privilege*]
+- Who attended is for the people running it — the program's leader, its core
+  volunteers, the board and sysadmins. Anyone else is refused outright rather than
+  handed a trimmed version, because the names are the part that matters and they
+  survive any trimming.  [Decision — *Principle: least privilege*]
 
----
-
-## Policy requirements not yet enforced here
-
-- **A member cannot correct their own visit.** Settled design rather than policy,
-  and not built. It was decided; the implementation is pending.
-
-- **The supervision check is weaker than the policy on three counts.** It counts
-  adults present. Policy requires two adults who are *volunteers*, who are *not
-  students*, and who are *unrelated and from different households*. Any of those
-  three can be false while the app reports the room compliant.
-
-- **Primary keyholder is not modelled.** There is no single designated primary,
-  no consent-based transfer, and no obligation on a departing primary to
-  transfer or close.
-
-- **The closing guard is keyed on keyholders, not on the last youth.** A last
-  keyholder is stopped and made to confirm, which covers the common case — but
-  policy's requirement is two adults on site with a last youth, and a
-  non-keyholder adult can leave a youth with a single remaining adult without
-  being interrupted.

--- a/docs/rules/finance-payments.md
+++ b/docs/rules/finance-payments.md
@@ -169,5 +169,11 @@ Things the app takes as true because they are handled outside it.
 - A request for something starting after the next membership year is marked as
   such, never hidden or filtered away.  [Decision — deliberate limit]
 
+- Removal for non-payment is a human decision on an admin surface. The
+  non-payment sweep warns the household and escalates to the board; it never
+  removes anyone.  [Decision — *Principle: people decide about people*]
 
-- Removal for non-payment is a human decision on an admin surface.  [Decision — *Principle: people decide about people*]
+- The one removal that happens on its own follows a *denied* scholarship or
+  payment-plan request: when the grace period the board set runs out, the
+  enrollment goes and the held seat is released. Nothing is sent when it does, so
+  the board's own message has to have stated the deadline.  [Decision — *Principle: fail closed*]

--- a/docs/rules/membership.md
+++ b/docs/rules/membership.md
@@ -167,7 +167,7 @@ Procedure below is built on them.
   stopgap waiting to be automated.
 
 - Declining a scholarship or payment-plan request is a conversation between two
-  people. The app has no deny route and needs none.
+  people. Telling the family is the board's own act and happens outside the app.
 
 - Both signing adults in a household are marked as household leads. The app
   records no relationship between members, so lead status and age are together
@@ -240,8 +240,8 @@ Procedure below is built on them.
   — a former member keeps app access and loses facility privileges. Because the
   lockout reaches the whole household, denial is confirmed before it executes.  [Decision — *Principle: accountability*]
 
-- A household containing a board member cannot be denied. Removing the board role
-  first is a separate act, as it is outside the app.  [Decision — deliberate limit]
+- A household containing a board member cannot be denied. The board role is
+  removed in the app first, and that removal is a separate act from the denial.  [Decision — deliberate limit]
 
 - The denied landing page says only that access is denied. No reason, no contact,
   no mention of membership, no way to sign out.  [Decision — deliberate limit; *Principle: no existence oracle*]
@@ -259,6 +259,11 @@ Procedure below is built on them.
 
 - The board can activate a household with no payment by certifying a payment
   plan.  [Decision — *Policy: Membership Policy, Art. XIII*]
+
+- A board member declines a membership scholarship or payment-plan request in the
+  app, and the decline sends nothing: the request clears and the household returns
+  to owing its dues by the normal route. The decision is recorded; carrying it to
+  the family is not the app's job.  [Decision — deliberate limit; *Principle: people decide about people*]
 
 - A household that has settled its dues but is still waiting on its background
   check is a member for program pricing and for reaching members-only programs,
@@ -303,9 +308,13 @@ Procedure below is built on them.
   household's program-attached adults. It is surfaced for follow-up and gates
   nothing — chasing it is a conversation, not a refusal at the door.  [Decision — deliberate limit; *Policy: Volunteer Policy, Art. IV*]
 
-- Age is judged as of the membership-year boundary, which counts as inside it.
-  Turning 18 afterwards waits for the next boundary rather than firing on the
-  birthday.  [Decision — deliberate limit]
+- The annual sweep judges age as of the membership-year boundary, which counts as
+  inside it: turning 18 afterwards waits for the next sweep rather than firing on
+  the birthday.  [Decision — deliberate limit]
+
+- Activating a new membership judges age as of the activation instead, so someone
+  who has just turned 18 is caught on joining rather than read as a minor until
+  the next boundary comes round.  [Decision]
 
 - Under 18 is never checked, a minor being ineligible for one. This covers the
   young adult mentors, who volunteer without one.  [Decision — *Policy: Volunteer Policy, Art. IV*]
@@ -317,15 +326,20 @@ Procedure below is built on them.
 - A check covers the adult who took it. One person's clearance never satisfies
   another's.  [Decision]
 
-- An adult child carrying an obligation of their own — a background check or an
-  individual agreement — needs their own sign-in, and the lead supplies an email
-  address for them.  [Decision]
+- A background check for an adult child needs neither a sign-in of their own nor
+  an email address in the app. The board or a household lead records that an
+  external check exists and submits it for review, and consent is implicit in the
+  subject having gone and taken it. The applicant-facing consent attestation is a
+  household path and never this one.  [Decision]
 
 ### Individual agreement for adult children
 
 - An adult child of a household lead signs their own membership agreement rather
   than being covered by the household's. A spouse does not: a spouse stays on the
   household agreement.  [Decision]
+
+- Signing it needs a sign-in of their own, and the lead supplies an email address
+  for them.  [Decision]
 
 - It is signed again every membership year, as the household agreement is.
   [Decision — *Policy: Membership Policy, Art. III §III.1*]
@@ -373,27 +387,3 @@ Procedure below is built on them.
   program-attached surface reads it per person. A lead who never took a check
   reads there as covered rather than needed.
 
-- **A household that loses its only checked adult mid-year keeps its membership.**
-  Removing or demoting that person leaves the household active with youth still
-  enrolled, and nothing responds. Whether the answer is a block, a grace period,
-  or a warning is undecided.
-
-- **The sysadmin role decides membership matters policy reserves to the board,
-  and has no policy existence at all.** The policy corpus enumerates board
-  members, officers, Treehouse leaders, program leaders, tool certifiers,
-  keyholders, and shop stewards. There is no sysadmin. Yet someone holding only
-  that flag can override a blocked application, certify a payment plan, and
-  grant a membership outright — while policy requires reviewers to be board
-  members or authorised in writing by the board, and makes the remedy for a
-  contested check an independent three-person appeals committee.
-
-  Compounding it: a sysadmin who is not a board member can **grant board
-  membership**, including to themselves. They cannot remove a sitting board
-  member, board membership can never be revoked to zero, and every action is
-  audit-logged with a required reason — so the board keeps the power to revoke
-  the flag. But who sits on the board can be changed by someone the policy does
-  not recognise.
-
-  **This needs a board decision, not a code change chosen by whoever touches it
-  next.** Narrowing which surfaces accept the flag, or making it easier to
-  obtain, belongs to the board.

--- a/docs/rules/people-households.md
+++ b/docs/rules/people-households.md
@@ -148,13 +148,18 @@ Things the app takes as true because they are handled outside it.
 - Where someone signs in with Google, the address they sign in with is the
   address they are contacted at. There is no second one to diverge from it.  [Decision]
 
-- A person is never deleted. A merged record stays as a tombstone and drops out
-  of every list, count and roster rather than out of the database.  [Decision — *Principle: decisions are reversible*]
+- A person is never lost. A merged record is kept and marked as merged rather
+  than removed, and drops out of every live list, count and roster. A record of
+  what happened still names them, because hiding a since-merged identity there
+  would falsify the history rather than protect anyone.  [Decision — *Principle: decisions are reversible*]
 
 - A merge moves email, sign-in identity and verification together as one unit,
   never split across the two records.  [Decision]
 
-- A merged person's pre-merge state is recorded so the merge can be undone.  [Decision — *Principle: decisions are reversible*]
+- A merged person's pre-merge state is recorded, so a merge of the wrong two
+  people can be investigated and the person reconstructed. There is no un-merge:
+  what the record does not carry is which rows moved, so putting a bad merge right
+  is hand work, not a button.  [Decision — *Principle: decisions are reversible*]
 
 ### Who may see what
 
@@ -172,22 +177,31 @@ Things the app takes as true because they are handled outside it.
 - An emergency contact needs a name and a phone number. One missing either does
   not count toward the household's obligation to have one.  [Decision]
 
+- An emergency contact's relationship to the household is optional free text,
+  with no picklist of types.  [Decision — deliberate limit]
+
 - A household names at least one emergency contact at intake, and its last valid
   contact cannot be removed.  [Decision]
 
 - A household change that invalidates a contact flags the row and keeps it.
   Nothing is blocked; the household resolves it.  [Decision]
 
-- A missing emergency contact is the household's to fix, not board work.  [Decision]
+- A missing emergency contact is the household's to fix and the board's to chase.
+  It raises a list of the households to contact, a count in the board's
+  navigation, and a notification the front desk sees too. Nothing is blocked —
+  chasing it is a conversation, not a refusal at the door.  [Decision — *Principle: people decide about people*]
 
 ### Trusted adults
 
 - Trusted-adult approval belongs to the household, not to an individual member.  [Decision — *Policy: Event, Location and Keyholder Policy, Art. IX*]
 
-- The board reads the family's context note; keyholders and program leaders read
-  the board's operational note. Neither side sees the other's.  [Decision — *Policy: Ethics Policy, Art. IV*]
+- The family's context note is written for the board and read by the board and
+  the family, never by keyholders or program leaders. The board's note on its own
+  decision is the board's alone. What reaches the front desk is the shared note
+  below, and nothing else.  [Decision — *Policy: Ethics Policy, Art. IV*]
 
-- Relationships are free text, with no picklist of types.  [Decision — deliberate limit]
+- How a trusted adult is connected to the family is prose inside the context note
+  the family has to write. There is no separate relationship field.  [Decision — deliberate limit]
 
 - Amending a trusted adult's details does not disturb the live approval, and
   rejecting the amendment is a separate action from revoking the person.  [Decision]
@@ -198,8 +212,11 @@ Things the app takes as true because they are handled outside it.
 - An approval lasts a year. The family is warned a month out and resubmits
   without re-entering what the board already holds.  [Decision]
 
-- A withdrawn trusted adult can be hidden from the household's own view. The
-  record stays and the board still sees it; the household cannot bring it back.  [Decision]
+- A withdrawn trusted adult can be hidden from the household's own view, and the
+  household cannot bring it back. The record is kept, but no board surface lists
+  it either — the review queue holds what is awaiting action or expiring, and the
+  pickup list holds what is approved. A withdrawn one survives in the audit trail
+  rather than in anyone's view.  [Decision]
 
 - One board member settles a disclosure; it does not need the whole board.  [Decision]
 

--- a/docs/rules/principles.md
+++ b/docs/rules/principles.md
@@ -78,8 +78,10 @@ before, not an approximation of it.
 
   What is still open is where those lines sit, and whether capturing a whole
   record into the audit trail counts as capturing it or merely defers the same
-  dependency. Only people are kept today; enrollments and visits are removed with
-  the row written to the audit trail.
+  dependency. People and visits are kept today, each marked rather than removed,
+  and each with a filter every listing surface must pass through and a guard that
+  fails the build when a new one forgets. Enrollments are removed, with the row
+  written to the audit trail.
 
 The tell is a status that swallows its predecessor — a row that goes to ARCHIVED
 or MERGED with no record of what it was before. That is the moment to capture,
@@ -168,8 +170,10 @@ to do anything in it.
   inferred from what is left behind.
 
 - **A record that is no longer a person here holds nothing.** Merged away,
-  tombstoned, denied, revoked — such a record appears in no roster, no headcount,
-  no capacity calculation, and passes no gate.
+  denied, revoked, or kept only as a record of what was — such a record appears in
+  no roster, no headcount, no capacity calculation, and passes no gate. The rule governs live standing, not
+  the past: a record of what happened still names them, and what it never does is
+  admit them anywhere.
 
 The failure looks like a gate that tests the wrong thing: authorising on the
 presence of an id rather than on a right the caller currently holds. It survives

--- a/docs/rules/programs.md
+++ b/docs/rules/programs.md
@@ -103,6 +103,10 @@ Things the app takes as true because they are handled outside it.
 - A program leader is 23 or older, the floor belonging to the role rather than to
   adulthood. A program volunteer has no age floor at all — youth volunteer too.  [Decision — *Policy: Sponsored Program Policy, Art. IV*]
 
+- Nothing checks either the age floor or the requirement that a leader be a
+  member who has passed a background check: the leader pickers admit anyone 18 or
+  over.  [Short of policy — *Policy: Sponsored Program Policy, Art. IV*]
+
 - Nobody under 18 enrolls themselves. A youth is enrolled by their household lead.  [Decision]
 
 ### Enrollment
@@ -180,14 +184,24 @@ Things the app takes as true because they are handled outside it.
 
 - The grace period is a board setting. Unset means the feature is off.  [Decision — *Principle: fail closed*]
 
-- A request whose seat hold failed cannot be approved as though it held one.  [Decision]
+- A request whose seat hold failed waits for a board member to take the seat off
+  sale by hand. It can still be approved or denied without one, deliberately: the
+  queue offers each as a named override behind a confirmation that states the
+  oversell risk. A failed store call is the organisation's fault, and stranding
+  the family is the worse outcome.  [Decision — deliberate limit]
 
 ### Access to program information
 
 - A program's catalogue entry is public; its roster is visible only to the people
   running it — its leader, its core volunteers, the board and sysadmins — and to
-  people enrolled in it. The catalogue route is never gated: an anonymous caller
-  reaches it and the response is filtered instead.  [Decision — *Policy: Records Policy, Art. IV*]
+  people enrolled in it. The catalogue filters rather than gates: an anonymous
+  caller reaches it and sees less, and is never told that a members-only program
+  exists.  [Decision — *Policy: Records Policy, Art. IV*]
+
+- A members-only program's own page keeps that silence. An anonymous caller is
+  told there is no such program; a signed-in caller who is not a member is told it
+  exists and that it is members only. Signing in is what earns the reason for
+  being turned away.  [Decision — *Principle: no existence oracle*]
 
 - A program leader is defined by the program they lead, not by a role they hold.
   They reach the programs they lead and no others; the board and sysadmins reach
@@ -212,24 +226,3 @@ Things the app takes as true because they are handled outside it.
 
 - Cross-selling one program from another will not be built.  [Decision — deliberate limit]
 
----
-
-## Policy requirements not yet enforced here
-
-- **A program can be created with no dates at all.** Both start and end are
-  optional and nothing rejects either being absent. A start date should be
-  required, and an absent end should default to the end of the fiscal year
-  (30 June) rather than staying null.
-
-  Three rules quietly change meaning when they are missing. Age eligibility
-  falls back to the registration date, which is the thing that rule exists to
-  avoid. The catalogue reads a null end as running indefinitely. Member-pricing
-  coverage falls back to status alone.
-
-- **The program-leader minimum age of 23 is not checked**, nor is the
-  requirement that a leader be a member who has passed a check.
-
-- **The second-adult-volunteer requirement is not modelled** as a precondition of
-  scheduling a session.
-
-- **School enrollment for youth is not captured.**

--- a/docs/rules/tools-certification.md
+++ b/docs/rules/tools-certification.md
@@ -91,13 +91,3 @@ Things the app takes as true because they are handled outside it.
 - Certifying authority is per tool; a certifier's reach across the app is not.
   Holding the level on any tool opens the certification surfaces for all of them.  [Decision — deliberate limit]
 
----
-
-## Policy requirements not yet enforced here
-
-- **No age minimum is checked against a level.** Nothing stops a 9-year-old
-  being recorded as certified, or someone under 21 as a certifier.
-
-- **Tool category is not modelled**, so the split between hand, heat,
-  powered-motion, and high-hazard tools — and the different age floors and
-  supervision rules that follow from it — has no representation.


### PR DESCRIPTION
Sixteen of the twenty-two Class-A rows on #1528, plus the structural change that
stops the class recurring. Docs only, apart from one comment in `schema.prisma`
that repeated a false claim.

No closing keyword: six rows are still open on the issue.

## What was wrong

Class A means the register describes behaviour the code does not have. Three of
these were dangerous rather than merely stale — following them would have broken
something:

- **`programs.md` forbade a shipped repair surface.** "A request whose seat hold
  failed cannot be approved as though it held one" — it can, deliberately, behind
  a red modal naming the oversell risk. An engineer restoring that invariant by
  adding `inventoryHeldAt: { not: null }` to the CAS would have silently killed
  the surface. Now written as the carve-out it is.
- **`attendance-checkin.md` listed self-correction as unbuilt.** It shipped in
  #1357, and the entry sat in a "not yet enforced" list, which reads as a to-do.
  Closing it would have reverted a deliberate trust-first design.
- **`people-households.md` implied an un-merge exists.** "A merged person's
  pre-merge state is recorded so the merge can be undone." There is no un-merge
  route or UI, and the merge records the repointing as `moved` **tallies — counts,
  not row ids** — so nothing says which visits and join rows came across. Someone
  who merged the wrong two people would have gone looking for a button. The rule
  now says what the record is actually for.

## Three rows reverse the audit's own finding

Reading the code to fix the wording changed the verdict:

- **A20 — the audit called correct code a bug.** It read the grace-expiry cron as
  contradicting "removal for non-payment is a human decision". It does not:
  `cron/pending-participants` is the non-payment sweep and its header says it
  never removes anyone — "core customer service, and a computer isn't enough
  here." The original sentence was true; what was missing is the *denial* grace
  clock, which is the only automatic removal. Both rules now sit side by side.
- **A12, A14 — withdrawn**, see below.

## The appendices are gone

Four files ended with `## Policy requirements not yet enforced here`. A rule
stated in Procedure and contradicted a hundred lines later reads as true to
anyone who stops when they find their answer, and `DOCUMENTATION_STANDARD.md`
§3.2 already says the register runs three sections.

Twelve of thirteen entries deleted, three of four sections with them. §3.7's own
test sorted them: one had shipped, **four were never divergences** (the app
models nothing to qualify), three were real divergences handed to their issues,
two belong to work in flight, and three had no tracker at all — now #1550, #1551,
#1552.

**Every deletion left a handover comment first**, naming the register file and
section that gains rules when the work lands: #1433, #1436, #1437, #1438, #1439,
#1440, #1442, #1514, and PR #1470. None of those trackers knew the register
described their gap. Two of them are implementation PRs that would have fixed
behaviour and left the register asserting the old version.

`membership.md` keeps one entry, which PR #1470 has been asked to take.

## The standard changes with it

§3.7 now says a shortfall is stated **at the rule it qualifies, never in a list**,
and §3.6 gains `[Short of policy — *Policy: …*]` for it.

That tag and `[Decision — deliberate limit]` are the pair most easily confused
and they demand opposite actions — a deliberate limit must **not** be "fixed",
a shortfall must be. `programs.md` is the first use: the leader age floor read as
enforced and is not (#1433).

Also added to §3.7: the work that closes a divergence updates the rule in the
same change, and a deficiency written as an Assumption is the failure mode to
watch now that there is no section to collect gaps in.

## Reviewer notes

- **`schema.prisma`** is one doc comment on `TrustedAdult.hiddenAt`, which
  claimed "Board & sysadmin views still see it". No board view lists a withdrawn
  approval — the review queue selects pending/expired, the pickup list selects
  approved, and withdrawal sets every review to `REVOKED`. No `@sensitivity` line
  changed, and `classifications.ts` carries tiers only, so `prisma generate` is
  unaffected.
- **Verified against the code, not the audit.** Every claim above was checked at
  the route or service, which is how the three reversals surfaced.
- **Rebased past #1477**, which rewrote one of the same lines to bind *both* an
  adult child's obligations to a sign-in. Its agreement section is kept whole and
  its combined line split: the individual agreement needs a sign-in, the
  background check needs neither.