### PR TITLE
fix(audit): record the nightly DoB purge without recording the date (B15, #1529)

### DIFF
--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -333,10 +333,10 @@ describe('Cron Nightly API Integration Tests', () => {
             });
             expect(purgeRows.length).toBeGreaterThanOrEqual(1);
             for (const r of purgeRows) {
-                const { timestamp: _timestamp, ...rest } = r;
-                expect(JSON.stringify(rest)).not.toContain(String(dob.getTime()));
-                expect(JSON.stringify(rest)).not.toContain(dob.toISOString());
-                expect(JSON.stringify(rest)).not.toContain(dob.toISOString().slice(0, 10));
+                const serialized = JSON.stringify({ ...r, timestamp: undefined });
+                expect(serialized).not.toContain(String(dob.getTime()));
+                expect(serialized).not.toContain(dob.toISOString());
+                expect(serialized).not.toContain(dob.toISOString().slice(0, 10));
 
                 // Anything date-shaped, in any format, anywhere a value can be
                 // carried. Scoped to the free-form columns because the numeric

--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -291,5 +291,65 @@ describe('Cron Nightly API Integration Tests', () => {
             expect(closed?.departedAt).toEqual(new Date(arrivedAt.getTime() + MAX_VISIT_MS));
             expect(closed?.departedVia).toBe('AUTO_CLOSE');
         });
+
+        it('audits the DoB purge per person, attributed to cron:nightly, without recording the date', async () => {
+            await closeAllOpenVisits();
+            await prisma.auditLog.deleteMany();
+            mockBadVisitIds.clear();
+
+            const dob = new Date(Date.UTC(1990, 3, 17));
+            const agedOut = await prisma.person.create({
+                data: {
+                    email: 'agedout-nightly@example.com',
+                    name: 'Aged Out',
+                    dateOfBirth: dob,
+                    household: { create: { name: 'Test HH' } }
+                }
+            });
+
+            const res = await GET(cronReq());
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            expect(data.adultDobPurged).toBeGreaterThanOrEqual(1);
+
+            const purged = await prisma.person.findUnique({ where: { id: agedOut.id } });
+            expect(purged?.dateOfBirth).toBeNull();
+            expect(purged?.isDeclaredAdult).toBe(true);
+
+            const row = await prisma.auditLog.findFirst({
+                where: { tableName: 'Person', affectedEntityId: agedOut.id, action: 'DELETE' }
+            });
+            expect(row).not.toBeNull();
+            expect(row?.actorId).toBe(0);
+            expect(row?.actorSystem).toBe('cron:nightly');
+
+            // The purge exists to destroy the date; a row that carries it out
+            // has re-stored it. Scan every field the purge wrote, not just the
+            // one we expect the date to hide in, so a later `context` blob or a
+            // pre-image in `oldData` fails here too. `timestamp` is excluded —
+            // it is the audit's own clock, not anybody's date of birth.
+            const purgeRows = await prisma.auditLog.findMany({
+                where: { tableName: 'Person', actorSystem: 'cron:nightly', action: 'DELETE' }
+            });
+            expect(purgeRows.length).toBeGreaterThanOrEqual(1);
+            for (const r of purgeRows) {
+                const { timestamp: _timestamp, ...rest } = r;
+                expect(JSON.stringify(rest)).not.toContain(String(dob.getTime()));
+                expect(JSON.stringify(rest)).not.toContain(dob.toISOString());
+                expect(JSON.stringify(rest)).not.toContain(dob.toISOString().slice(0, 10));
+
+                // Anything date-shaped, in any format, anywhere a value can be
+                // carried. Scoped to the free-form columns because the numeric
+                // id columns are autoincrement and can hit a year by accident.
+                const payload = JSON.stringify({
+                    actorSystem: r.actorSystem,
+                    tableName: r.tableName,
+                    oldData: r.oldData,
+                    newData: r.newData
+                });
+                expect(payload).not.toMatch(/\b(?:19|20)\d{2}\b/);
+                expect(payload).not.toMatch(/dateOfBirth"\s*:\s*(?!null)[^,}]/);
+            }
+        });
     });
 });

