### PR TITLE
docs(vocabulary): settle the background-check verbs

### DIFF
--- a/checkin-app/docs/VOCABULARY.md
+++ b/checkin-app/docs/VOCABULARY.md
@@ -138,10 +138,11 @@ Rules:
    "I approve this person" states the judgement, which is what is stored.
    *(rename pending: the reviewer queue's confirm modal and row button)*
 3. **`clear` never means erase.** Undoing attestations is **discard**. `clear` is
-   reserved for the outcome above. *(rename pending: the "Clear approvals" button)*
+   reserved for the outcome above. Erasing a person's clearance date is **remove**.
+   *(rename pending: the "Clear approvals" button; the compliance page's erase path)*
 4. **"Attest" is the reviewer's word alone.** An applicant **consents**; a Tool
    Certifier **certifies** (see Shop & Certification).
-   *(rename pending: `selfAttestBgConsent` → `recordBgConsent`)*
+   *(rename pending: `selfAttestBgConsent` → `selfRecordBgConsent`)*
 5. **`PENDING_BG_REVIEW` and `PENDING_BG_CLEARANCE` do not mark review vs
    clearance** — they differ by whether dues are paid. A known misnomer; the enum
    stays, because renaming a status reaches the schema, a migration, and the

--- a/checkin-app/docs/VOCABULARY.md
+++ b/checkin-app/docs/VOCABULARY.md
@@ -76,7 +76,7 @@ Program roles (all Treehouse Volunteers):
 - **Board Member** (`isBoardMember`) — a governance role; **distinct from the OrgMembership "Treehouse Member"** (a Board Member need not be a Treehouse Member). Not the bare-`member` this dictionary bans.
 - **Treehouse Account** — an internal org-domain (`@innovationtreehouse.org`) account; not a real Member Family. `isTreehouseAccount` *(rename pending from `isStaffAccount`; also `STAFF_ENTERED`)*.
 - **Admin** — ⚠️ **UNRESOLVED / do not rely on.** "admin" is a loose derived label (no `isAdmin` column) that means `isSysadmin` in some files and `isSysadmin || isBoardMember` in others. Security-sensitive; deferred to its own discussion (UNFINISHED.md).
-- **Review / Reviewer** — ⚠️ overloaded across BG-reviewer role, attestation reviewer, membership review, and trusted-adult "decider"; lower-priority followup (UNFINISHED.md). Never use "review" bare until resolved.
+- **Review / Reviewer** — the BG-reviewer role, the membership review queue, and `BackgroundCheckAttestation.reviewer` are **one concept**, defined under [Background check](#background-check). Trusted-adult review keeps its own **review** + **decider** (`TrustedAdultReview.decidedBy`) — one board member's decision with recorded reasoning, not a two-of-N attestation. **Scholarship Review Team** (see Money) is a third, unrelated.
 
 ## Shop & Certification
 
@@ -109,6 +109,43 @@ Rules:
 - **Scholarship Review Team** — the board-designated recipients of scholarship / payment-plan
   request notifications (`BoardSettings.scholarshipNotifyEmail`; falls back to all board members
   when unset). The canonical UI/copy term — **retire "Finance Committee"** for this concept.
+
+## Background check
+
+One flow, three acts to keep apart. **Reviewing is the job; attesting is the act
+that ends it; a clearance is what two attestations produce.**
+
+**review** (read the report on Averity) → **attest** (one reviewer's judgement of one
+adult) → two attestations → **clearance** (dated; the validity window runs from it).
+
+| Term | Meaning | Code | UI |
+|---|---|---|---|
+| **Reviewer** | the person — a background-check reviewer, or a board member (implicitly one). The role and the job, not the act | `isBackgroundCheckReviewer` / `BG_REVIEWER` | "reviewer" |
+| **Review** | the **reading** of the Averity report. Not the decision | `/membership-ops/review`, `/api/membership/reviews` | "review" |
+| **Attest** | one reviewer putting their name to a judgement about one adult — the act, and the only thing the app stores | `attest()`, `BackgroundCheckAttestation` | "Attest" |
+| **Approve / Reject** | the **value** carried on an attestation — what was judged, never the act of judging | `AttestationResult` | "Approve" / "Reject" |
+| **Clearance** / **cleared** | the outcome: two attestations, dated. The re-check window runs from that date | `bgClearedAt`, `PENDING_BG_CLEARANCE`, `Person.lastBackgroundCheck` | "cleared" |
+| **Consent** | the **applicant's** act — they submitted the Averity form. Never "attest" | `bgConsentAt`, `markBgConsent` | "consent" |
+| **Override** | the board acting against the flow's own outcome — force-approving a blocked application, or discarding attestations | `overrideBlocked` | "override" |
+
+Rules:
+1. **A reviewer attests; two attestations clear the check.** One word per sense —
+   never "approve" for the act, never "attest" for the outcome.
+2. **Never "clean."** The app never holds the report or its result, only that a
+   reviewer read it and what they judged
+   ([../../docs/rules/membership.md](../../docs/rules/membership.md), Procedure ›
+   Application and review). "The check is clean" asserts the document's content;
+   "I approve this person" states the judgement, which is what is stored.
+   *(rename pending: the reviewer queue's confirm modal and row button)*
+3. **`clear` never means erase.** Undoing attestations is **discard**. `clear` is
+   reserved for the outcome above. *(rename pending: the "Clear approvals" button)*
+4. **"Attest" is the reviewer's word alone.** An applicant **consents**; a Tool
+   Certifier **certifies** (see Shop & Certification).
+   *(rename pending: `selfAttestBgConsent` → `recordBgConsent`)*
+5. **`PENDING_BG_REVIEW` and `PENDING_BG_CLEARANCE` do not mark review vs
+   clearance** — they differ by whether dues are paid. A known misnomer; the enum
+   stays, because renaming a status reaches the schema, a migration, and the
+   applicant-facing wire.
 
 ## Attendance / check-in
 

--- a/checkin-app/docs/designs/UNFINISHED.md
+++ b/checkin-app/docs/designs/UNFINISHED.md
@@ -41,19 +41,28 @@ privileged-"staff" onto it. (4) audit every call site for over/under-grant.
 
 ---
 
-## 🟡 "Review" / "Reviewer" — followup (lower priority than Admin)
+## 🟢 "Review" / "Reviewer" — decided
 
-Four review flows share the word, and product owner isn't sure yet where each term
-is used or whether they should converge:
+Of the four flows listed here, three were one flow: the BG Reviewer role, the
+membership review queue, and `BackgroundCheckAttestation.reviewer` are the same
+people doing the same job. Trusted-adult review keeps **review** + **decider** —
+one board member deciding with recorded reasoning, unlike the two-of-N attestation.
+Terms recorded in [../VOCABULARY.md](../VOCABULARY.md) › Background check.
 
-- **BG Reviewer** role — `isBackgroundCheckReviewer` → "BG Reviewer".
-- **Attestation reviewer** — `BackgroundCheckAttestation.reviewer`.
-- **Membership review** — `/api/membership/reviews`, `membership-ops/review`.
-- **Trusted-adult review** — `TrustedAdultReview.decidedBy` (a "reviewer" called a
-  **"decider"** — is that the same concept?).
+**Reviewer** = the role and the job (reading the Averity report). **Attest** = the
+act. **Clearance** = what two attestations produce. Renames this implies:
 
-Decide: one canonical word, or keep distinct per subsystem; and reconcile
-"decider" vs "reviewer". Deserves its own pass. _(VOCAB #9)_
+- "check is clean" copy → the reviewer's judgement, not the report's content
+  (`membership-ops/review/page.tsx`, 5 strings — partly reverses PR #1575).
+- "Clear approvals" → "Discard approvals" (`membership-ops/applications/page.tsx`,
+  button + confirm label + comment).
+- `selfAttestBgConsent` → `recordBgConsent` (~17 refs across 5 files, internal
+  only — the `/api/membership/bg-consent` route path is unchanged).
+
+Deliberately **not** renamed: `AttestationResult.result` (reads as "the check's
+result", the thing never stored) and the `PENDING_BG_REVIEW` /
+`PENDING_BG_CLEARANCE` misnomer — both reach the schema, a migration, and
+`src/security/`, for a wording gain. _(VOCAB #9)_
 
 ---
 

--- a/checkin-app/docs/designs/UNFINISHED.md
+++ b/checkin-app/docs/designs/UNFINISHED.md
@@ -41,28 +41,24 @@ privileged-"staff" onto it. (4) audit every call site for over/under-grant.
 
 ---
 
-## 🟢 "Review" / "Reviewer" — decided
+## 🟢 Background-check verbs (decided)
 
-Of the four flows listed here, three were one flow: the BG Reviewer role, the
-membership review queue, and `BackgroundCheckAttestation.reviewer` are the same
-people doing the same job. Trusted-adult review keeps **review** + **decider** —
-one board member deciding with recorded reasoning, unlike the two-of-N attestation.
-Terms recorded in [../VOCABULARY.md](../VOCABULARY.md) › Background check.
-
-**Reviewer** = the role and the job (reading the Averity report). **Attest** = the
-act. **Clearance** = what two attestations produce. Renames this implies:
-
-- "check is clean" copy → the reviewer's judgement, not the report's content
-  (`membership-ops/review/page.tsx`, 5 strings — partly reverses PR #1575).
+**✅ A reviewer *reviews*, *attests*, and two attestations *clear* the check**
+([../VOCABULARY.md](../VOCABULARY.md) › Background check). Three copy/identifier
+renames, all ops-facing or internal — no schema, no `src/security/`:
+- The reviewer queue names the act two wrong ways: the confirm modal calls it
+  "Clear…" (that's the outcome) and the row button asserts "check is clean" (that's
+  the report's content). Both become *attest*
+  (`membership-ops/review/page.tsx`, 3 strings + 8 test assertions). PR #1575, open
+  at the time of writing, does half — modal "Clear…" → "Attest…", but adds "clean"
 - "Clear approvals" → "Discard approvals" (`membership-ops/applications/page.tsx`,
-  button + confirm label + comment).
-- `selfAttestBgConsent` → `recordBgConsent` (~17 refs across 5 files, internal
-  only — the `/api/membership/bg-consent` route path is unchanged).
+  button + confirm label + comment)
+- `selfAttestBgConsent` → `recordBgConsent` (~17 refs / 5 files; the
+  `/api/membership/bg-consent` route path is unchanged)
 
-Deliberately **not** renamed: `AttestationResult.result` (reads as "the check's
-result", the thing never stored) and the `PENDING_BG_REVIEW` /
-`PENDING_BG_CLEARANCE` misnomer — both reach the schema, a migration, and
-`src/security/`, for a wording gain. _(VOCAB #9)_
+**Do not "fix"** `AttestationResult.result` or the `PENDING_BG_REVIEW` /
+`PENDING_BG_CLEARANCE` misnomer. Both are wrong and both stay: renaming either
+reaches the schema, a migration, and `src/security/`. _(VOCAB #9)_
 
 ---
 

--- a/checkin-app/docs/designs/UNFINISHED.md
+++ b/checkin-app/docs/designs/UNFINISHED.md
@@ -44,17 +44,23 @@ privileged-"staff" onto it. (4) audit every call site for over/under-grant.
 ## 🟢 Background-check verbs (decided)
 
 **✅ A reviewer *reviews*, *attests*, and two attestations *clear* the check**
-([../VOCABULARY.md](../VOCABULARY.md) › Background check). Three copy/identifier
+([../VOCABULARY.md](../VOCABULARY.md) › Background check). Four copy/identifier
 renames, all ops-facing or internal — no schema, no `src/security/`:
-- The reviewer queue names the act two wrong ways: the confirm modal calls it
-  "Clear…" (that's the outcome) and the row button asserts "check is clean" (that's
-  the report's content). Both become *attest*
-  (`membership-ops/review/page.tsx`, 3 strings + 8 test assertions). PR #1575, open
-  at the time of writing, does half — modal "Clear…" → "Attest…", but adds "clean"
+- The reviewer queue asserts the report's content rather than the reviewer's
+  judgement: "check is clean" on the row button, in the modal title, confirm label
+  and both body branches (`membership-ops/review/page.tsx`, 5 strings + 8 test
+  assertions). All become *attest*, and the outcome is named as the **noun** —
+  `clear` as a verb on a button next to "Reject" reads as *reset*
 - "Clear approvals" → "Discard approvals" (`membership-ops/applications/page.tsx`,
-  button + confirm label + comment)
-- `selfAttestBgConsent` → `recordBgConsent` (~17 refs / 5 files; the
-  `/api/membership/bg-consent` route path is unchanged)
+  button + confirm label + comment; 2 test assertions)
+- The whole erase path for a person's background-check date is built on `clear` —
+  handler, button, modal title, confirm label, toast
+  (`membership-audit/compliance/page.tsx`, 8 sites + 4 test assertions). Becomes
+  *remove*, the verb its own body text already uses
+- `selfAttestBgConsent` → `selfRecordBgConsent` (~17 refs / 5 files; the
+  `/api/membership/bg-consent` route path is unchanged). Keeps the `self` prefix:
+  `markBgConsent` is exported and called from seven places, so a bare
+  `recordBgConsent` wrapping it would be a coin flip at every call site
 
 **Do not "fix"** `AttestationResult.result` or the `PENDING_BG_REVIEW` /
 `PENDING_BG_CLEARANCE` misnomer. Both are wrong and both stay: renaming either

--- a/docs/rules/membership.md
+++ b/docs/rules/membership.md
@@ -166,6 +166,12 @@ Procedure below is built on them.
   consent link and its result comes back by hand. That is the arrangement, not a
   stopgap waiting to be automated.
 
+- A check that comes back with a restriction on how someone may volunteer is
+  carried by the board, not the app. Reviewers record only approval or rejection,
+  so a restricted volunteer is approved here and the restriction lives in the
+  board's own arrangement with them. The assumption holds as long as the reviewers
+  who read the report are the people who set that arrangement.
+
 - Declining a scholarship or payment-plan request is a conversation between two
   people. Telling the family is the board's own act and happens outside the app.
 


### PR DESCRIPTION
The background-check flow used five words for three things, and it was not settled
which word named which.

`attest` named both the reviewer's act and — on the second click only — its
consequence: the same act, writing the same row with the same `result: "APPROVE"`,
was called "Record your approval?" for the first reviewer and "Clear this
background check?" for the second. The word changed with the outcome, not with the
act.

`clear` meant both *grant a clearance* and *erase*, twice inside one confirm modal:
"the check itself has not cleared yet" sits three lines above a button labelled
"Clear approvals".

`attest` also covered two acts that are not the reviewer's at all — the applicant's
consent self-attestation, and a Tool Certifier attesting a level change.

## The decision

One word per sense. A reviewer **reviews** the Averity report, **attests** to a
judgement about one adult, and two attestations produce a **clearance**.

- **Approve / Reject** demote from naming the act to being the value carried on an
  attestation.
- **"Clean" is banned.** The register records that the background-check result is
  never stored — only that reviewers saw it and what they judged. "The check is
  clean" asserts the content of a document the app never holds; "I approve this
  person" states the judgement, which is what is stored. That rule is Procedure
  tier (the app's stricter-than-policy expression), so this is a wording call
  rather than a policy escalation — but it is the reason for the call.
- **`clear` never means erase.** Undoing attestations is *discard*.
- The applicant **consents**; a Tool Certifier **certifies**.

This also resolves the existing "Review / Reviewer is overloaded" entry rather than
adding a second beside it. Three of its four flows turned out to be one flow — the
BG-reviewer role, the membership review queue and `BackgroundCheckAttestation.reviewer`
are the same people doing the same job (117 refs). Trusted-adult review keeps
**review** + **decider** (48 refs): one board member deciding with reasoning
recorded, not a two-of-N blind attestation. "Scholarship Review Team" is a third,
unrelated, and already canonical.

## Scope

**Glossary only — nothing is renamed.** The renames this implies are listed in
`UNFINISHED.md` so they can be spun off and sized separately. All of them are
ops-facing copy or internal identifiers; none touch `prisma/schema.prisma`,
`src/security/`, or any wire key.

Two things are recorded as **wrong and deliberately staying**, so nobody closes them
as oversights: `AttestationResult.result` (reads as "the check's result", the one
thing never stored) and `PENDING_BG_REVIEW` / `PENDING_BG_CLEARANCE`, which differ
by whether dues are paid rather than by review-vs-clearance. Renaming either reaches
the schema, a migration, and the security boundary.

## Relationship to #1575

Open PR #1575 changes the same modal. It fixes half of this — the modal stops
calling the act "Clear…" — while introducing "clean", which this decision bans. This
PR is based on `main`, not on that branch, and touches no source file, so the two do
not conflict either way.

Decision for #1322; no closing keyword, since the ledger it tracks covers renames
this PR does not perform.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
