### PR TITLE
docs(rules): extract "reachability is not permission" from the Index page design

### DIFF
--- a/docs/rules/principles.md
+++ b/docs/rules/principles.md
@@ -182,6 +182,26 @@ people it should.
 
 ---
 
+## Reachability is not permission
+
+Distinct from *identity is not authorisation*, which asks what a surviving
+record grants. This asks about arrival: how someone reached a surface says
+nothing about whether they may use it.
+
+- **A listing grants nothing.** A directory, index, search result or navigation
+  menu shows only what the viewer's existing gates already admit them to; it
+  never widens one, and it is not where the decision is made.
+
+- **A destination never trusts its entry point.** Every surface enforces its own
+  gate on arrival, whatever linked to it. A link that should not have been shown
+  is a cosmetic defect; a page that admits whoever followed it is not.
+
+The failure is a gate deleted as redundant, because the menu already hides the
+page so the page stops checking. It tests clean, since in testing the only way
+anyone reaches the page is through the menu that filters it.
+
+---
+
 ## People decide about people
 
 - **Automation classifies, warns, and escalates. It does not act on a person.**


### PR DESCRIPTION
Distils `docs/designs/INDEX_PAGE_SCOPING.md` under `docs/DOCUMENTATION_STANDARD.md`. One principle came out; the design doc stays in place, for the reason below.

## What changed

`docs/rules/principles.md` gains **"Reachability is not permission"**, placed after *Identity is not authorisation* and opening with the distinction from it: that one asks what a surviving record grants, this one asks about arrival.

- A listing grants nothing. A directory, index, search result or navigation menu shows only what the viewer's existing gates already admit them to; it never widens one, and it is not where the decision is made.
- A destination never trusts its entry point. Every surface enforces its own gate on arrival, whatever linked to it.

It passes §3.9 and §3.3. A change can violate it, and the change is easy to picture: a layout gate deleted as redundant because the nav already hides the page. It is cross-cutting, covering the nav, the Index, deep links, emailed links and the deferred command palette. No policy names it, and nothing already in the file states it; *least privilege* sets how wide a grant is, and *identity is not authorisation* covers surviving identifiers.

## Verified in code before extracting

- `checkin-app/src/app/index/page.tsx` renders `PAGES.filter((p) => p.visible(...))` and has no unfiltered path.
- Every listed section re-enforces its own gate on arrival: `useRequireRole` in seven section layouts, `shopRoles().isCertifier` in shop-ops, `leadsAnyProgram(counts)` in my-programs, and its own layout gate in program-ops.
- The drift guard fires. I replicated `pageRegistry.test.ts`'s `routeOf`/`findPages` against the tree, since this worktree has no `node_modules`. Baseline is 80 routes with `missing: []` and `stale: []`; adding an unregistered `page.tsx` produces `missing: ["/zzz-drift-probe"]`, which fails `expect(missing).toEqual([])`. The probe was removed.

Delivered by PR #512, merge commit `0039c43b`, which introduced all four files in one commit.

## What was cut

Everything else in the design doc is mechanism a reader derives from the code: the registry, the section-predicate mapping, the nav placement, and the deferred palette, `NAV_ITEMS` derivation and detail-page listing.

The drift guard was cut too, and so was a `docs/conventions.md` line for the obligation it enforces. That file already carries *"An invariant everyone must remember is not an invariant"*, whose second bullet names this exact arrangement as a smell: a filter every caller must remember, a guard that hunts for the ones who forgot, and a list of justified exceptions are one smell, not three. `PAGES` plus `pageRegistry.test.ts` plus `REGISTRY_EXCLUDED` is that arrangement. Writing "a new page must be registered" as a convention would endorse what an existing convention says to move into the data.

## Why the design doc is not deleted

The doc's other decision, "this is the single source of truth the registry must read, not fork", did not ship. `pageRegistry.ts` declares its own predicates rather than reading the section gates, and only `leadsAnyProgram` is shared; `shopRoles()` is exported from `src/lib/shopNav.ts` and reimplemented inline. The two copies have already diverged, and one divergence hides a page from someone who can reach it: a background-check reviewer sees no Membership Ops rows, including `/membership-ops/review`, which is exactly where the nav's `hrefFor` sends them.

That is #1569, filed and on project 1. No new rule was written for it, because `docs/conventions.md` already rules it out under *"The server decides, the client mirrors"*: the two are written against one source so they cannot drift.

## For the reviewer

`checkin-app/src/components/pageRegistry.ts` still points at the design doc in its header comment, which stays correct while the doc does.

`docs/in-design/DOCUMENTATION_MIGRATION.md` lists `INDEX_PAGE_SCOPING.md` among the files it deletes. That entry now disagrees with this PR, and the migration should leave the doc alone until #1569 closes.

The doc itself is left unedited, so one sentence in it now overstates what shipped: its "Reuse the section gates; never re-implement them" section reads as delivered, and only the section-granularity half was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
