### PR TITLE
fix(programs): refuse enrollment into a priced-but-unsellable program

### DIFF
--- a/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPaymentPlansAPI.integration.test.ts
@@ -157,9 +157,12 @@ describe('Program payment-plan routes', () => {
         });
     }
 
+    // The cookie is inert except under CHECKIN_ENV=local, where the keyless-kiosk
+    // fallback in authenticateRequest hijacks any cookie-less request as `kiosk`.
     function requestReq(body: unknown) {
         return new Request(`http://localhost/api/programs/${programId}/request-payment-plan`, {
             method: 'POST',
+            headers: { cookie: 'session=test' },
             body: JSON.stringify(body),
         }) as unknown as import("next/server").NextRequest;
     }
@@ -685,6 +688,9 @@ describe('Program payment-plan routes', () => {
 
     describe('Composed: scholarship holds a capacity seat with no Shopify involvement', () => {
         it('enroll (PENDING) -> request plan -> board approves -> ACTIVE, seat held, no fetch fires', async () => {
+            // A priced program needs a variant (an unsellable one is refused at
+            // enrollment), and the hold's -1 goes through the local mock — so the
+            // whole journey still fires no Shopify HTTP call.
             const scholarshipProgram = await prisma.program.create({
                 data: {
                     name: `PP Scholarship Program ${TAG}`,
@@ -692,10 +698,13 @@ describe('Program payment-plan routes', () => {
                     maxParticipants: 1,
                     orgMemberPriceCents: 1000,
                     nonOrgMemberPriceCents: 1500,
+                    shopifyVariantId: `dev-mock-variant-scholarship-${TAG}`,
                 },
             });
 
             const fetchSpy = jest.spyOn(global, 'fetch');
+            const prevCheckinEnv = process.env.CHECKIN_ENV;
+            process.env.CHECKIN_ENV = 'local';
 
             try {
                 // 1. Participant enrolls — paid program, so lands PENDING and
@@ -704,6 +713,7 @@ describe('Program payment-plan routes', () => {
                 const enrollRes = await ParticipantsPost(
                     new Request(`http://localhost/api/programs/${scholarshipProgram.id}/participants`, {
                         method: 'POST',
+                        headers: { cookie: 'session=test' },
                         body: JSON.stringify({ participantId: selfId }),
                     }) as unknown as import('next/server').NextRequest,
                     { params: Promise.resolve({ id: String(scholarshipProgram.id) }) },
@@ -723,6 +733,7 @@ describe('Program payment-plan routes', () => {
                 const approveRes = await PlansPost(
                     new Request('http://localhost', {
                         method: 'POST',
+                        headers: { cookie: 'session=test' },
                         body: JSON.stringify({ programId: scholarshipProgram.id, participantId: selfId }),
                     }) as unknown as import('next/server').NextRequest,
                 );
@@ -740,6 +751,7 @@ describe('Program payment-plan routes', () => {
                 const secondRes = await ParticipantsPost(
                     new Request(`http://localhost/api/programs/${scholarshipProgram.id}/participants`, {
                         method: 'POST',
+                        headers: { cookie: 'session=test' },
                         body: JSON.stringify({ participantId: otherId }),
                     }) as unknown as import('next/server').NextRequest,
                     { params: Promise.resolve({ id: String(scholarshipProgram.id) }) },
@@ -748,6 +760,7 @@ describe('Program payment-plan routes', () => {
                 expect((await secondRes.json()).error).toMatch(/maximum capacity/);
             } finally {
                 fetchSpy.mockRestore();
+                process.env.CHECKIN_ENV = prevCheckinEnv;
                 await prisma.programParticipant.deleteMany({ where: { programId: scholarshipProgram.id } });
                 await prisma.program.delete({ where: { id: scholarshipProgram.id } });
             }

--- a/checkin-app/src/app/__tests__/programsEnrollCheckoutBroken.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsEnrollCheckoutBroken.integration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Guard: a priced program with no Shopify variant (isProgramCheckoutBroken)
+ * rejects any payment-bound enrollment on POST /api/programs/[id]/participants,
+ * because the seat would sit PENDING with nothing to pay through. An external
+ * admin's confirmed override is a comp (ACTIVE, no payment) and still goes in.
+ */
+import { POST as ENROLL } from '@/app/api/programs/[id]/participants/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/notifications', () => ({ sendNotification: jest.fn().mockResolvedValue(true) }));
+
+const TAG = 'enroll-checkout-broken-test';
+
+describe('Enroll into a priced-but-unsellable program is rejected', () => {
+    let userId: number;
+    let adminId: number;
+    let brokenProgramId: number;
+    let sellableProgramId: number;
+
+    async function cleanup() {
+        const progs = await prisma.program.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
+        const progIds = progs.map(p => p.id);
+        await prisma.programParticipant.deleteMany({ where: { programId: { in: progIds } } });
+        const members = await prisma.person.findMany({ where: { OR: [{ email: { contains: TAG } }, { programParticipants: { some: { programId: { in: progIds } } } }] }, select: { id: true, householdId: true } });
+        const hhIds = [...new Set(members.map(m => m.householdId).filter((x): x is number => x != null))];
+        await prisma.auditLog.deleteMany({ where: { actorId: { in: members.map(m => m.id) } } });
+        await prisma.emergencyContact.deleteMany({ where: { householdId: { in: hhIds } } });
+        await prisma.person.deleteMany({ where: { householdId: { in: hhIds } } });
+        await prisma.household.deleteMany({ where: { id: { in: hhIds } } });
+        await prisma.program.deleteMany({ where: { id: { in: progIds } } });
+    }
+
+    beforeAll(async () => {
+        await cleanup();
+        const user = await prisma.person.create({
+            data: { email: `user-${TAG}@example.com`, name: 'Self Enroller', isDeclaredAdult: true, household: { create: { name: `HH ${TAG}` } } },
+        });
+        userId = user.id;
+        const admin = await prisma.person.create({
+            data: { email: `admin-${TAG}@example.com`, name: 'Board Admin', isDeclaredAdult: true, isBoardMember: true, household: { create: { name: `Admin HH ${TAG}` } } },
+        });
+        adminId = admin.id;
+        const broken = await prisma.program.create({
+            data: { name: `Broken ${TAG}`, phase: 'RUNNING', enrollmentStatus: 'OPEN', nonOrgMemberPriceCents: 5000, shopifyVariantId: null },
+        });
+        brokenProgramId = broken.id;
+        const sellable = await prisma.program.create({
+            data: { name: `Sellable ${TAG}`, phase: 'RUNNING', enrollmentStatus: 'OPEN', nonOrgMemberPriceCents: 5000, shopifyVariantId: 'gid://shopify/ProductVariant/1' },
+        });
+        sellableProgramId = sellable.id;
+    });
+
+    afterAll(async () => {
+        await cleanup();
+        await prisma.$disconnect();
+    });
+
+    const params = (id: number) => ({ params: Promise.resolve({ id: id.toString() }) });
+
+    async function enroll(programId: number, actor: Record<string, unknown>, participantId: number, body: Record<string, unknown> = {}) {
+        (getServerSession as jest.Mock).mockResolvedValue({ user: actor });
+        const req = new Request(`http://localhost:4000/api/programs/${programId}/participants`, {
+            method: 'POST',
+            body: JSON.stringify({ participantId, ...body }),
+        });
+        return ENROLL(req as unknown as import('next/server').NextRequest, params(programId) as unknown as never);
+    }
+
+    it('self-enroll into a priced program with no variant → 400, no row', async () => {
+        const res = await enroll(brokenProgramId, { id: userId }, userId);
+        expect(res.status).toBe(400);
+        const data = await res.json();
+        expect(data.error).toMatch(/payment link/i);
+        expect(data.requiresOverride).toBeUndefined();
+        expect(await prisma.programParticipant.count({ where: { programId: brokenProgramId } })).toBe(0);
+    });
+
+    it('an admin comp (external, confirmed override) still enrolls ACTIVE', async () => {
+        const res = await enroll(brokenProgramId, { id: adminId, isBoardMember: true }, userId, { override: true });
+        expect(res.status).toBe(200);
+        const row = await prisma.programParticipant.findFirst({ where: { programId: brokenProgramId, personId: userId } });
+        expect(row?.status).toBe('ACTIVE');
+    });
+
+    it('a sellable priced program still enrolls PENDING', async () => {
+        const res = await enroll(sellableProgramId, { id: userId }, userId);
+        expect(res.status).toBe(200);
+        const row = await prisma.programParticipant.findFirst({ where: { programId: sellableProgramId, personId: userId } });
+        expect(row?.status).toBe('PENDING');
+    });
+});

--- a/checkin-app/src/app/__tests__/programsEnrollCheckoutBroken.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsEnrollCheckoutBroken.integration.test.ts
@@ -21,6 +21,7 @@ describe('Enroll into a priced-but-unsellable program is rejected', () => {
     let adminId: number;
     let brokenProgramId: number;
     let sellableProgramId: number;
+    let zeroPricedProgramId: number;
 
     async function cleanup() {
         const progs = await prisma.program.findMany({ where: { name: { contains: TAG } }, select: { id: true } });
@@ -53,6 +54,10 @@ describe('Enroll into a priced-but-unsellable program is rejected', () => {
             data: { name: `Sellable ${TAG}`, phase: 'RUNNING', enrollmentStatus: 'OPEN', nonOrgMemberPriceCents: 5000, shopifyVariantId: 'gid://shopify/ProductVariant/1' },
         });
         sellableProgramId = sellable.id;
+        const zeroPriced = await prisma.program.create({
+            data: { name: `Zero ${TAG}`, phase: 'RUNNING', enrollmentStatus: 'OPEN', orgMemberPriceCents: 0, nonOrgMemberPriceCents: 0, shopifyVariantId: null },
+        });
+        zeroPricedProgramId = zeroPriced.id;
     });
 
     afterAll(async () => {
@@ -84,6 +89,13 @@ describe('Enroll into a priced-but-unsellable program is rejected', () => {
         const res = await enroll(brokenProgramId, { id: adminId, isBoardMember: true }, userId, { override: true });
         expect(res.status).toBe(200);
         const row = await prisma.programParticipant.findFirst({ where: { programId: brokenProgramId, personId: userId } });
+        expect(row?.status).toBe('ACTIVE');
+    });
+
+    it('a zero-priced program is free: enrolls ACTIVE, never waits on a payment', async () => {
+        const res = await enroll(zeroPricedProgramId, { id: userId }, userId);
+        expect(res.status).toBe(200);
+        const row = await prisma.programParticipant.findFirst({ where: { programId: zeroPricedProgramId, personId: userId } });
         expect(row?.status).toBe('ACTIVE');
     });
 

--- a/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsParticipantsAPI.integration.test.ts
@@ -163,7 +163,9 @@ describe('Program Participants API Integration Tests', () => {
 
         // Create mock programs
         const standardProgram = await prisma.program.create({
-            data: { name: 'Standard Partic API Test', phase: 'RUNNING', enrollmentStatus: 'OPEN', leadMentorId: leadId, orgMemberPriceCents: 1000, nonOrgMemberPriceCents: 1500 }
+            // Priced programs carry a variant — a priced one without it is
+            // checkout-broken and the route now refuses payment-bound enrollment.
+            data: { name: 'Standard Partic API Test', phase: 'RUNNING', enrollmentStatus: 'OPEN', leadMentorId: leadId, orgMemberPriceCents: 1000, nonOrgMemberPriceCents: 1500, shopifyVariantId: 'dev-mock-variant-standard-partic' }
         });
         standardProgramId = standardProgram.id;
 

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -146,7 +146,10 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
             }
         }
 
-        const isFree = currentProgram.orgMemberPriceCents === null && currentProgram.nonOrgMemberPriceCents === null;
+        // Zero is free, same as unpriced: variants are minted only above zero
+        // (api/programs POST), so a zero-priced program has nothing to charge
+        // through and must not wait on a payment.
+        const isFree = (currentProgram.orgMemberPriceCents ?? 0) === 0 && (currentProgram.nonOrgMemberPriceCents ?? 0) === 0;
         
         // PENDING (awaits payment) unless the program is free or an external
         // admin is comping it. A board parent overriding a soft limit for their

--- a/checkin-app/src/app/api/programs/[id]/participants/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/participants/route.ts
@@ -7,6 +7,7 @@ import { lockProgramAndCheckCapacity, ProgramCapacityError, withdrawAndReleaseHo
 import { checkProgramAge, isKnownAdult } from "@/lib/programAge";
 import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 import { isDuesSettled } from "@/lib/orgMembership";
+import { isProgramCheckoutBroken } from "@/lib/programCheckout";
 import { adjustProgramInventory } from "@/lib/shopify";
 import { apiError } from "@/lib/api-response";
 
@@ -151,6 +152,17 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         // admin is comping it. A board parent overriding a soft limit for their
         // own household still pays — the override bypasses limits, not the fee.
         const initialStatus = ((isExternalAdmin && override) || isFree) ? 'ACTIVE' : 'PENDING';
+
+        // Fail closed on a priced-but-unsellable program: PENDING means "awaits a
+        // Shopify payment", and a priced program with no variant has nothing to
+        // pay through — the seat would sit PENDING forever. Keyed off the status,
+        // not the actor, so an admin comp (ACTIVE, skips payment entirely) still
+        // goes through while every payment-bound enrollment — including a
+        // conflicted admin's override, which still owes the fee — is refused.
+        // No requiresOverride: an override cannot make the program sellable.
+        if (initialStatus === 'PENDING' && isProgramCheckoutBroken(currentProgram)) {
+            return apiError("This program has a price but no payment link set up, so enrollment can't be paid for. An admin must fix the Shopify link in program-ops before anyone can enroll.", 400);
+        }
 
         const enrollment = await prisma.$transaction(async (tx) => {
             // Re-check capacity under a row lock right before insert, so

--- a/docs/rules/programs.md
+++ b/docs/rules/programs.md
@@ -140,7 +140,15 @@ Things the app takes as true because they are handled outside it.
 - A failed discount degrades to undiscounted checkout, never an error.  [Decision — deliberate limit]
 
 - A program priced on a tier with nothing wired to sell it is broken and is
-  reported as such. A free tier has nothing to wire and is never reported.  [Decision]
+  reported as such. A free tier has nothing to wire and is never reported, and a
+  tier priced at zero is free — it is never sold, never reported, and never waits
+  on a payment.  [Decision]
+
+- Such a program takes no enrollment that would have to be paid for. The place is
+  refused outright rather than admitted and left waiting on a payment that can
+  never arrive. An administrator's comped place never reaches the store and is
+  seated as normal; nobody else's confirmation makes the program sellable, so
+  none is offered.  [Decision — *Principle: fail closed*]
 
 > **Candidate, not settled — for owner ratification.** Member pricing requires
 > the membership to cover the program's end date, not merely be active today; a


### PR DESCRIPTION
Fixes #1435 (backlog P32).

## What was wrong

A program priced on a tier with no Shopify variant has nothing to pay through. The enrollment was admitted anyway, landed `PENDING`, and stayed there forever — the parent can never reach checkout, so the `orders/paid` webhook never fires. The app already *detected* the state (`isProgramCheckoutBroken` drives the program-ops badge and the nav todo count) but the write path still let the enrolment through.

## What changed

`POST /api/programs/[id]/participants` now fails closed, keyed off the **computed initial status** rather than the actor:

```ts
if (initialStatus === 'PENDING' && isProgramCheckoutBroken(currentProgram)) {
    return apiError("This program has a price but no payment link set up, ...", 400);
}
```

This settles the one term the issue left open — whether a non-conflicted sysadmin/board add may override the reject:

- **External admin comp** (board/sysadmin, outside their own household, confirmed `override`) is `ACTIVE` and skips payment entirely, so it strands nothing and still goes through.
- **Every payment-bound enrollment** is refused — self-enroll, household lead, and a *conflicted* admin's override, which bypasses soft limits but still owes the fee.

The response deliberately carries **no `requiresOverride`**: no override can make the program sellable, so surfacing the sibling guards' confirm button would be a dead end. The fix is wiring the variant (program-ops → Sync Shopify).

Distinct from #1241 (P13, deliberately manual-only programs): the predicate keys off a *priced* tier, never off a missing variant alone, so a free program with no variant is untouched.

## A zero-priced tier is free

The first pass left a second way to strand: `isFree` required both tiers `null`, so a program priced `0`/`0` was neither free nor payable and landed `PENDING` on a checkout that cannot exist. The enroll route held the only null-only reading of "free" in the codebase — variants are minted only above zero (`api/programs` POST), `isProgramCheckoutBroken` keys off a tier above zero, and the client's paid-path check is a truthiness test that never redirects for zero. Zero now reads as free there too, and the seat activates immediately.

## Docs

`docs/rules/programs.md` described the pre-fix behaviour — an unsellable program is *reported*, with nothing on what enrollment does about it. The pricing rules now state the refusal, the comp carve-out, the absence of any confirmation path (none can make the program sellable), and that a tier priced at zero is free.

## Blast radius

`programParticipant.create` has exactly one production call site — this route. (`src/lib/dev/seed-helpers.ts` is the dev seed.) The public enroll page already refused a missing-variant checkout client-side; this makes the server the authority.

## Test fixture fallout

Two existing suites priced a program with **no** variant and expected `PENDING` — a state that is now refused. Both fixtures now carry a variant, and the composed scholarship journey runs its hold under the local Shopify mock (`CHECKIN_ENV=local` + a `dev-mock-variant-*` id + the keyless-kiosk cookie the fallback needs), so it still asserts that zero Shopify HTTP calls fire.

## Verification

- New: `src/app/__tests__/programsEnrollCheckoutBroken.integration.test.ts` — reject + no row written, admin comp still `ACTIVE`, zero-priced program `ACTIVE`, sellable priced program still `PENDING`.
- Full integration suite: 1359 passed. Full unit suite: 2565 passed. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)