--- a/checkin-app/src/app/api/cron/nightly/route.ts
+++ b/checkin-app/src/app/api/cron/nightly/route.ts
@@ -83,12 +83,26 @@ export const GET = withCron(async () => {
         // declared-adult flag so age gates / search / UI still see them as an adult.
         // The #1165 backfill migration did the one-time sweep; this keeps it clean as
         // members age in. Raw SQL so age is judged in the DB, tombstones included.
-        const adultDobPurged = await prisma.$executeRaw`
+        const purgedPeople = await prisma.$queryRaw<{ id: number }[]>`
             UPDATE "Person"
             SET "dateOfBirth" = NULL, "isDeclaredAdult" = true
             WHERE "dateOfBirth" IS NOT NULL
-              AND "dateOfBirth" <= (CURRENT_DATE - INTERVAL '26 years')`;
+              AND "dateOfBirth" <= (CURRENT_DATE - INTERVAL '26 years')
+            RETURNING "id"`;
+        const adultDobPurged = purgedPeople.length;
         if (adultDobPurged > 0) {
+            // The row records that a date of birth was removed, never the date
+            // itself: retention forbids keeping it past 25, and an audit row
+            // outlives the Person field it would be copied from.
+            await prisma.auditLog.createMany({
+                data: purgedPeople.map(({ id }) => ({
+                    ...systemActor("cron:nightly"),
+                    action: 'DELETE' as const,
+                    tableName: 'Person',
+                    affectedEntityId: id,
+                    newData: { field: 'dateOfBirth', reason: 'aged_out_over_25' }
+                }))
+            });
             logger.info(`Nightly cron: purged DoB for ${adultDobPurged} member(s) now over 25 (#1165).`);
         }
 


### PR DESCRIPTION
Finding **B15** of the #1529 domain-register audit. (Plain reference, no closing keyword; #1529 carries 27 other findings.)

## The gap

`GET /api/cron/nightly` audits its own notifications and not its own destruction. Around `:60` the facility-close branch writes an `auditLog` row when it force-closes abandoned visits and alerts the board. Twenty-odd lines below, the branch that nulls `Person.dateOfBirth` for everyone past 26 wrote nothing — while its own comment calls that field "our most-sensitive field."

So within one handler, a notification was attributable and an irreversible deletion was not. `docs/rules/principles.md`, under *Accountability*: a surface that changes standing, money or access and writes no audit row is unfinished. The purge is not merely a state change — it destroys the value, and afterwards there is nothing left to read.

## What changed

One row per affected person, written after the purge:

```
actorId 0 / actorSystem cron:nightly
DELETE  Person #<id>
newData { field: "dateOfBirth", reason: "aged_out_over_25" }
```

`$executeRaw` becomes `$queryRaw<{id:number}[]> … RETURNING "id"`, then a single `auditLog.createMany`. Actor comes from `systemActor("cron:nightly")` — already in `SYSTEM_ACTORS`, so no change there.

**The date is not in the row.** Not in `oldData`, not in `newData`, not in the log line. The surrounding convention is a before-and-after pair, so the reflexive shape here is `oldData: { dateOfBirth: <value> }` — that shape is the bug, not the fix. `docs/rules/people-households.md` ("Identity and age") does not retain a date of birth past 25, and that rule is Policy-tier (Records Policy, Art. VI §VI.2). `AuditLog` outlives the `Person` field and is read through a different path with a different audience, so a pre-image there would re-store exactly what the purge exists to remove — an audit row that preserves what the deletion removed is worse than no audit row. `logger.info` still logs only the count.

## Why per-person, not one row per run

An aggregate row carrying the count is the smaller change — the statement already returned a count, so nothing else would have been needed.

It lost because it cannot answer the question an audit trail on a per-person field gets asked: *why did this person's date of birth disappear.* Answering it from a nightly tally means inferring a person's row from the timing of a sweep, which `principles.md` names directly — reconstructing from the audit trail is a fallback, not a design. Per-person also matches the theme #1536 set for archive and merge: capture what a destructive operation destroys.

The cost is honest and small. `RETURNING "id"` on a statement that was already scanning those rows, and N rows a night where N is only whoever crossed 26 since the last run — the one-time backfill migration already swept the accumulated set. The person's id is the subject of the row, a fact about them rather than the value that was deleted.

The `DELETE` / `Person` pair overlaps with what the merge route writes for a merged-away person. The audit panel renders rows raw (`DELETE  Person #123`, the `cron:nightly` badge, the payload JSON), so nothing reads as a person deletion; `actorSystem` and `newData.reason` separate them.

## Not touched

The purge itself. Same predicate, same `SET`, same raw SQL so age is still judged in the DB with tombstones included. This PR adds a record of the work; it does not alter the work. Response shape is unchanged (`adultDobPurged` is still a count). No schema change, no migration, nothing under `src/security/`.

## Tests

One test in `cronNightlyAPI.integration.test.ts`, verified in three directions:

| Route state | Result |
|---|---|
| With the fix | 4/4 pass |
| Audit write reverted | `✕ … Received: null` |
| Date deliberately re-added as `newData.context.was` | `✕ Expected substring: not "1990-04-17"` |

The third run is the one that matters. The PII assertion does not check the field the date is expected to be in — it serializes the row and scans it, so a date re-added later in a `context` blob, or as an `oldData` pre-image, fails here too. Specific-value checks (epoch ms, ISO datetime, ISO date) run over the whole row; a generic `/\b(19|20)\d{2}\b/` runs over `actorSystem` / `tableName` / `oldData` / `newData` only, since autoincrement ids can hit a year by accident and `timestamp` is the audit's own clock.

```
test:ci           272 suites, 2621 passed
test:integration  134 suites, 1398 passed, 3 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
