### PR TITLE
fix(attendance): cap a machine-closed visit at 24 hours (B12, #1529)

### DIFF
--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -4,6 +4,7 @@
 import { GET } from '@/app/api/cron/nightly/route';
 import prisma from '@/lib/prisma';
 import { sendEmail } from '@/lib/email';
+import { MAX_VISIT_MS } from '@/lib/visitTimes';
 
 jest.mock('@/lib/email', () => ({
     runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())),
@@ -21,11 +22,11 @@ jest.mock('@/lib/attendanceTransitions', () => {
     return {
         __esModule: true,
         ...actual,
-        processVisitCheckout: jest.fn((visitId: number, checkoutTime: Date, db?: unknown) => {
+        processVisitCheckout: jest.fn((visitId: number, checkoutTime: Date, db?: unknown, source?: unknown) => {
             if (mockBadVisitIds.has(visitId)) {
                 return Promise.reject(new Error(`Simulated checkout failure for visit ${visitId}`));
             }
-            return actual.processVisitCheckout(visitId, checkoutTime, db);
+            return actual.processVisitCheckout(visitId, checkoutTime, db, source);
         }),
     };
 });
@@ -273,6 +274,22 @@ describe('Cron Nightly API Integration Tests', () => {
 
             expect(await systemNotifyCount()).toBe(1); // no NEW force-checkout audit row
             expect(sendEmail).not.toHaveBeenCalled(); // no duplicate board/post-event email
+        });
+
+        it('caps a visit the sweep missed at arrival + MAX_VISIT_MS instead of stamping run time', async () => {
+            await closeAllOpenVisits();
+            await prisma.auditLog.deleteMany();
+            mockBadVisitIds.clear();
+
+            const arrivedAt = new Date(Date.now() - 30 * 60 * 60 * 1000);
+            const missed = await prisma.visit.create({ data: { personId: normalUserId, arrivedAt } });
+
+            const res = await GET(cronReq());
+            expect(res.status).toBe(200);
+
+            const closed = await prisma.visit.findUnique({ where: { id: missed.id } });
+            expect(closed?.departedAt).toEqual(new Date(arrivedAt.getTime() + MAX_VISIT_MS));
+            expect(closed?.departedVia).toBe('AUTO_CLOSE');
         });
     });
 });

--- a/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
@@ -12,6 +12,7 @@ import { processCheckout } from '@/lib/scan-service';
 import prisma from '@/lib/prisma';
 import { authenticateRequest } from '@/lib/auth';
 import { processPostEventEmails } from '@/lib/postEventEmails';
+import { MAX_VISIT_MS } from '@/lib/visitTimes';
 import type { Person } from '@/generated/prisma/client';
 
 jest.mock('@/lib/auth', () => ({ authenticateRequest: jest.fn() }));
@@ -113,6 +114,36 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
             where: { personId: { in: [isKeyholder.id, normal.id] }, departedAt: null },
         });
         expect(openAnyone).toBe(0);
