### PR TITLE
fix(trusted-adult): notify the family when an approval expires

### DIFF
--- a/checkin-app/jest.setup.js
+++ b/checkin-app/jest.setup.js
@@ -195,6 +195,7 @@ const KNOWN_INTENTIONAL = [
   /^Zoho webhook received but ZOHO_WEBHOOK_SECRET is not configured\./,
   /^Zoho status sync failed for process/,
   /^Shopify webhook signature mismatch\./,
+  /^Family trusted-adult ping failed:/,    // trusted-adult sweep: send fails, expiry still stands
   /^Failed to check out visit/,            // cron nightly per-visit failure injection
   /^Error in pass \d+ for row/,            // finance reconcile bad-row negative path
 ];

--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -326,12 +326,56 @@ describe('Trusted Adults service', () => {
         expect(again!.expiryWarningSentAt).not.toBeNull();
 
         await prisma.trustedAdultReview.update({ where: { id: r.id }, data: { reviewBy: new Date(Date.now() - 86400000) } });
+        sendEmail.mockClear();
         const expireRun = await runExpirySweep(new Date());
         expect(expireRun.expired).toBeGreaterThanOrEqual(1);
         const expired = await prisma.trustedAdultReview.findUnique({ where: { id: r.id } });
         expect(expired!.status).toBe('EXPIRED');
 
+        // Expiring drops the adult off the pickup list, so the family hears about it that
+        // day — not only from the warning a month earlier.
+        expect(sendEmail).toHaveBeenCalledWith(
+            `lead-${TAG}@ex.com`,
+            'Trusted adult approval expired: Jane External',
+            expect.stringContaining('no longer authorized at the front desk'),
+        );
+
         // The system, not a person, drives the nightly expiry transition.
+        const audit = await latestAudit(ta.id);
+        expect(audit?.actorId).toBe(0); // SYSTEM_ACTOR
+        expect(normalizeAuditData(audit?.newData)).toMatchObject({ status: 'EXPIRED' });
+
+        // The flip is its own dedup: an EXPIRED review is no longer selectable, so the
+        // next night's run neither re-expires nor re-notifies.
+        sendEmail.mockClear();
+        const rerun = await runExpirySweep(new Date());
+        expect(rerun.expired).toBe(0);
+        expect(sendEmail).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining('expired'), expect.anything());
+    });
+
+    it('a failed expiry email still leaves the review EXPIRED and audited', async () => {
+        const ta = await discloseOne();
+        const r = await decideReview(ta.reviews[0].id, boardId, { decision: 'APPROVE', sharedNote: SHARED });
+        await prisma.trustedAdultReview.update({ where: { id: r.id }, data: { reviewBy: new Date(Date.now() - 86400000) } });
+
+        sendEmail.mockRejectedValueOnce(new Error('smtp down'));
+        try {
+            const run = await runExpirySweep(new Date());
+            expect(run.expired).toBeGreaterThanOrEqual(1);
+            // The rejected send is the expiry notice itself, not some other email.
+            expect(sendEmail).toHaveBeenCalledWith(
+                `lead-${TAG}@ex.com`,
+                'Trusted adult approval expired: Jane External',
+                expect.any(String),
+            );
+        } finally {
+            // mockReset, not mockResolvedValue: an unconsumed ...Once rejection would
+            // otherwise leak into the next test.
+            sendEmail.mockReset();
+            sendEmail.mockResolvedValue(true);
+        }
+
+        expect((await prisma.trustedAdultReview.findUnique({ where: { id: r.id } }))!.status).toBe('EXPIRED');
         const audit = await latestAudit(ta.id);
         expect(audit?.actorId).toBe(0); // SYSTEM_ACTOR
         expect(normalizeAuditData(audit?.newData)).toMatchObject({ status: 'EXPIRED' });
@@ -621,7 +665,9 @@ describe('runExpirySweep edge cases', () => {
         const run = await runExpirySweep(now);
         expect(run.warned).toBe(0); // boundary row expires, it does not get a fresh warning
         expect(run.expired).toBe(2);
-        expect(sendEmail).not.toHaveBeenCalled();
+        // Each expiry emails the family; neither row gets the 30-days-out warning.
+        expect(sendEmail).toHaveBeenCalledTimes(2);
+        expect(sendEmail).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining('expiring'), expect.anything());
 
         for (const r of [atNow, past]) {
             const after = await prisma.trustedAdultReview.findUnique({ where: { id: r.id } });

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -527,7 +527,8 @@ export async function overrideReview(
 /**
  * Nightly sweep: (1) warn the household 30 days before an approval lapses, once;
  * (2) expire approvals whose reviewBy has passed so they re-enter the board queue
- * via a renewal.
+ * via a renewal, and tell the family — expiring drops the adult off the front
+ * desk's pickup list, so silence would surface as a refused pickup.
  */
 export async function runExpirySweep(now: Date) {
     const warnThreshold = daysFromNow(now, WARN_LEAD_DAYS);
@@ -550,7 +551,7 @@ export async function runExpirySweep(now: Date) {
 
     const lapsed = await prisma.trustedAdultReview.findMany({
         where: { status: "APPROVED", reviewBy: { not: null, lte: now } },
-        select: { id: true, trustedAdultId: true, status: true },
+        select: { id: true, trustedAdultId: true, status: true, householdId: true, trustedAdult: { select: { trustedAdultName: true } } },
     });
     let expired = 0;
     for (const r of lapsed) {
@@ -559,6 +560,15 @@ export async function runExpirySweep(now: Date) {
             await audit(tx, systemActor("cron:trusted-adult-expiry"), r.trustedAdultId, { status: r.status }, { status: "EXPIRED" });
         });
         expired++;
+        // Notify only after the flip commits: the status change is the authoritative act,
+        // the email a courtesy on top, so a slow or failing provider can't hold the tx.
+        // The flip is its own dedup — an EXPIRED row is no longer selected by this query.
+        const name = r.trustedAdult.trustedAdultName?.trim() || "your trusted adult";
+        await notifyHouseholdFamily(
+            r.householdId,
+            `Trusted adult approval expired: ${name}`,
+            `The board's approval of ${name} has expired. They are no longer authorized at the front desk. You can resubmit them for board review in one click — no need to re-enter anything.`,
+        );
     }
 
     return { warned, expired };


### PR DESCRIPTION
Addresses the notification half of finding **B14** from the Class-B domain-register audit (#1529), "Cron withdraws live pickup authority".

## The gap

`runExpirySweep` in `checkin-app/src/lib/trusted-adult/service.ts` has two loops. The warn loop emails a household 30 days before a board-approved trusted adult lapses, once, guarded by `expiryWarningSentAt`. The expire loop flips the review to `EXPIRED`, writes an audit row, and notifies nobody.

That flip is not administrative. `/api/trusted-adults/operational` — the front-desk pickup list — selects on `reviews: { some: { status: "APPROVED" } }`, so an expired review drops the adult off the list and pickup authority ends at that moment. The family's last word on the subject was an email a month earlier. The next thing they learned was a refused pickup at the desk.

## What changed

The expire loop now emails the household leads, naming the adult:

> **Trusted adult approval expired: {name}**
>
> The board's approval of {name} has expired. They are no longer authorized at the front desk. You can resubmit them for board review in one click — no need to re-enter anything.

The copy lands on the same "no longer authorized at the front desk" phrasing as the existing deny and revoke messages, and the one-click resubmit it promises is real (`/api/trusted-adults/[id]/resubmit`). It names the adult because the deny/revoke messages do and a household may have several.

## Notes for a reviewer

- **The send is after the commit, not inside it.** The status flip is the authoritative act; the notice is a courtesy on top. A slow or failing mail provider must not hold the transaction open or roll the flip back.
- **A failed send needed no new handling.** `emailHouseholdLeads` already catches and logs, and `sendEmail` never rejects — failures resolve `false` and are persisted via `logIntegrationError`. Because the flip has already committed, a failure cannot undo it. The one thing that did need adding: that swallowed log now trips `jest-fail-on-console`, so its fixed prefix is on the `KNOWN_INTENTIONAL` allowlist.
- **No dedup column, and that is a reading rather than an omission.** The warn loop needs `expiryWarningSentAt` because an `APPROVED` row stays selectable night after night. The expire query selects `status: "APPROVED"`, so the flip itself makes the row unselectable on the next run. Covered by a test that runs the sweep twice.
- **Two adults lapsing the same night produce two emails.** Each names its own adult, so batching would lose the thing that makes the message useful.
- **The policy question is deliberately untouched.** Whether an administrative review deadline should revoke a safety authority at all, or merely flag it, is a board decision; patching it either way would silently pick a side. Which reviews expire, and when, is unchanged — this adds a message and nothing else.
- No schema change. Nothing under `checkin-app/src/security/` was touched.

## Tests

Three integration tests in `trustedAdultService.integration.test.ts`, all of which fail without the service change:

1. A review whose `reviewBy` has passed expires **and** notifies its household — and a second sweep neither re-expires nor re-notifies.
2. A rejecting send leaves the review `EXPIRED` and audited, with the rejected call asserted to be the expiry notice itself.
3. `expires at the boundary` previously asserted `expect(sendEmail).not.toHaveBeenCalled()` after two rows expired — **it had pinned the gap in place.** It now asserts two expiry notices and no warning email, which is what it was trying to prove.

```
npm run test:integration -- --testPathPatterns "trustedAdultService"
  with the fix:              28 passed, 28 total
  with service.ts stashed:   3 failed, 25 passed
npm run test:ci              272 suites, 2621 passed
tsc --noEmit                 clean
```

The full unit suite was run because `jest.setup.js` is shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
