### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix stack trace exposure in database logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Found early returns checking buffer lengths (e.g., `providedBuffer.length !== expectedBuffer.length`) on webhook secrets and cron auth tokens before using `crypto.timingSafeEqual`.
 **Learning:** Returning early on length mismatch leaks the exact length of the expected secret.
 **Prevention:** Hash both the expected and provided secrets to a fixed length (e.g., using SHA-256) before passing them to `crypto.timingSafeEqual` to avoid leaking secret lengths while still safely catching any mismatch.
+
+## 2024-05-24 - Stack Trace Exposure in Database Logs
+**Vulnerability:** Raw error stack traces were being persisted to the `ErrorLog` table in the database, which feeds into administrative dashboards.
+**Learning:** Persisting raw error stack traces in database tables that feed application dashboards violates defense-in-depth principles, potentially exposing internal server information (like directory structures and dependency versions).
+**Prevention:** Never persist raw error stack traces in database tables accessed by application dashboards. Stack traces should only be sent to secure, centralized logging infrastructure (e.g., standard output for aggregation).

--- a/checkin-app/src/lib/__tests__/logger.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/logger.integration.test.ts
@@ -62,8 +62,13 @@ describe('logger DB persistence + TTL purge', () => {
             data: { message: 'recent', route: `${TAG}-recent`, timestamp: new Date(now - 5 * DAY) },
         });
 
+        // Mock console.error to prevent jest-fail-on-console from failing the test
+        // since logBackendError now calls console.error explicitly.
+        const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
         // logBackendError writes the new row, then runs the 30-day purge.
         await logBackendError(new Error('trigger'), `${TAG}-trigger`);
+        mockConsoleError.mockRestore();
 
         expect(await prisma.errorLog.findUnique({ where: { id: old.id } })).toBeNull();
         expect(await prisma.errorLog.findUnique({ where: { id: recent.id } })).not.toBeNull();

--- a/checkin-app/src/lib/logger.ts
+++ b/checkin-app/src/lib/logger.ts
@@ -16,14 +16,15 @@ export const logger = {
 export async function logBackendError(error: unknown, route?: string, context?: unknown) {
     try {
         const message = error instanceof Error ? error.message : String(error);
-        const stack = error instanceof Error ? error.stack : undefined;
+
+        // Log stack trace to central console securely, do not persist to DB where dashboards can see it.
+        console.error(`[BackendError] route: ${route || 'unknown'} | msg: ${message}\n`, error instanceof Error ? error.stack : error);
 
         // 1. Insert the new error log
         await prisma.errorLog.create({
             data: {
                 message,
                 route,
-                stack,
                 context: context ? JSON.parse(JSON.stringify(context)) : undefined, // Ensure it's JSON serializable
             }
         });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw error stack traces were being persisted to the `ErrorLog` database table, which feeds administrative dashboards.
🎯 Impact: Potential exposure of internal server information (directory structures, dependency versions) to users with dashboard access, violating defense-in-depth principles.
🔧 Fix: Removed stack trace persistence from `logBackendError` and instead log it to standard error for secure centralized aggregation.
✅ Verification: Verified that `logBackendError` no longer writes the `stack` field to the database.

---
*PR created automatically by Jules for task [9900129378056148480](https://jules.google.com/task/9900129378056148480) started by @dkaygithub*