### PR TITLE
fix(membership): apply the settled background-check vocabulary

### DIFF
--- a/checkin-app/docs/VOCABULARY.md
+++ b/checkin-app/docs/VOCABULARY.md
@@ -131,18 +131,20 @@ adult) → two attestations → **clearance** (dated; the validity window runs f
 Rules:
 1. **A reviewer attests; two attestations clear the check.** One word per sense —
    never "approve" for the act, never "attest" for the outcome.
-2. **Never "clean."** The app never holds the report or its result, only that a
-   reviewer read it and what they judged
+2. **Never "clean," never "passed."** The app never holds the report or its
+   result, only that a reviewer read it and what they judged
    ([../../docs/rules/membership.md](../../docs/rules/membership.md), Procedure ›
-   Application and review). "The check is clean" asserts the document's content;
-   "I approve this person" states the judgement, which is what is stored.
-   *(rename pending: the reviewer queue's confirm modal and row button)*
-3. **`clear` never means erase.** Undoing attestations is **discard**. `clear` is
-   reserved for the outcome above. Erasing a person's clearance date is **remove**.
-   *(rename pending: the "Clear approvals" button; the compliance page's erase path)*
+   Application and review). Both words state an outcome of the report; "I approve
+   this person" states the judgement, which is what is stored. Policy's own
+   outcome vocabulary is approval, restriction, or denial — a pass/fail framing
+   has nowhere to put the middle one.
+3. **`clear` never means erase.** Undoing attestations is **discard**. Erasing a
+   person's clearance date is **remove**. `clear` is reserved for the outcome
+   above — and as a **verb on a button** it reads as *reset* even so, which is why
+   the reviewer queue names the outcome with the noun (*complete the clearance*),
+   not the verb.
 4. **"Attest" is the reviewer's word alone.** An applicant **consents**; a Tool
    Certifier **certifies** (see Shop & Certification).
-   *(rename pending: `selfAttestBgConsent` → `selfRecordBgConsent`)*
 5. **`PENDING_BG_REVIEW` and `PENDING_BG_CLEARANCE` do not mark review vs
    clearance** — they differ by whether dues are paid. A known misnomer; the enum
    stays, because renaming a status reaches the schema, a migration, and the

--- a/checkin-app/src/app/api/membership-ops/applications/external/route.ts
+++ b/checkin-app/src/app/api/membership-ops/applications/external/route.ts
@@ -43,7 +43,7 @@ export const POST = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (
     //
     // The guard belongs on the route, not in the service: markContractSigned is also
     // the Zoho webhook's entry point (system actor), and markBgConsent is what
-    // selfAttestBgConsent calls, where the actor IS the applicant by design.
+    // selfRecordBgConsent calls, where the actor IS the applicant by design.
     const process = await prisma.orgMembershipProcess.findUnique({
         where: { id: processId },
         select: { orgMembershipId: true, subjectPersonId: true },

--- a/checkin-app/src/app/api/membership/bg-consent/route.ts
+++ b/checkin-app/src/app/api/membership/bg-consent/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth";
 import { logger } from "@/lib/logger";
-import { selfAttestBgConsent, ExternalError, type ExternalErrorCode } from "@/lib/membership/external";
+import { selfRecordBgConsent, ExternalError, type ExternalErrorCode } from "@/lib/membership/external";
 import { apiError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
@@ -19,7 +19,7 @@ const STATUS_BY_CODE: Record<ExternalErrorCode, number> = {
 
 /**
  * POST /api/membership/bg-consent — applicant-facing "I submitted my consent on
- * Averity" self-attestation (#875). Records consent on the caller's own process
+ * Averity" self-report (#875). Records consent on the caller's own process
  * awaiting external action via markBgConsent (applicant as audit actor), which
  * may advance the application to PENDING_PAYMENT. Honor-system by design; the
  * board's mark-bg-consent remains the backstop.
@@ -27,13 +27,13 @@ const STATUS_BY_CODE: Record<ExternalErrorCode, number> = {
 export const POST = withAuth({}, async (_req, auth) => {
     if (auth.type !== "session") return apiError("Unauthorized", 401);
     try {
-        const status = await selfAttestBgConsent(auth.user.id);
+        const status = await selfRecordBgConsent(auth.user.id);
         return NextResponse.json({ status });
     } catch (error) {
         if (error instanceof ExternalError) {
             return NextResponse.json({ error: error.message, code: error.code }, { status: STATUS_BY_CODE[error.code] });
         }
-        logger.error(`Membership bg-consent attest error: ${error instanceof Error ? error.message : String(error)}`);
+        logger.error(`Membership bg-consent error: ${error instanceof Error ? error.message : String(error)}`);
         return apiError("Internal Server Error", 500);
     }
 });

--- a/checkin-app/src/app/membership-audit/compliance/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/__tests__/page.test.tsx
@@ -67,7 +67,7 @@ describe("membership-audit/compliance page", () => {
     expect(screen.getByText(/Submitted their own consent/)).toBeInTheDocument();
     expect(screen.getByText(/No evidence either way/)).toBeInTheDocument();
     // Both leads get a button — the evidence is a label, not a decision.
-    expect(screen.getAllByRole("button", { name: "Clear this date" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Remove this date" })).toHaveLength(2);
     // The board's confirmed cutoff is the default, so the list starts narrowed.
     // Unfiltered on load: a list that already hides everything before the cutoff
     // cannot be used to confirm the cutoff.
@@ -82,9 +82,9 @@ describe("membership-audit/compliance page", () => {
     renderPage();
     await screen.findByText("Rivera Household");
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Clear this date" })[1]);
-    expect(await screen.findByText("Clear this background-check date?")).toBeInTheDocument();
-    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Clear the date" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove this date" })[1]);
+    expect(await screen.findByText("Remove this background-check date?")).toBeInTheDocument();
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Remove the date" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(

--- a/checkin-app/src/app/membership-audit/compliance/page.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/page.tsx
@@ -163,12 +163,12 @@ export default function CompliancePage() {
     }
   };
 
-  // Clear one person's background-check date. Not a new capability: the same
+  // Remove one person's background-check date. Not a new capability: the same
   // board-gated PUT the participants edit modal already uses, one person at a time,
   // audited with the acting board member as the actor. It never touches a process or
   // its bgClearedAt, and it can never cost a household its membership — one checked
   // adult is all membership requires, so the worst case is a redundant re-check.
-  const clearStamp = async (personId: number) => {
+  const removeStamp = async (personId: number) => {
     setBusyId(personId);
     try {
       const res = await fetch(`/api/membership-ops/participants/${personId}`, {
@@ -178,10 +178,10 @@ export default function CompliancePage() {
       });
       if (res.ok) {
         setClearedStampIds((s) => new Set(s).add(personId));
-        notifications.show({ message: "Stamp cleared — they will show up as needing a check." });
+        notifications.show({ message: "Date removed — they will show up as needing a check." });
       } else {
         const data = await res.json().catch(() => ({}));
-        notifications.show({ color: "red", message: data.error || "Could not clear the stamp." });
+        notifications.show({ color: "red", message: data.error || "Could not remove the date." });
       }
     } catch {
       notifications.show({ color: "red", message: "Network error." });
@@ -190,9 +190,9 @@ export default function CompliancePage() {
     }
   };
 
-  const confirmClearStamp = (row: BlanketStampedRow, lead: BlanketStampedRow["leads"][number]) =>
+  const confirmRemoveStamp = (row: BlanketStampedRow, lead: BlanketStampedRow["leads"][number]) =>
     modals.openConfirmModal({
-      title: "Clear this background-check date?",
+      title: "Remove this background-check date?",
       children: (
         <Text size="sm">
           This removes <strong>{lead.name}</strong>&apos;s background-check date, so they will be
@@ -201,9 +201,9 @@ export default function CompliancePage() {
           adult. Do this when their report is not the one that was reviewed.
         </Text>
       ),
-      labels: { confirm: "Clear the date", cancel: "Cancel" },
+      labels: { confirm: "Remove the date", cancel: "Cancel" },
       confirmProps: { color: "orange" },
-      onConfirm: () => clearStamp(lead.personId),
+      onConfirm: () => removeStamp(lead.personId),
     });
 
   const load = useCallback(async (since: string) => {
@@ -325,7 +325,7 @@ export default function CompliancePage() {
         <Title order={4}>Background-check dates to confirm</Title>
         <Text c="dimmed" size="sm">
           These households had one check approved, but every lead was marked checked. Confirm who
-          actually had the check and clear the others. Clearing the wrong one costs a redundant
+          actually had the check and remove the others. Removing the wrong one costs a redundant
           re-check, never a membership.
         </Text>
         <TextInput
@@ -371,9 +371,9 @@ export default function CompliancePage() {
                           color="orange"
                           loading={busyId === lead.personId}
                           disabled={busyId === lead.personId}
-                          onClick={() => confirmClearStamp(row, lead)}
+                          onClick={() => confirmRemoveStamp(row, lead)}
                         >
-                          Clear this date
+                          Remove this date
                         </Button>
                       )}
                     </Group>

--- a/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/applications/__tests__/page.test.tsx
@@ -172,10 +172,10 @@ describe("AdminMembershipPage", () => {
         await screen.findByText("Payment Family");
 
         // Only the in-review row with an approval on it offers the reset.
-        const reset = screen.getByRole("button", { name: "Clear approvals — start the review over" });
+        const reset = screen.getByRole("button", { name: "Discard approvals — start the review over" });
         fireEvent.click(reset);
         expect(await screen.findByText("Start this background-check review over?")).toBeInTheDocument();
-        fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Clear approvals" }));
+        fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Discard approvals" }));
 
         await waitFor(() =>
             expect(fetchMock).toHaveBeenCalledWith(

--- a/checkin-app/src/app/membership-ops/applications/page.tsx
+++ b/checkin-app/src/app/membership-ops/applications/page.tsx
@@ -199,7 +199,7 @@ function ApplicationsBoard() {
           mistake — the check itself has not cleared yet, so nothing else changes.
         </Text>
       ),
-      labels: { confirm: "Clear approvals", cancel: "Cancel" },
+      labels: { confirm: "Discard approvals", cancel: "Cancel" },
       onConfirm: () => override(r.id, "reset"),
     });
   };
@@ -415,10 +415,10 @@ function ApplicationsBoard() {
                     Background check (in parallel) — <Text component="span" fw={600}>{approvals(r)}/2</Text> approvals recorded.
                   </Text>
                   {/* The board's way back from a reviewer's misclick: the review is still
-                      open, so clearing the attestations undoes it with nothing to unwind. */}
+                      open, so discarding the attestations undoes it with nothing to unwind. */}
                   {approvals(r) > 0 && (
                     <Button size="xs" fz={15} variant="default" disabled={busyId === r.id || ownHousehold(r)} onClick={() => confirmResetReview(r)}>
-                      Clear approvals — start the review over
+                      Discard approvals — start the review over
                     </Button>
                   )}
                 </Group>

--- a/checkin-app/src/app/membership-ops/participants/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/page.tsx
@@ -452,7 +452,7 @@ export default function AdminParticipantsIndex() {
             <TextInput
               type="date"
               label="Last Background Check Review"
-              description="Date the board last reviewed this person's background check. Clear the field to remove it."
+              description="Date the board last reviewed this person's background check. Leave the field blank to remove it."
               value={editForm.lastBackgroundCheck}
               onChange={(e) => { const value = e.currentTarget.value; setEditForm(f => ({ ...f, lastBackgroundCheck: value })); }}
             />

--- a/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
@@ -66,9 +66,9 @@ describe("membership-ops/review page", () => {
     renderPage();
     await screen.findByText("The Smiths");
 
-    expect(screen.getByRole("button", { name: "Attest — the check passed" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Attest — approve this person" })).toBeDisabled();
     nameSubject("Sam Smith");
-    expect(screen.getByRole("button", { name: "Attest — the check passed" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Attest — approve this person" })).toBeEnabled();
   });
 
   it("approves an attestation", async () => {
@@ -77,13 +77,13 @@ describe("membership-ops/review page", () => {
     renderPage();
     await screen.findByText("The Smiths");
 
-    fireEvent.click(screen.getByRole("button", { name: "Attest — the check passed" }));
+    fireEvent.click(screen.getByRole("button", { name: "Attest — approve this person" }));
     // Pat already holds one approval, so naming Pat is the SECOND — the confirm names
     // the consequence of a clearing approve rather than a generic "are you sure?".
-    expect(await screen.findByText("Attest that this background check passed?")).toBeInTheDocument();
+    expect(await screen.findByText("Approve the background check clearance?")).toBeInTheDocument();
     expect(screen.getByText(/emails the family/)).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledTimes(1); // the queue GET only — nothing posted yet
-    fireEvent.click(screen.getByRole("button", { name: "Confirm — the check passed" }));
+    fireEvent.click(screen.getByRole("button", { name: "Attest — approve the clearance" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
@@ -103,10 +103,10 @@ describe("membership-ops/review page", () => {
     renderPage();
     await screen.findByText("The Smiths");
 
-    fireEvent.click(screen.getByRole("button", { name: "Attest — the check passed" }));
+    fireEvent.click(screen.getByRole("button", { name: "Attest — approve this person" }));
     fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
 
-    await waitFor(() => expect(screen.queryByText("Attest that this background check passed?")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText("Approve the background check clearance?")).not.toBeInTheDocument());
     expect(fetchMock).toHaveBeenCalledTimes(1); // the queue GET only
   });
 
@@ -117,10 +117,10 @@ describe("membership-ops/review page", () => {
     await screen.findByText("The Smiths");
 
     nameSubject("Pat Smith");
-    fireEvent.click(screen.getByRole("button", { name: "Attest — the check passed" }));
-    expect(await screen.findByText("Record your approval?")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Attest — approve this person" }));
+    expect(await screen.findByText("Record your attestation?")).toBeInTheDocument();
     expect(screen.getByText(/A second\s+reviewer must also\s+approve/)).toBeInTheDocument();
-    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Approve" }));
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Attest" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -126,7 +126,7 @@ export default function MembershipReviewPage() {
   };
 
   // Attesting is a one-click, two-of-two decision, and the SECOND approval
-  // completes the check — stamping the named adult, opening payment or activating, and
+  // completes the clearance — stamping the named adult, opening payment or activating, and
   // emailing the family. Confirm both actions, and say what the click actually does
   // rather than "are you sure?", which trains people to click through.
   const confirmSubmit = (item: QueueItem, result: "APPROVE" | "REJECT") => {
@@ -135,7 +135,7 @@ export default function MembershipReviewPage() {
     // by then, so an existing attestation is enough to know this click is the last one.
     const clearing = result === "APPROVE" && item._count.attestations >= 1;
     modals.openConfirmModal({
-      title: result === "REJECT" ? "Reject this background check?" : clearing ? "Attest that this background check passed?" : "Record your approval?",
+      title: result === "REJECT" ? "Reject this background check?" : clearing ? "Approve the background check clearance?" : "Record your attestation?",
       children: (
         <Text size="sm">
           {result === "REJECT" ? (
@@ -145,8 +145,8 @@ export default function MembershipReviewPage() {
             </>
           ) : clearing ? (
             <>
-              You are the second reviewer for <strong>{who}</strong>. Attesting that the check passed
-              records that against {item.subjectPerson ? "the subject" : leadName(item, chosenSubject(item)!)},
+              You are the second reviewer for <strong>{who}</strong>. Attesting completes the clearance,
+              records it against {item.subjectPerson ? "the subject" : leadName(item, chosenSubject(item)!)},
               opens payment (or activates the membership if the fee is already paid), and emails the
               family. It cannot be undone.
             </>
@@ -154,12 +154,12 @@ export default function MembershipReviewPage() {
             <>
               This records your approval of <strong>{who}</strong>&apos;s background check
               {item.subjectPerson ? "" : ` for ${leadName(item, chosenSubject(item)!)}`}. A second
-              reviewer must also approve the same person before the check passes.
+              reviewer must also approve the same person before the clearance completes.
             </>
           )}
         </Text>
       ),
-      labels: { confirm: result === "REJECT" ? "Reject" : clearing ? "Confirm — the check passed" : "Approve", cancel: "Cancel" },
+      labels: { confirm: result === "REJECT" ? "Reject" : clearing ? "Attest — approve the clearance" : "Attest", cancel: "Cancel" },
       confirmProps: { color: result === "REJECT" ? "red" : clearing ? "orange" : undefined },
       onConfirm: () => submit(item.id, result),
     });
@@ -288,7 +288,7 @@ export default function MembershipReviewPage() {
                   loading={busyId === item.id}
                   onClick={() => confirmSubmit(item, "APPROVE")}
                 >
-                  Attest — the check passed
+                  Attest — approve this person
                 </Button>
                 <Button color="red" variant="light" disabled={busyId === item.id || !reviewNotes[item.id]?.trim()} onClick={() => confirmSubmit(item, "REJECT")}>
                   Reject

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -159,11 +159,11 @@ export default function MembershipPage() {
   // request as received rather than resurrecting the button.
   const [planRequested, setPlanRequested] = useState(false);
   const [confirmPlanOpened, { open: openConfirmPlan, close: closeConfirmPlan }] = useDisclosure(false);
-  // Self-attest gate for the background-check task (#875): the confirm checkbox
+  // Self-report gate for the background-check task (#875): the confirm checkbox
   // unlocks only after the applicant has opened the Averity consent link this
-  // visit, so they can't attest to a form they never saw.
+  // visit, so they can't confirm a form they never saw.
   const [bgLinkOpened, setBgLinkOpened] = useState(false);
-  const [bgAttesting, setBgAttesting] = useState(false);
+  const [bgConsenting, setBgConsenting] = useState(false);
   // Serialized form as last loaded/saved; isDirty compares it to current state.
   const [savedForm, setSavedForm] = useState<string | null>(null);
 
@@ -597,8 +597,8 @@ export default function MembershipPage() {
   // Applicant confirms they submitted consent on Averity. On success the reload
   // flips the task to done (and may advance the whole card to payment); on
   // failure the checkbox reverts so they can retry.
-  const attestBgConsent = async () => {
-    setBgAttesting(true);
+  const recordBgConsent = async () => {
+    setBgConsenting(true);
     try {
       const res = await fetch("/api/membership/bg-consent", { method: "POST" });
       const data = await res.json().catch(() => ({}));
@@ -606,11 +606,11 @@ export default function MembershipPage() {
         await load();
         notifyNavRefresh();
       } else {
-        setBgAttesting(false);
+        setBgConsenting(false);
         flash(apiError(data, "Could not record your consent. Please try again."), true);
       }
     } catch {
-      setBgAttesting(false);
+      setBgConsenting(false);
       notifications.show({ color: "red", message: "Network error.", autoClose: false });
     }
   };
@@ -915,9 +915,9 @@ export default function MembershipPage() {
                             <Checkbox
                               label="I submitted my consent on Averity"
                               description={bgLinkOpened ? undefined : "Open the Averity form above first, then confirm here."}
-                              checked={bgAttesting}
-                              disabled={!bgLinkOpened || bgAttesting}
-                              onChange={(e) => { if (e.currentTarget.checked) attestBgConsent(); }}
+                              checked={bgConsenting}
+                              disabled={!bgLinkOpened || bgConsenting}
+                              onChange={(e) => { if (e.currentTarget.checked) recordBgConsent(); }}
                             />
                           </>
                         ) : (

--- a/checkin-app/src/lib/membership/__tests__/external.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/external.test.ts
@@ -10,7 +10,7 @@
  *   - advanceExternalIfComplete: the volunteer-designation allowlist is matched
  *     at the PENDING_PAYMENT transition (#874) — and only by the race winner.
  */
-import { setZohoEnvelope, findProcessByEnvelope, getOrCreateContractSigningUrl, selfAttestBgConsent, advanceExternalIfComplete, ExternalError } from '@/lib/membership/external';
+import { setZohoEnvelope, findProcessByEnvelope, getOrCreateContractSigningUrl, selfRecordBgConsent, advanceExternalIfComplete, ExternalError } from '@/lib/membership/external';
 
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
@@ -118,7 +118,7 @@ describe('findProcessByEnvelope', () => {
     });
 });
 
-describe('selfAttestBgConsent', () => {
+describe('selfRecordBgConsent', () => {
     const pendingProcess = {
         id: 20,
         status: 'PENDING_EXTERNAL_ACTION',
@@ -137,17 +137,17 @@ describe('selfAttestBgConsent', () => {
 
     it('not_found when the user does not exist', async () => {
         prisma.person.findUnique.mockResolvedValue(null);
-        await expect(selfAttestBgConsent(1)).rejects.toMatchObject({ code: 'not_found' });
+        await expect(selfRecordBgConsent(1)).rejects.toMatchObject({ code: 'not_found' });
     });
 
     it('no_household when the user has no household', async () => {
         prisma.person.findUnique.mockResolvedValue({ ...leadUser, householdId: null });
-        await expect(selfAttestBgConsent(1)).rejects.toMatchObject({ code: 'no_household' });
+        await expect(selfRecordBgConsent(1)).rejects.toMatchObject({ code: 'no_household' });
     });
 
     it('not_lead when the caller is not a household lead and not a sysadmin', async () => {
         prisma.person.findUnique.mockResolvedValue({ ...leadUser, isHouseholdLead: false });
-        await expect(selfAttestBgConsent(1)).rejects.toMatchObject({ code: 'not_lead' });
+        await expect(selfRecordBgConsent(1)).rejects.toMatchObject({ code: 'not_lead' });
     });
 
     it('wrong_phase when no process is awaiting external action', async () => {
@@ -155,7 +155,7 @@ describe('selfAttestBgConsent', () => {
             ...leadUser,
             household: { orgMembership: { processes: [{ ...pendingProcess, status: 'PENDING_PAYMENT' }] } },
         });
-        await expect(selfAttestBgConsent(1)).rejects.toMatchObject({ code: 'wrong_phase' });
+        await expect(selfRecordBgConsent(1)).rejects.toMatchObject({ code: 'wrong_phase' });
     });
 
     it('records consent with the applicant as the audit actor and returns the external status', async () => {
@@ -167,7 +167,7 @@ describe('selfAttestBgConsent', () => {
             // advanceExternalIfComplete re-read: consent set, contract still unsigned → no advance
             .mockResolvedValueOnce({ ...pendingProcess, bgConsentAt: new Date() });
 
-        const status = await selfAttestBgConsent(1);
+        const status = await selfRecordBgConsent(1);
 
         expect(prisma.orgMembershipProcess.updateMany).toHaveBeenCalledWith(
             expect.objectContaining({ where: { id: 20, bgConsentAt: null } }),

--- a/checkin-app/src/lib/membership/background-check/manual-adapter.ts
+++ b/checkin-app/src/lib/membership/background-check/manual-adapter.ts
@@ -6,7 +6,7 @@ import type { BackgroundCheckProvider } from "./provider";
  *
  * Consent link comes from the AVERITY_CONSENT_URL env var (Averity exposes no API,
  * so it's a static hosted deep link, configured out-of-band rather than board-edited).
- * After submitting on Averity the applicant self-attests in-app (#875); a board
+ * After submitting on Averity the applicant self-reports in-app (#875); a board
  * member — who receives Averity's email — can also mark it as the backstop.
  */
 export class ManualBackgroundCheckProvider implements BackgroundCheckProvider {

--- a/checkin-app/src/lib/membership/external.ts
+++ b/checkin-app/src/lib/membership/external.ts
@@ -21,8 +21,8 @@ import { systemActor, personOrSystemActor } from "@/lib/auditActor";
  * the final ACTIVE transition waits on it.
  *
  * The contract is recorded automatically (Zoho webhook) or manually by the
- * board. BG consent is human-marked (no Averity API): the applicant self-attests
- * after submitting on Averity (selfAttestBgConsent, #875), with the board's
+ * board. BG consent is human-marked (no Averity API): the applicant self-reports
+ * after submitting on Averity (selfRecordBgConsent, #875), with the board's
  * mark-bg-consent action as the backstop. The system never sees contract content
  * or check results.
  *
@@ -195,16 +195,16 @@ export async function markBgConsent(processId: number, actorId: number) {
 }
 
 /**
- * Applicant self-attestation that they submitted background-check consent on
+ * Applicant self-report that they submitted background-check consent on
  * Averity (#875). Honor-system by design: Averity has no API, so the applicant's
  * own claim records consent the same way a board mark does — through
- * markBgConsent, with the applicant as the audit actor, so a self-attested
+ * markBgConsent, with the applicant as the audit actor, so a self-reported
  * consent stays distinguishable from a board-confirmed one. The board
  * mark-bg-consent action remains as the backstop. Idempotent (markBgConsent
  * no-ops on a second call), and restricted to a household lead — the person who
  * actually consents on Averity.
  */
-export async function selfAttestBgConsent(userId: number): Promise<ExternalStatus> {
+export async function selfRecordBgConsent(userId: number): Promise<ExternalStatus> {
     const user = await prisma.person.findUnique({
         where: { id: userId },
         include: {


### PR DESCRIPTION
Fixes #1580. Applies the vocabulary settled in #1579 — a reviewer **reviews** the
Averity report, **attests** to a judgement about one adult, and two attestations
produce a **clearance**. `clear` names that outcome and never means *erase*; the
applicant **consents**.

Copy and identifiers only. No schema, no `src/security/`, no wire keys, no route paths.

## The reviewer queue

Scope added after @jee7s settled the deferred question on this PR in favour of the
dictionary. #1592 removed "clean" but replaced it with "passed", which states an
outcome of the report — the same claim, and the app never holds the report.

The objection #1592 was fixing was never the word *clearance*; it was `clear` as a
**verb** on a button reading as *reset*, next to Reject and on a screen whose sibling
control said "Clear approvals" for discard. The noun doesn't have that problem.

| | Was (#1592) | Now |
|---|---|---|
| Row button | Attest — the check passed | **Attest — approve this person** |
| 2nd-reviewer title | Attest that this background check passed? | **Approve the background check clearance?** |
| 2nd-reviewer confirm | Confirm — the check passed | **Attest — approve the clearance** |
| 1st-reviewer title | Record your approval? | **Record your attestation?** |
| 1st-reviewer confirm | Approve | **Attest** |

Row and modal keep distinct accessible names — the row proposes, the modal commits.
That was #1592's own finding and it stands.

## `clear` meant erase in two places

Both acted on the clearance itself.

`membership-ops/applications/page.tsx` — "Clear approvals" sat three lines below "the
check itself has not cleared yet" inside one confirm modal. Now **Discard approvals**.

`membership-audit/compliance/page.tsx` — the entire erase path for a person's
background-check date (handler, button, modal title, confirm label, toast) was built
on "clear". Now **Remove**, the verb its own body text already used. 8 sites, 4 assertions.

`membership-ops/participants/page.tsx` — "Clear the field to remove it" → "Leave the
field blank to remove it".

## The applicant does not attest

`selfAttestBgConsent` → `selfRecordBgConsent`, plus surrounding prose and the
page-local `bgAttesting` / `attestBgConsent`. Kept the `self` prefix rather than the
plain `recordBgConsent` named in #1580: `markBgConsent` is exported and called from
seven places, and a bare `recordBgConsent` wrapping it would be a coin flip at every
call site.

## Dictionary

Drops the three `(rename pending)` markers this PR satisfies, and records **"passed"**
alongside **"clean"** as words the dictionary rules out, with the reason, so it isn't
re-derived. Rule 3 now says explicitly that `clear` is fine as the outcome noun and
wrong as a button verb — the distinction the #1592 discussion turned on.

## Note on the audit

The compliance page's erase path was **not** in the audit behind #1579, and I reported
"0 test assertions" for the applications page when there were two — one sweep ran from
the wrong directory and returned a false zero. Re-swept; `clear`-as-erase is at zero
across the membership surface, with generic UI uses (`Clear filter`, `onClear`) and
correct outcome uses (`bgClearedAt`, "reviewers clear it") left alone.

## Checks

`tsc --noEmit` clean, `eslint --max-warnings 0` clean, full unit suite 2710 passed /
278 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)