### PR TITLE
docs: retire the program sense of "staff"

### DIFF
--- a/checkin-app/docs/designs/UNFINISHED.md
+++ b/checkin-app/docs/designs/UNFINISHED.md
@@ -68,17 +68,6 @@ Watch tsc-blind escapes (Prisma relation strings, mocks). _(VOCAB #7)_
 
 ---
 
-## 🟢 Retire "staff" (program sense) → Treehouse Volunteers
-
-100% volunteer, no staff. Scrub "program staff" strings:
-[my-programs/layout.tsx:15](../../src/app/my-programs/layout.tsx#L15),
-[nav/todo-counts/route.ts:65](../../src/app/api/nav/todo-counts/route.ts#L65),
-[programs/[id]/route.ts:72](../../src/app/api/programs/[id]/route.ts#L72),
-[programs/[id]/volunteers/route.ts:38](../../src/app/api/programs/[id]/volunteers/route.ts#L38).
-Umbrella = **Treehouse Volunteers**. _(VOCAB #7)_
-
----
-
 ## 🟢 "staff account" → "Treehouse Account"
 
 Org-domain (`@innovationtreehouse.org`) account sense: rename `isStaffAccount` →

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -87,7 +87,7 @@ export type TodoCounts = {
     // = ones they approved that still need a second reviewer (gray).
     review?: { canActOn: number; approvedAwaitingSecond: number };
     // Lead surface: programs the caller runs (program.leadMentorId). Present only
-    // when they lead ≥1 program — drives the staff "My Programs" nav item's
+    // when they lead ≥1 program — drives the "My Programs (as Volunteer)" nav item's
     // visibility and its green badge (sum of pending attendance to confirm).
     // `pending` mirrors the post-event email's targets (ended events not yet
     // confirmed), deep-linked to the existing confirm screen. No new capability.

--- a/checkin-app/src/app/api/programs/[id]/volunteers/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/volunteers/route.ts
@@ -35,7 +35,7 @@ export const POST = withAuth({}, async (req, auth, { params }: { params: Promise
         }
 
         // ponytail: no eligibility gate (age/membership) on volunteers — they're
-        // staff/mentors, not enrollees. ProgramVolunteer has only isCore; any
+        // volunteers/program leaders, not enrollees. ProgramVolunteer has only isCore; any
         // participant is assignable. Add a gate here only if product asks for one.
         const assignment = await prisma.programVolunteer.create({
             data: {

--- a/checkin-app/src/app/my-programs/layout.tsx
+++ b/checkin-app/src/app/my-programs/layout.tsx
@@ -13,7 +13,7 @@ import { leadsAnyProgram, leadPendingCount } from "@/components/navBadges";
 
 import { PageLoader } from "@/components/ui/PageLoader";
 /**
- * Staff "My Programs" chrome: section title + subtabs (Attendance inbox /
+ * Program-leader "My Programs" chrome: section title + subtabs (Attendance inbox /
  * Conflicts), gated to program lead mentors. Lead status rides in on the
  * todo-counts payload the nav already fetches — no new session field. Matches the
  * program-ops layout's route-driven Tabs pattern.

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -57,10 +57,10 @@ export const PAGES: PageEntry[] = [
   { href: '/my-activities/events', label: 'My Events', section: 'Personal', visible: SIGNED_IN },
   { href: '/my-activities/programs', label: 'My Programs (as Participant)', section: 'Personal', visible: SIGNED_IN },
   { href: '/profile', label: 'My Profile', section: 'Personal', visible: SIGNED_IN },
-  // Staff home for program lead mentors. Lead status rides in on the todo-counts
+  // Home for program lead mentors. Lead status rides in on the todo-counts
   // payload (leadsAnyProgram), matching the nav gate. Distinct from the attendee
   // "My Programs" tab above.
-  { href: '/my-programs/attendance', label: 'My Programs (as Volunteer)', section: 'Personal', keywords: 'lead mentor program staff attendance', visible: LEADS_PROGRAM },
+  { href: '/my-programs/attendance', label: 'My Programs (as Volunteer)', section: 'Personal', keywords: 'lead mentor program volunteer attendance', visible: LEADS_PROGRAM },
   { href: '/my-programs/conflicts', label: 'Attendance Conflicts', section: 'Personal', keywords: 'lead mentor duplicate overlapping visit attendance', visible: LEADS_PROGRAM },
   // Stays visible to all members: also the Join/renewal entry for new applicants
   // who aren't a household lead yet (gating it on lead would break joining).


### PR DESCRIPTION
The org is 100% volunteer — there is no program staff. `docs/VOCABULARY.md` already lists `staff` / "program staff" under **Retired words (do not use)**; four comments and one search keyword still used it. This scrubs them.

Comments and one search keyword only — **zero behavior change**.

## What changed

- `src/app/my-programs/layout.tsx` — doc comment `Staff "My Programs" chrome` → `Program-leader "My Programs" chrome`.
- `src/app/api/nav/todo-counts/route.ts` — `drives the staff "My Programs" nav item's visibility` → names the nav item's actual label, `"My Programs (as Volunteer)"`.
- `src/app/api/programs/[id]/volunteers/route.ts` — `they're staff/mentors, not enrollees` → `they're volunteers/program leaders, not enrollees`. The `ponytail:` prefix and the rest of the comment are unchanged.
- `src/components/pageRegistry.ts` — dropped `Staff` from the entry's comment, and swapped the search keyword `staff` → `volunteer` (`'lead mentor program volunteer attendance'`) so the entry stays findable by search. `href`, `label`, `section`, and `visible` are untouched.
- `docs/designs/UNFINISHED.md` — deleted the `🟢 Retire "staff" (program sense) → Treehouse Volunteers` section; it is a running ledger of open items and this one is now closed.

## What deliberately did NOT change

**"Staff" also means privileged viewer (board/sysadmin).** That sense is under the unresolved admin-role-ambiguity review and is left exactly as-is: the `Staff (admin/board/lead/core-vol)` comments in `api/programs/[id]/route.ts`, the "staff-only" roster/policy comments in `api/events/[id]/route.ts`, `security/registry.ts`, and `api/shop/certifications/route.ts`, and every `isStaff` identifier. No auth gate is touched.

`isStaffAccount` / `STAFF_ENTERED` are the org-domain-account sense — a separate open item in `UNFINISHED.md`.

The `leadMentor` → `programLeader` rename (~261 refs) is its own item, so "lead mentor" wording stays in these files on purpose.

## Verification

- `npx tsc --noEmit` — clean.
- The `pageRegistry` drift guard (`src/__tests__/pageRegistry.test.ts`) — 3/3 pass. That is the suite covering the registry entry whose keyword changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