+    });
+
+    it('caps a >24h visit at arrival + MAX_VISIT_MS, stamps the rest at the close moment, and leaves a tombstone open', async () => {
+        const stale = new Date(Date.now() - 30 * 60 * 60 * 1000);
+        const beforeClose = Date.now();
+
+        const kVisit = await prisma.visit.create({
+            data: { personId: isKeyholder.id, arrivedAt: new Date(), forceCloseWarnedAt: new Date(Date.now() - 5000) },
+        });
+        const staleVisit = await prisma.visit.create({ data: { personId: normal.id, arrivedAt: stale } });
+        // Open AND tombstoned — the one-open-visit index only covers live rows.
+        const tombstoned = await prisma.visit.create({
+            data: { personId: normal.id, arrivedAt: stale, deletedAt: new Date() },
+        });
+
+        const res = await processCheckout(isKeyholder, kVisit.id, 'kiosk');
+        expect((await res.json()).facilityClosed).toBe(true);
+
+        const capped = await prisma.visit.findUnique({ where: { id: staleVisit.id } });
+        expect(capped?.departedAt).toEqual(new Date(stale.getTime() + MAX_VISIT_MS));
+        expect(capped?.departedVia).toBe('FACILITY_CLOSE');
+
+        // An in-range visit still takes the close moment itself.
+        const sameDay = await prisma.visit.findUnique({ where: { id: kVisit.id } });
+        expect(sameDay!.departedAt!.getTime()).toBeGreaterThanOrEqual(beforeClose);
+        expect(sameDay!.departedAt!.getTime()).toBeLessThanOrEqual(Date.now());
+        expect(sameDay?.departedVia).toBe('FACILITY_CLOSE');
+
+        const untouched = await prisma.visit.findUnique({ where: { id: tombstoned.id } });
+        expect(untouched?.departedAt).toBeNull();
     });
 
     it('warns instead of closing when others are present and no warning has been shown', async () => {

--- a/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/attendanceTransitions.integration.test.ts
@@ -9,6 +9,7 @@
  * already-closed/missing visits) was untested.
  */
 import { findAssociatedEventAt, processVisitCheckout } from '@/lib/attendanceTransitions';
+import { MAX_VISIT_MS } from '@/lib/visitTimes';
 import prisma from '@/lib/prisma';
 
 const TAG = 'attendance-transitions-test';
@@ -154,6 +155,33 @@ describe('attendanceTransitions', () => {
             expect(v1!.departedAt).toEqual(e2Start);
             expect(v2!.arrivedAt).toEqual(e2Start);
             expect(v2!.departedAt).toEqual(checkout);
+        });
+
+        it('caps a stamped-now close at MAX_VISIT_MS after arrival', async () => {
+            const arrivedAt = new Date(Date.now() - 30 * HOUR);
+            const visit = await prisma.visit.create({ data: { personId: unenrolledId, arrivedAt } });
+
+            const result = await processVisitCheckout(visit.id, new Date(), undefined, 'AUTO_CLOSE');
+
+            expect(result).toHaveLength(1);
+            expect(result[0].departedAt).toEqual(new Date(arrivedAt.getTime() + MAX_VISIT_MS));
+            expect(result[0].departedVia).toBe('AUTO_CLOSE');
+        });
+
+        it('caps the chunked span as a whole: an event past the cap yields no chunk', async () => {
+            const t0 = new Date(Date.now() - 30 * HOUR);
+            const cap = new Date(t0.getTime() + MAX_VISIT_MS);
+            const early = await makeEvent('capped-early', new Date(t0.getTime() + HOUR), new Date(t0.getTime() + 2 * HOUR));
+            // Starts after the cap but before the uncapped checkout time.
+            await makeEvent('capped-late', new Date(cap.getTime() + HOUR), new Date(cap.getTime() + 2 * HOUR));
+            const visit = await prisma.visit.create({ data: { personId: participantId, arrivedAt: t0 } });
+
+            const result = await processVisitCheckout(visit.id, new Date(), undefined, 'AUTO_CLOSE');
+
+            // Gap then the early event, ending at the cap — the late event is out of span.
+            expect(result.map(v => v.associatedEventId)).toEqual([null, early.id]);
+            expect(result[0].arrivedAt).toEqual(t0);
+            expect(result[result.length - 1].departedAt).toEqual(cap);
         });
 
         it('returns [] for an already-departedAt visit (idempotent)', async () => {

--- a/checkin-app/src/lib/attendanceTransitions.ts
+++ b/checkin-app/src/lib/attendanceTransitions.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { type DbClient, type TxClient, withTx } from "@/lib/db-client";
+import { MAX_VISIT_MS } from "@/lib/visitTimes";
 
 /**
  * Finds all program IDs that a participant is associated with
@@ -74,7 +75,12 @@ export async function findAssociatedEventAt(participantId: number, targetTime: D
 /**
  * Processes a checkout. It takes an open visit and a checkout time, and creates multiple
  * visits if the user was enrolled in back-to-back events during their stay.
- * 
+ *
+ * The departure is capped at `arrivedAt + MAX_VISIT_MS`. A caller that took a
+ * typed time has already rejected anything longer, so the cap only ever bites
+ * on a stamped-now close — where the alternative is a record no human path
+ * would have been allowed to write.
+ *
  * It returns the final list of visits spanning their arrival to departure.
  */
 export async function processVisitCheckout(visitId: number, checkoutTime: Date, db: DbClient = prisma, source: "SCANNER" | "WEB" | "AUTO_CLOSE" = "WEB") {
@@ -90,22 +96,26 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
     // the original arrival's source and take `source` as their departure channel.
     const { personId: participantId, arrivedAt, arrivedVia } = originalVisit;
 
+    // Cap the whole span, before the event lookup, so every chunk boundary below
+    // derives from the capped departure and the segments still sum to one visit.
+    const departure = new Date(Math.min(checkoutTime.getTime(), arrivedAt.getTime() + MAX_VISIT_MS));
+
     const relevantProgramIds = await getRelevantProgramIds(participantId, db);
 
     if (relevantProgramIds.length === 0) {
         // No programs enrolled, just close the visit normally
         return [await db.visit.update({
             where: { id: visitId },
-            data: { departedAt: checkoutTime, departedVia: source }
+            data: { departedAt: departure, departedVia: source }
         })];
     }
 
-    // Find all events in these programs that fall between arrival and checkoutTime
+    // Find all events in these programs that fall between arrival and departure
     const eventsDuringStay = await db.event.findMany({
         where: {
             programId: { in: relevantProgramIds },
             // An event overlaps if it starts before checkout time AND ends after arrival time
-            startAt: { lt: checkoutTime },
+            startAt: { lt: departure },
             endAt: { gt: arrivedAt }
         },
         orderBy: { startAt: 'asc' }
@@ -115,7 +125,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
         // No relevant events during their stay, just close normally
         return [await db.visit.update({
             where: { id: visitId },
-            data: { departedAt: checkoutTime, departedVia: source }
+            data: { departedAt: departure, departedVia: source }
         })];
     }
 
@@ -137,7 +147,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
             // If there's a gap between current time and the event start time,
             // create an unassociated visit for the gap time
             if (currentIterStart < event.startAt) {
-                const gapEnd = event.startAt < checkoutTime ? event.startAt : checkoutTime;
+                const gapEnd = event.startAt < departure ? event.startAt : departure;
                 if (currentIterStart < gapEnd) {
                     createdVisits.push(await tx.visit.create({
                         data: {
@@ -154,7 +164,7 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
             }
 
             // If we've reached checkout time before the event logic starts, break.
-            if (currentIterStart >= checkoutTime) {
+            if (currentIterStart >= departure) {
                 break;
             }
 
@@ -163,8 +173,8 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
             const eventVisitStart = currentIterStart > event.startAt ? currentIterStart : event.startAt;
 
             // Check out when the next event starts, or when they physically leave
-            let eventVisitEnd = checkoutTime;
-            if (nextEvent && nextEvent.startAt < checkoutTime) {
+            let eventVisitEnd = departure;
+            if (nextEvent && nextEvent.startAt < departure) {
                 eventVisitEnd = nextEvent.startAt;
             }
 
@@ -184,12 +194,12 @@ export async function processVisitCheckout(visitId: number, checkoutTime: Date, 
         }
 
         // If there is still remaining time after the last event until checkOut time, create one last unassociated visit
-        if (currentIterStart < checkoutTime) {
+        if (currentIterStart < departure) {
             createdVisits.push(await tx.visit.create({
                 data: {
                     personId: participantId,
                     arrivedAt: currentIterStart,
-                    departedAt: checkoutTime,
+                    departedAt: departure,
                     arrivedVia,
                     departedVia: source,
                     associatedEventId: null

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -4,6 +4,7 @@ import { sendCheckinNotifications } from "@/lib/notifications";
 import { apiError, apiJson } from "@/lib/api-response";
 import type { Person } from "@/generated/prisma/client";
 import { type DbClient, isRootClient } from "@/lib/db-client";
+import { MAX_VISIT_MS } from "@/lib/visitTimes";
 
 /** How long a displayed force-close warning stays confirmable. The scan route's
  *  3s debounce eats the front of it, so the kiosk copy says "3 to 60 seconds". */
@@ -162,17 +163,32 @@ export async function processCheckout(
 }
 
 /** Mark every still-open visit as departed. Facility-wide, not participant-scoped:
- *  a single atomic statement, so it needs no wrapping transaction. */
+ *  a single atomic statement, so it needs no wrapping transaction.
+ *
+ *  Raw rather than `updateMany` because the stamp is per-row: the close moment
+ *  is capped at the visit's own `arrivedAt + MAX_VISIT_MS`, and `updateMany`
+ *  can only set one constant for every row it touches.
+ *
+ *  FACILITY_CLOSE, not AUTO_CLOSE: the stamp is normally the moment the building
+ *  actually closed, so it is bounded by building hours — plausible, unlike the
+ *  cron's midnight sweep. Where the cap bites the stamp is 24h after arrival
+ *  instead; both are placeholders the member is meant to correct, and a
+ *  placeholder inside the 24h rule beats an accurate record that breaks it.
+ *
+ *  `now()` is timestamptz and the columns are timestamp-without-zone holding
+ *  UTC, so the clock must be pulled AT TIME ZONE 'UTC' or the comparison is off
+ *  by the server's offset. */
 async function closeAllOpenVisits(db: DbClient) {
-    await db.visit.updateMany({
-        // Tombstoned visits are excluded: closing one would rewrite a record the
-        // member chose to erase, and resurrect a machine departure if it is undone.
-        where: { departedAt: null, deletedAt: null },
-        // FACILITY_CLOSE, not AUTO_CLOSE: this stamp is the moment the building
-        // actually closed, so it is bounded by building hours — plausible, unlike
-        // the cron's midnight sweep.
-        data: { departedAt: new Date(), departedVia: "FACILITY_CLOSE" },
-    });
+    // Tombstoned visits are excluded: closing one would rewrite a record the
+    // member chose to erase, and resurrect a machine departure if it is undone.
+    await db.$executeRaw`
+        UPDATE "Visit"
+        SET "departedAt" = LEAST(
+                (now() AT TIME ZONE 'UTC'),
+                "arrivedAt" + ${MAX_VISIT_MS}::double precision * interval '1 millisecond'
+            ),
+            "departedVia" = 'FACILITY_CLOSE'::"VisitSource"
+        WHERE "departedAt" IS NULL AND "deletedAt" IS NULL`;
 }
 
 /** Fire-and-forget post-event email run on facility close. The dynamic import


### PR DESCRIPTION
Fixes finding **B12** from the Class-B domain-register audit (#1529): "24h cap not enforced on machine closers". No closing keyword — #1529 tracks 28 findings and this is one of them.

## What was wrong

`docs/rules/attendance-checkin.md` states it plainly: *"A visit cannot run longer than 24 hours. [Decision]"* `MAX_VISIT_MS` / `withinMaxDuration` live in `src/lib/visitTimes.ts`, and five routes enforce them — every path where a person types a departure time is checked.

Neither machine closer was. Both stamped "now" unconditionally:

- `closeAllOpenVisits` (`scan-service.ts`) — the facility-wide close when the last keyholder badges out. A bare `updateMany` setting `departedAt: new Date()`.
- `processVisitCheckout` (`attendanceTransitions.ts`) — the per-visit closer the nightly cron calls with `AUTO_CLOSE`. Set `departedAt: checkoutTime`, never consulted the duration.

So a visit that survived a nightly sweep and was closed later became a record every human path would have rejected.

**Not a live fire.** The sweep fires at 22:50 America/Chicago with no flex window, so nothing reaches 24 hours in normal operation, and open manual backfills are separately capped at six hours stale at creation. It takes a missed run or a repeating per-visit exception to get there. The value is that the invariant stops depending on a schedule defined in a different repository.

## The change

Both closers cap the departure at `arrivedAt + MAX_VISIT_MS`. No schema change, no migration, nothing under `src/security/`. Which visits get closed, and when either closer runs, are unchanged — only the stamp.

### `closeAllOpenVisits` → `$executeRaw`

The cap is per-row (`arrivedAt + 24h` differs per visit) and `updateMany` can only set a constant. The existing comment makes the single atomic statement the point ("so it needs no wrapping transaction"), so the statement stays single — raw rather than a select-then-loop, which would trade the atomicity away:

```sql
UPDATE "Visit"
SET "departedAt" = LEAST(
        (now() AT TIME ZONE 'UTC'),
        "arrivedAt" + $1::double precision * interval '1 millisecond'
    ),
    "departedVia" = 'FACILITY_CLOSE'::"VisitSource"
WHERE "departedAt" IS NULL AND "deletedAt" IS NULL
```

Two details worth a reviewer's eye:

- **`AT TIME ZONE 'UTC'` is load-bearing.** The columns are `timestamp(3) without time zone` holding UTC; `now()` is `timestamptz`. A bare `LEAST(now(), "arrivedAt" + …)` resolves to timestamptz and converts the column through the session `TimeZone` — off by 5–6 hours on a `America/Chicago` server.
- `MAX_VISIT_MS` is passed as a parameter rather than hardcoded as `interval '24 hours'`, so the SQL cannot drift from the TS constant. The explicit `::double precision` cast is because Postgres has no `numeric * interval` operator.

The tombstone exclusion carries over verbatim as `"deletedAt" IS NULL`.

### `processVisitCheckout` — capped once, not per chunk

```ts
const departure = new Date(Math.min(checkoutTime.getTime(), arrivedAt.getTime() + MAX_VISIT_MS));
```

The cap belongs to the visit's overall span, so it is applied at the top, before the event lookup. Capping each chunk instead would be a no-op on every chunk (they are already short) while the total still exceeded 24h, and the trailing chunk would still be stamped at "now".

Capping the span first means the event query (`startAt: { lt: departure }`) drops events starting past the cap, so no segment is created for them; the last surviving segment ends exactly at the cap, and the segments still sum to one capped visit. All downstream `checkoutTime` uses move to `departure`.

The cap sits in the shared function rather than at the cron call site, so the WEB and SCANNER stamped-now closeouts are covered too. It is a no-op for the three callers that pass a typed time — they already reject >24h at the route.

### A clamped close is not distinguishable, deliberately

It keeps its ordinary `FACILITY_CLOSE` / `AUTO_CLOSE`. Both already weigh `0` in `lib/visit/significance.ts` — "a placeholder the member is *meant* to fix, so correcting one never flags" — which is exactly the semantics a capped stamp needs, so a new source value would change no behaviour anywhere. It would cost a `VisitSource` enum change (schema + migration) plus edits to the ops-page icon map, email templates, the trends split and the weight table, to buy something already derivable: `departedAt - arrivedAt == 24h` on a machine source.

### One comment became false

`closeAllOpenVisits` justified its stamp as "the moment the building actually closed, so it is bounded by building hours". Once capped that is no longer true of a >24h visit, whose `departedAt` is 24 hours after *its own arrival*. The comment now says the building-hours claim holds normally, and what the stamp means where the cap bites — an in-range visit with an approximate stamp beats an out-of-range one.

## Tests

Four new cases, all four verified to fail on unmodified `main`:

```
● Cron Nightly API › caps a visit the sweep missed at arrival + MAX_VISIT_MS instead of stamping run time
● Scan causal chain › caps a >24h visit at arrival + MAX_VISIT_MS, stamps the rest at the close moment, and leaves a tombstone open
● attendanceTransitions › caps a stamped-now close at MAX_VISIT_MS after arrival
● attendanceTransitions › caps the chunked span as a whole: an event past the cap yields no chunk
```

The facility-close test covers all three required cases in one close: the capped >24h visit, the keyholder's same-day visit still stamped at the close moment, and a tombstoned open visit still `departedAt: null`.

```
before (fix reverted, tests kept)  3 suites failed, 4 tests failed
after                              3 suites passed, 20 tests passed

npm run test:ci           272 suites, 2621 passed
npm run test:integration  134 suites, 1401 passed, 3 skipped
tsc --noEmit              clean
npm run lint              clean
```

## Two things for the reviewer

1. **A test-harness bug fixed in passing.** `cronNightlyAPI.integration.test.ts`'s `processVisitCheckout` mock wrapper took `(visitId, checkoutTime, db)` and dropped the 4th argument, so every cron-path visit in that suite was silently recorded as `WEB` instead of `AUTO_CLOSE`. The new test caught it; the wrapper now forwards `source`. Nothing else in the file asserted on `departedVia`.

2. **The raw statement is now invisible to the LIVE_VISIT drift guard.** `liveVisitDriftGuard.test.ts` matches `prisma|tx|db.visit.updateMany(...)`; a `$executeRaw` does not match, so the guard no longer polices this statement's tombstone exclusion. The exclusion is present and covered by a test, but CI will not catch a future edit that drops it. Extending the guard to raw `"Visit"` UPDATEs wants its own thinking about false positives across the other raw sites, so it is left out of a clamp-sized PR — flagging rather than silently absorbing the loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
