### PR TITLE
fix(membership-ops): name the reviewer's act, not its consequence

### DIFF
--- a/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
@@ -83,7 +83,7 @@ describe("membership-ops/review page", () => {
     expect(await screen.findByText("Clear this background check?")).toBeInTheDocument();
     expect(screen.getByText(/emails the family/)).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledTimes(1); // the queue GET only — nothing posted yet
-    fireEvent.click(screen.getByRole("button", { name: "Clear the check" }));
+    fireEvent.click(screen.getByRole("button", { name: "Attest the check is clean" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(

--- a/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
@@ -80,7 +80,7 @@ describe("membership-ops/review page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Attest — check is clean" }));
     // Pat already holds one approval, so naming Pat is the SECOND — the confirm names
     // the consequence of a clearing approve rather than a generic "are you sure?".
-    expect(await screen.findByText("Clear this background check?")).toBeInTheDocument();
+    expect(await screen.findByText("Attest this background check is clean?")).toBeInTheDocument();
     expect(screen.getByText(/emails the family/)).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledTimes(1); // the queue GET only — nothing posted yet
     fireEvent.click(screen.getByRole("button", { name: "Attest the check is clean" }));
@@ -106,7 +106,7 @@ describe("membership-ops/review page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Attest — check is clean" }));
     fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
 
-    await waitFor(() => expect(screen.queryByText("Clear this background check?")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText("Attest this background check is clean?")).not.toBeInTheDocument());
     expect(fetchMock).toHaveBeenCalledTimes(1); // the queue GET only
   });
 

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -135,7 +135,7 @@ export default function MembershipReviewPage() {
     // by then, so an existing attestation is enough to know this click is the last one.
     const clearing = result === "APPROVE" && item._count.attestations >= 1;
     modals.openConfirmModal({
-      title: result === "REJECT" ? "Reject this background check?" : clearing ? "Clear this background check?" : "Record your approval?",
+      title: result === "REJECT" ? "Reject this background check?" : clearing ? "Attest this background check is clean?" : "Record your approval?",
       children: (
         <Text size="sm">
           {result === "REJECT" ? (
@@ -145,8 +145,8 @@ export default function MembershipReviewPage() {
             </>
           ) : clearing ? (
             <>
-              You are the second reviewer for <strong>{who}</strong>. This clears the background
-              check, records it against {item.subjectPerson ? "the subject" : leadName(item, chosenSubject(item)!)},
+              You are the second reviewer for <strong>{who}</strong>. Attesting the check is clean
+              records that against {item.subjectPerson ? "the subject" : leadName(item, chosenSubject(item)!)},
               opens payment (or activates the membership if dues are already paid), and emails the
               family. It cannot be undone.
             </>
@@ -154,7 +154,7 @@ export default function MembershipReviewPage() {
             <>
               This records your approval of <strong>{who}</strong>&apos;s background check
               {item.subjectPerson ? "" : ` for ${leadName(item, chosenSubject(item)!)}`}. A second
-              reviewer must also approve the same person before the check clears.
+              reviewer must also approve the same person before the check is attested clean.
             </>
           )}
         </Text>

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -159,7 +159,7 @@ export default function MembershipReviewPage() {
           )}
         </Text>
       ),
-      labels: { confirm: result === "REJECT" ? "Reject" : clearing ? "Clear the check" : "Approve", cancel: "Cancel" },
+      labels: { confirm: result === "REJECT" ? "Reject" : clearing ? "Attest the check is clean" : "Approve", cancel: "Cancel" },
       confirmProps: { color: result === "REJECT" ? "red" : clearing ? "orange" : undefined },
       onConfirm: () => submit(item.id, result),
     });


### PR DESCRIPTION
The second reviewer's background-check approval modal used **"clear"** throughout, and that word reads two ways: *attest the check came back clean*, or *remove the check from the record*. This modal sits beside "Reject", on an action it says cannot be undone. The wrong reading was available at exactly the wrong moment.

All three user-visible strings now say the same thing in the same words:

| | Before | After |
|---|---|---|
| Title | Clear this background check? | Attest this background check is clean? |
| Body | This clears the background check, records it against… | Attesting the check is clean records that against… |
| Button | Clear the check | Attest the check is clean |

Plus the first-reviewer copy, which ended "…before the check clears" → "…before the check is attested clean."

The title and the body's opening clause matter more than the button did: the title names the action before any consequence is described, and the first clause of the body is the one that sticks. The consequence list — payment opening, the family being emailed, the irreversibility — is unchanged.

"Attest" is also the domain's own verb rather than a softer synonym for it. This is a two-reviewer attestation model: `BackgroundCheckAttestation`, two APPROVEs recorded against a named subject. The copy now matches what the system records.

Behaviour is unchanged; only strings move. The three test assertions that drive the modal by title and button name move with them.

**Verified:** `jest src/app/membership-ops/review` 9/9, lint clean, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier