### PR TITLE
refactor(vocab): retire "dues" for "membership fee" on BoardSettings

### DIFF
--- a/checkin-app/docs/VOCABULARY.md
+++ b/checkin-app/docs/VOCABULARY.md
@@ -100,7 +100,7 @@ Rules:
 
 ## Money
 
-**The canonical money word is `fee`.** Kinds: **membership fee** *(rename pending from "dues": `normalDuesCents`→`standardMembershipFeeCents`, `volunteerDuesCents`→`volunteerMembershipFeeCents`)*, **program fee** (`Fee`), plus **shop fee** and **facility fee** (shop and facility are billed separately). `price` = the cents **amount** on a fee, not a rival concept.
+**The canonical money word is `fee`.** Kinds: **membership fee** (`BoardSettings.standardMembershipFeeCents`, `BoardSettings.volunteerMembershipFeeCents`), **program fee** (`Fee`), plus **shop fee** and **facility fee** (shop and facility are billed separately). `price` = the cents **amount** on a fee, not a rival concept.
 
 **Payment vs relief** (keep separate):
 - **Manual payment** — payment landed **outside Shopify** (recorded in QuickBooks), so a membership activates without a Shopify order. `via: "manual"` / `manualPaymentById` *(rename pending from `"certified"` / `certifiedById` — which collided with tool certification)*. **Not** a comp.

--- a/checkin-app/docs/designs/UNFINISHED.md
+++ b/checkin-app/docs/designs/UNFINISHED.md
@@ -140,11 +140,30 @@ _(VOCAB #17)_
 
 ---
 
-## 🟢 "dues" → "membership fee"
+## 🟢 Drop the `BoardSettings` membership-fee `@map` shims (contract stage)
 
-Canonical money word = **fee**. Rename `normalDuesCents` →
-`standardMembershipFeeCents`, `volunteerDuesCents` → `volunteerMembershipFeeCents`
-(kills the `normal`=non-member trap). Coordinate with P4's `*PriceCents` work.
+The "dues" → "membership fee" rename shipped the Prisma/API/UI half only. Both
+fields still carry an `@map` to their original physical column, so the DB columns
+are still named `normalDuesCents` / `volunteerDuesCents`:
+
+```prisma
+standardMembershipFeeCents  Int @default(0) @map("normalDuesCents")
+volunteerMembershipFeeCents Int @default(0) @map("volunteerDuesCents")
+```
+
+The physical rename is a **contract-stage** change (`DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md`
+rule 3): ~25 call sites read `BoardSettings` with a bare `findUnique`, so the
+previous release's Prisma client selects the old column names by hand and 500s
+for the whole rolling-deploy drain window if the columns are renamed underneath it.
+Once the shimmed release is fully rolled out, drop both `@map`s and hand-write:
+
+```sql
+BEGIN;
+ALTER TABLE "BoardSettings" RENAME COLUMN "normalDuesCents" TO "standardMembershipFeeCents";
+ALTER TABLE "BoardSettings" RENAME COLUMN "volunteerDuesCents" TO "volunteerMembershipFeeCents";
+COMMIT;
+```
+
 _(VOCAB #6)_
 
 ---

--- a/checkin-app/docs/designs/UNFINISHED.md
+++ b/checkin-app/docs/designs/UNFINISHED.md
@@ -142,28 +142,9 @@ _(VOCAB #17)_
 
 ## 🟢 Drop the `BoardSettings` membership-fee `@map` shims (contract stage)
 
-The "dues" → "membership fee" rename shipped the Prisma/API/UI half only. Both
-fields still carry an `@map` to their original physical column, so the DB columns
-are still named `normalDuesCents` / `volunteerDuesCents`:
-
-```prisma
-standardMembershipFeeCents  Int @default(0) @map("normalDuesCents")
-volunteerMembershipFeeCents Int @default(0) @map("volunteerDuesCents")
-```
-
-The physical rename is a **contract-stage** change (`DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md`
-rule 3): ~25 call sites read `BoardSettings` with a bare `findUnique`, so the
-previous release's Prisma client selects the old column names by hand and 500s
-for the whole rolling-deploy drain window if the columns are renamed underneath it.
-Once the shimmed release is fully rolled out, drop both `@map`s and hand-write:
-
-```sql
-BEGIN;
-ALTER TABLE "BoardSettings" RENAME COLUMN "normalDuesCents" TO "standardMembershipFeeCents";
-ALTER TABLE "BoardSettings" RENAME COLUMN "volunteerDuesCents" TO "volunteerMembershipFeeCents";
-COMMIT;
-```
-
+"dues" → "membership fee" shipped the Prisma/API/UI half; both fields still `@map`
+to the old physical columns, which a rolling deploy can't rename in the same
+release. Rename them once that release is out — [#1583](https://github.com/innovationtreehouse/checkin/issues/1583).
 _(VOCAB #6)_
 
 ---

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -571,10 +571,15 @@ model VolunteerDesignation {
 model BoardSettings {
   /// @sensitivity:public
   id                         Int       @id @default(1)
+  // The @maps keep the physical columns on their old names: a bare
+  // boardSettings.findUnique selects every column by name, so renaming them here
+  // would 500 the previous release for the whole rolling-deploy drain window.
+  // Contract stage (drop the @maps + ALTER ... RENAME COLUMN) is a later release
+  // — see docs/designs/UNFINISHED.md.
   /// @sensitivity:public
-  normalDuesCents            Int       @default(0)
+  standardMembershipFeeCents Int       @default(0) @map("normalDuesCents")
   /// @sensitivity:public
-  volunteerDuesCents         Int       @default(0)
+  volunteerMembershipFeeCents Int      @default(0) @map("volunteerDuesCents")
   /// @sensitivity:public
   orgMembershipYearBoundary  DateTime? @db.Date
   /// Shopify variant ID of the membership product everyone checks out through.

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -571,11 +571,10 @@ model VolunteerDesignation {
 model BoardSettings {
   /// @sensitivity:public
   id                         Int       @id @default(1)
-  // The @maps keep the physical columns on their old names: a bare
-  // boardSettings.findUnique selects every column by name, so renaming them here
-  // would 500 the previous release for the whole rolling-deploy drain window.
-  // Contract stage (drop the @maps + ALTER ... RENAME COLUMN) is a later release
-  // — see docs/designs/UNFINISHED.md.
+  // The @maps hold the physical columns on their old names: a bare
+  // boardSettings.findUnique selects every column by name, so the previous release
+  // reads these through a rolling deploy's drain window. Rename them in a later
+  // release (contract stage).
   /// @sensitivity:public
   standardMembershipFeeCents Int       @default(0) @map("normalDuesCents")
   /// @sensitivity:public

--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -76,7 +76,7 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         prevBoundary = existingSettings?.orgMembershipYearBoundary ?? null;
         await prisma.boardSettings.upsert({
             where: { id: 1 },
-            create: { id: 1, normalDuesCents: 0, volunteerDuesCents: 0, orgMembershipYearBoundary: BOUNDARY, bgRecheckMonths: BG_RECHECK_MONTHS },
+            create: { id: 1, standardMembershipFeeCents: 0, volunteerMembershipFeeCents: 0, orgMembershipYearBoundary: BOUNDARY, bgRecheckMonths: BG_RECHECK_MONTHS },
             update: { orgMembershipYearBoundary: BOUNDARY, bgRecheckMonths: BG_RECHECK_MONTHS },
         });
 

--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -53,7 +53,7 @@ describe('Membership payment API', () => {
     let gateProc: number, gateLeadId: number, gateNonLeadId: number;
     const prevWebhookSecret = process.env.SHOPIFY_WEBHOOK_SECRET;
     const prevStoreDomain = process.env.SHOPIFY_STORE_DOMAIN;
-    let prevSettings: { normalDuesCents: number; volunteerDuesCents: number; orgMembershipVariantId: string | null; volunteerDiscountCode: string | null } | null = null;
+    let prevSettings: { standardMembershipFeeCents: number; volunteerMembershipFeeCents: number; orgMembershipVariantId: string | null; volunteerDiscountCode: string | null } | null = null;
 
     async function makeProc(label: string, isVolunteer: boolean, withLead = false) {
         const hh = await prisma.household.create({ data: { name: `${label} ${TAG}` } });
@@ -86,10 +86,10 @@ describe('Membership payment API', () => {
         process.env.SHOPIFY_WEBHOOK_SECRET = WEBHOOK_SECRET;
         process.env.SHOPIFY_STORE_DOMAIN = STORE_DOMAIN;
         const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-        prevSettings = existing ? { normalDuesCents: existing.normalDuesCents, volunteerDuesCents: existing.volunteerDuesCents, orgMembershipVariantId: existing.orgMembershipVariantId, volunteerDiscountCode: existing.volunteerDiscountCode } : null;
+        prevSettings = existing ? { standardMembershipFeeCents: existing.standardMembershipFeeCents, volunteerMembershipFeeCents: existing.volunteerMembershipFeeCents, orgMembershipVariantId: existing.orgMembershipVariantId, volunteerDiscountCode: existing.volunteerDiscountCode } : null;
         const settingsData = {
-            normalDuesCents: 10000,
-            volunteerDuesCents: 2500,
+            standardMembershipFeeCents: 10000,
+            volunteerMembershipFeeCents: 2500,
             orgMembershipVariantId: VARIANT_ID,
             volunteerDiscountCode: DISCOUNT_CODE,
         };

--- a/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipRenewalAPI.integration.test.ts
@@ -59,7 +59,7 @@ describe('Membership renewal', () => {
     async function setBoundary(date: Date | null) {
         await prisma.boardSettings.upsert({
             where: { id: 1 },
-            create: { id: 1, normalDuesCents: 0, volunteerDuesCents: 0, orgMembershipYearBoundary: date, bgRecheckMonths: BG_RECHECK_MONTHS },
+            create: { id: 1, standardMembershipFeeCents: 0, volunteerMembershipFeeCents: 0, orgMembershipYearBoundary: date, bgRecheckMonths: BG_RECHECK_MONTHS },
             update: { orgMembershipYearBoundary: date, bgRecheckMonths: BG_RECHECK_MONTHS },
         });
     }

--- a/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipSettingsAPI.integration.test.ts
@@ -26,7 +26,7 @@ function jsonReq(method: string, body?: unknown, url = 'http://localhost:4000/x'
 
 describe('Membership settings + volunteer designations API', () => {
     let boardId: number, plainId: number;
-    let prevSettings: { normalDuesCents: number; volunteerDuesCents: number } | null = null;
+    let prevSettings: { standardMembershipFeeCents: number; volunteerMembershipFeeCents: number } | null = null;
 
     async function wipe() {
         await prisma.volunteerDesignation.deleteMany({ where: { email: { contains: TAG } } });
@@ -42,7 +42,7 @@ describe('Membership settings + volunteer designations API', () => {
 
     beforeAll(async () => {
         const existing = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-        prevSettings = existing ? { normalDuesCents: existing.normalDuesCents, volunteerDuesCents: existing.volunteerDuesCents } : null;
+        prevSettings = existing ? { standardMembershipFeeCents: existing.standardMembershipFeeCents, volunteerMembershipFeeCents: existing.volunteerMembershipFeeCents } : null;
         await wipe();
 
         boardId = (await prisma.person.create({ data: { email: `board-${TAG}@example.com`, name: 'Board', isBoardMember: true, household: { create: { name: `Board HH ${TAG}` } } } })).id;
@@ -71,11 +71,11 @@ describe('Membership settings + volunteer designations API', () => {
         const getRes = await SETTINGS_GET(jsonReq('GET'));
         expect(getRes.status).toBe(200);
 
-        const putRes = await SETTINGS_PUT(jsonReq('PUT', { normalDuesCents: 12000, volunteerDuesCents: 3000 }));
+        const putRes = await SETTINGS_PUT(jsonReq('PUT', { standardMembershipFeeCents: 12000, volunteerMembershipFeeCents: 3000 }));
         expect(putRes.status).toBe(200);
         const { settings } = await putRes.json();
-        expect(settings.normalDuesCents).toBe(12000);
-        expect(settings.volunteerDuesCents).toBe(3000);
+        expect(settings.standardMembershipFeeCents).toBe(12000);
+        expect(settings.volunteerMembershipFeeCents).toBe(3000);
     });
 
     it('saves and clears the membership product URL', async () => {
@@ -94,17 +94,17 @@ describe('Membership settings + volunteer designations API', () => {
     it('rejects negative dues and keeps the previous value', async () => {
         asBoard(boardId);
         // Establish a known good value.
-        const seed = await SETTINGS_PUT(jsonReq('PUT', { normalDuesCents: 12000 }));
+        const seed = await SETTINGS_PUT(jsonReq('PUT', { standardMembershipFeeCents: 12000 }));
         expect(seed.status).toBe(200);
 
         // Negative input must be rejected, not clamped to zero.
-        const res = await SETTINGS_PUT(jsonReq('PUT', { normalDuesCents: -50 }));
+        const res = await SETTINGS_PUT(jsonReq('PUT', { standardMembershipFeeCents: -50 }));
         expect(res.status).toBe(400);
 
         // Old value survives untouched.
         const getRes = await SETTINGS_GET(jsonReq('GET'));
         const { settings } = await getRes.json();
-        expect(settings.normalDuesCents).toBe(12000);
+        expect(settings.standardMembershipFeeCents).toBe(12000);
     });
 
     it('accepts a positive scholarshipDenialGraceDays and clears it back to null', async () => {

--- a/checkin-app/src/app/api/outreach/__tests__/ledger.integration.test.ts
+++ b/checkin-app/src/app/api/outreach/__tests__/ledger.integration.test.ts
@@ -54,7 +54,7 @@ function req(method: string, body?: unknown) {
 async function setBoundary(date: Date | null) {
     await prisma.boardSettings.upsert({
         where: { id: 1 },
-        create: { id: 1, normalDuesCents: 0, volunteerDuesCents: 0, orgMembershipYearBoundary: date },
+        create: { id: 1, standardMembershipFeeCents: 0, volunteerMembershipFeeCents: 0, orgMembershipYearBoundary: date },
         update: { orgMembershipYearBoundary: date },
     });
 }

--- a/checkin-app/src/app/api/outreach/__tests__/recipients.integration.test.ts
+++ b/checkin-app/src/app/api/outreach/__tests__/recipients.integration.test.ts
@@ -19,7 +19,7 @@ const OFF_SEASON_NOW = new Date(Date.UTC(2026, 0, 15)); // Jan 15 — well outsi
 async function setBoundary(date: Date | null) {
     await prisma.boardSettings.upsert({
         where: { id: 1 },
-        create: { id: 1, normalDuesCents: 0, volunteerDuesCents: 0, orgMembershipYearBoundary: date },
+        create: { id: 1, standardMembershipFeeCents: 0, volunteerMembershipFeeCents: 0, orgMembershipYearBoundary: date },
         update: { orgMembershipYearBoundary: date },
     });
 }

--- a/checkin-app/src/app/api/settings/membership/route.ts
+++ b/checkin-app/src/app/api/settings/membership/route.ts
@@ -6,7 +6,7 @@ import { config } from "@/lib/config";
 
 export const dynamic = "force-dynamic";
 
-const DEFAULTS = { id: 1, normalDuesCents: 0, volunteerDuesCents: 0 };
+const DEFAULTS = { id: 1, standardMembershipFeeCents: 0, volunteerMembershipFeeCents: 0 };
 
 /** GET /api/settings/membership — board settings singleton (created on first read). */
 export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async () => {
@@ -16,19 +16,19 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async ()
 
 /**
  * PUT /api/settings/membership — update board settings.
- * Body may include: normalDuesCents, volunteerDuesCents, orgMembershipYearBoundary (ISO|null),
+ * Body may include: standardMembershipFeeCents, volunteerMembershipFeeCents, orgMembershipYearBoundary (ISO|null),
  * orgMembershipVariantId (string|null),
  * orgMembershipProductUrl (string|null), volunteerDiscountCode (string|null),
  * scholarshipDenialGraceDays (positive int|null — null disables the grace-period expiry cron).
- * Dues must be finite and >= 0; an invalid value rejects the whole update (400) so the
+ * Membership fees must be finite and >= 0; an invalid value rejects the whole update (400) so the
  * previous value survives rather than silently collapsing to zero. (The Averity consent
  * link is an env var, not a board setting. Email sender identity lives in /api/settings/email.)
  */
 export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (req, auth) => {
     if (auth.type !== "session") return apiError("Unauthorized", 401);
     let body: {
-        normalDuesCents?: number;
-        volunteerDuesCents?: number;
+        standardMembershipFeeCents?: number;
+        volunteerMembershipFeeCents?: number;
         orgMembershipYearBoundary?: string | null;
         orgMembershipVariantId?: string | null;
         orgMembershipProductUrl?: string | null;
@@ -44,14 +44,14 @@ export const PUT = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
     }
 
     const data: Record<string, unknown> = {};
-    const invalidDues = (v: number) => !Number.isFinite(v) || v < 0;
-    if (body.normalDuesCents !== undefined) {
-        if (invalidDues(body.normalDuesCents)) return apiError("normalDuesCents must be a number >= 0", 400);
-        data.normalDuesCents = Math.round(body.normalDuesCents);
+    const invalidFee = (v: number) => !Number.isFinite(v) || v < 0;
+    if (body.standardMembershipFeeCents !== undefined) {
+        if (invalidFee(body.standardMembershipFeeCents)) return apiError("standardMembershipFeeCents must be a number >= 0", 400);
+        data.standardMembershipFeeCents = Math.round(body.standardMembershipFeeCents);
     }
-    if (body.volunteerDuesCents !== undefined) {
-        if (invalidDues(body.volunteerDuesCents)) return apiError("volunteerDuesCents must be a number >= 0", 400);
-        data.volunteerDuesCents = Math.round(body.volunteerDuesCents);
+    if (body.volunteerMembershipFeeCents !== undefined) {
+        if (invalidFee(body.volunteerMembershipFeeCents)) return apiError("volunteerMembershipFeeCents must be a number >= 0", 400);
+        data.volunteerMembershipFeeCents = Math.round(body.volunteerMembershipFeeCents);
     }
     if (body.orgMembershipYearBoundary !== undefined) {
         data.orgMembershipYearBoundary = body.orgMembershipYearBoundary ? new Date(body.orgMembershipYearBoundary) : null;

--- a/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
@@ -181,7 +181,7 @@ export default function MembershipPaymentPlansPage() {
     <Stack>
       <Text c="dimmed">
         Review households that have requested a scholarship or payment plan for their membership
-        dues. Approving a request activates the membership without a Shopify payment (it still holds
+        fee. Approving a request activates the membership without a Shopify payment (it still holds
         for background clearance if that isn&apos;t done yet).
       </Text>
 
@@ -227,7 +227,7 @@ export default function MembershipPaymentPlansPage() {
         centered
       >
         <Text mb="lg">
-          Deny this request? The household stays awaiting payment and can still pay their dues
+          Deny this request? The household stays awaiting payment and can still pay their membership fee
           normally to activate, or re-request later. No automatic email is sent — contact the
           household to let them know.
         </Text>

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -147,7 +147,7 @@ export default function MembershipReviewPage() {
             <>
               You are the second reviewer for <strong>{who}</strong>. Attesting the check is clean
               records that against {item.subjectPerson ? "the subject" : leadName(item, chosenSubject(item)!)},
-              opens payment (or activates the membership if dues are already paid), and emails the
+              opens payment (or activates the membership if the fee is already paid), and emails the
               family. It cannot be undone.
             </>
           ) : (

--- a/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
+++ b/checkin-app/src/app/membership-ops/volunteer-memberships/page.tsx
@@ -84,7 +84,7 @@ export default function VolunteerMembershipsPage() {
         <Title order={3} mb="xs">Volunteer-only designated emails</Title>
         <Text c="dimmed" mb="md">
           If one of these emails applies for membership, that whole household is treated as a
-          volunteer only family (lower dues).
+          volunteer only family (lower membership fee).
         </Text>
         <Group gap="sm" wrap="wrap" mb="md" align="flex-end">
           <TextInput

--- a/checkin-app/src/app/membership/page.tsx
+++ b/checkin-app/src/app/membership/page.tsx
@@ -284,7 +284,7 @@ export default function MembershipPage() {
     })();
   }, [sessionStatus, load]);
 
-  // When awaiting payment, fetch the dues amount and Shopify checkout link. Leads
+  // When awaiting payment, fetch the membership-fee amount and Shopify checkout link. Leads
   // only — the route refuses anyone else, and the card hides the money from them.
   useEffect(() => {
     if (state?.process?.status !== "PENDING_PAYMENT" || !state.isLead) return;
@@ -354,7 +354,7 @@ export default function MembershipPage() {
 
   // Local dev has no Shopify store, so instead of a checkout redirect we fire the
   // mock orders/paid webhook in-app (same endpoint the Debug → Shopify tool uses),
-  // settling dues end-to-end with zero setup. Only rendered on a local instance.
+  // settling the membership fee end-to-end with zero setup. Only rendered on a local instance.
   const settleMockPayment = async () => {
     if (!state?.process) return;
     setSaving(true);
@@ -541,7 +541,7 @@ export default function MembershipPage() {
     // On success we navigate away, so we intentionally leave `saving` true.
   };
 
-  // Ask the board's Scholarship Review Team for a payment plan on membership dues.
+  // Ask the board's Scholarship Review Team for a payment plan on the membership fee.
   // Mirrors the program-page request; the finance-ops Membership Payment Plan tab
   // picks it up and activates the membership on approval (no Shopify payment).
   // Mirrors the server flag both ways (not just true->true) so a denial that

--- a/checkin-app/src/app/settings/email/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/email/__tests__/page.test.tsx
@@ -126,7 +126,7 @@ describe("EmailSettingsPage", () => {
 
     const subject = await screen.findByLabelText(/Scholarship ACK subject/i);
     expect(subject).toHaveValue("Custom subject");
-    const membershipBody = screen.getByLabelText(/Scholarship ACK body — membership dues request/i);
+    const membershipBody = screen.getByLabelText(/Scholarship ACK body — membership fee request/i);
     expect(membershipBody).toHaveValue("");
     expect(membershipBody).toHaveAttribute("placeholder", DEFAULT_ACK_MEMBERSHIP_BODY);
     const programBody = screen.getByLabelText(/Scholarship ACK body — program request/i);

--- a/checkin-app/src/app/settings/email/page.tsx
+++ b/checkin-app/src/app/settings/email/page.tsx
@@ -200,7 +200,7 @@ export default function EmailSettingsPage() {
               disabled={locked}
             />
             <Textarea
-              label="Scholarship ACK body — membership dues request"
+              label="Scholarship ACK body — membership fee request"
               description="Plain text (blank lines separate paragraphs) — not HTML. Blank = default shown below."
               placeholder={DEFAULT_ACK_MEMBERSHIP_BODY}
               minRows={3}

--- a/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
+++ b/checkin-app/src/app/settings/membership/__tests__/page.test.tsx
@@ -10,8 +10,8 @@ import { notifications } from "@mantine/notifications";
 import MembershipSettingsPage from "../page";
 
 const SETTINGS = {
-  normalDuesCents: 15000,
-  volunteerDuesCents: 5000,
+  standardMembershipFeeCents: 15000,
+  volunteerMembershipFeeCents: 5000,
   orgMembershipYearBoundary: "2025-09-01T00:00:00.000Z",
   orgMembershipVariantId: "123456",
   orgMembershipProductUrl: "https://test-store.myshopify.com/products/annual-membership",
@@ -43,15 +43,15 @@ describe("MembershipSettingsPage", () => {
     const fetchMock = mockFetchJson({ "/api/settings/membership": { settings: SETTINGS } });
     renderWithProviders(<MembershipSettingsPage />);
 
-    const normalDues = await screen.findByDisplayValue("150.00");
-    fireEvent.change(normalDues, { target: { value: "200.00" } });
+    const standardFee = await screen.findByDisplayValue("150.00");
+    fireEvent.change(standardFee, { target: { value: "200.00" } });
     fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/settings/membership", expect.objectContaining({ method: "PUT" }));
     });
     const [, putOpts] = fetchMock.mock.calls.find(([, opts]) => opts?.method === "PUT")!;
-    expect(JSON.parse(putOpts!.body as string)).toEqual(expect.objectContaining({ normalDuesCents: 20000 }));
+    expect(JSON.parse(putOpts!.body as string)).toEqual(expect.objectContaining({ standardMembershipFeeCents: 20000 }));
 
     await waitFor(() =>
       expect(notifications.show).toHaveBeenCalledWith(expect.objectContaining({ message: "Settings saved." })),
@@ -211,7 +211,7 @@ describe("MembershipSettingsPage", () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({}); // unmatched -> res.ok false, load() leaves state at its initial defaults
     renderWithProviders(<MembershipSettingsPage />);
-    await waitFor(() => expect(screen.getByLabelText("Annual dues (normal)")).toHaveValue("0"));
+    await waitFor(() => expect(screen.getByLabelText("Standard annual membership fee")).toHaveValue("0"));
 
     global.fetch = jest.fn(async () => ({ ok: false, status: 400, json: async () => ({ error: "Save blocked." }) })) as unknown as typeof fetch;
     fireEvent.click(screen.getByRole("button", { name: "Save settings" }));

--- a/checkin-app/src/app/settings/membership/page.tsx
+++ b/checkin-app/src/app/settings/membership/page.tsx
@@ -10,8 +10,8 @@ import { useCheckinEnv } from "@/components/EnvProvider";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 
 interface Settings {
-  normalDuesCents: number;
-  volunteerDuesCents: number;
+  standardMembershipFeeCents: number;
+  volunteerMembershipFeeCents: number;
   orgMembershipYearBoundary: string | null;
   orgMembershipVariantId: string | null;
   orgMembershipProductUrl: string | null;
@@ -35,8 +35,8 @@ const currentBoundaryLabel = (iso: string) => {
 };
 
 export default function MembershipSettingsPage() {
-  const [normalDues, setNormalDues] = useState("0");
-  const [volunteerDues, setVolunteerDues] = useState("0");
+  const [standardFee, setStandardFee] = useState("0");
+  const [volunteerFee, setVolunteerFee] = useState("0");
   const [bgRecheckMonths, setBgRecheckMonths] = useState("0");
   const [scholarshipGraceDays, setScholarshipGraceDays] = useState("");
   const [boundary, setBoundary] = useState("");
@@ -51,7 +51,7 @@ export default function MembershipSettingsPage() {
   const isDev = useCheckinEnv() === "dev";
   const [signingTarget, setSigningTarget] = useState("zoho");
 
-  // Snapshot of the dues-form values as last loaded/saved; isDirty compares it to
+  // Snapshot of the fee-form values as last loaded/saved; isDirty compares it to
   // current state to drive the unsaved-changes guard.
   // ponytail: guards the main Save-button form only. The go-live card below is a
   // separate save flow — wire it if it grows edits.
@@ -61,7 +61,7 @@ export default function MembershipSettingsPage() {
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [fieldErrors, setFieldErrors] = useState<{ normalDues?: string; volunteerDues?: string; variantId?: string; scholarshipGraceDays?: string }>({});
+  const [fieldErrors, setFieldErrors] = useState<{ standardFee?: string; volunteerFee?: string; variantId?: string; scholarshipGraceDays?: string }>({});
   const [saveNotice, setSaveNotice] = useState<{ text: string; err: boolean } | null>(null);
   const [renewalNotice, setRenewalNotice] = useState<{ text: string; err: boolean } | null>(null);
 
@@ -72,8 +72,8 @@ export default function MembershipSettingsPage() {
       if (sRes.ok) {
         const { settings } = (await sRes.json()) as { settings: Settings };
         const snap = {
-          normalDues: dollars(settings.normalDuesCents),
-          volunteerDues: dollars(settings.volunteerDuesCents),
+          standardFee: dollars(settings.standardMembershipFeeCents),
+          volunteerFee: dollars(settings.volunteerMembershipFeeCents),
           bgRecheckMonths: String(settings.bgRecheckMonths ?? 0),
           scholarshipGraceDays: settings.scholarshipDenialGraceDays != null ? String(settings.scholarshipDenialGraceDays) : "",
           boundary: settings.orgMembershipYearBoundary ? settings.orgMembershipYearBoundary.slice(0, 10) : "",
@@ -82,8 +82,8 @@ export default function MembershipSettingsPage() {
           discountCode: settings.volunteerDiscountCode ?? "",
           signingTarget: settings.devSigningTarget ?? "zoho",
         };
-        setNormalDues(snap.normalDues);
-        setVolunteerDues(snap.volunteerDues);
+        setStandardFee(snap.standardFee);
+        setVolunteerFee(snap.volunteerFee);
         setBgRecheckMonths(snap.bgRecheckMonths);
         setScholarshipGraceDays(snap.scholarshipGraceDays);
         setBoundary(snap.boundary);
@@ -107,23 +107,23 @@ export default function MembershipSettingsPage() {
   const saveSettings = async () => {
     setSaveNotice(null);
     setFieldErrors({});
-    const fe: { normalDues?: string; volunteerDues?: string; variantId?: string; scholarshipGraceDays?: string } = {};
-    const nd = parseFloat(normalDues); if (normalDues.trim() === "" || isNaN(nd) || nd < 0) fe.normalDues = "Enter a dollar amount of 0 or more.";
-    const vd = parseFloat(volunteerDues); if (volunteerDues.trim() === "" || isNaN(vd) || vd < 0) fe.volunteerDues = "Enter a dollar amount of 0 or more.";
+    const fe: { standardFee?: string; volunteerFee?: string; variantId?: string; scholarshipGraceDays?: string } = {};
+    const nd = parseFloat(standardFee); if (standardFee.trim() === "" || isNaN(nd) || nd < 0) fe.standardFee = "Enter a dollar amount of 0 or more.";
+    const vd = parseFloat(volunteerFee); if (volunteerFee.trim() === "" || isNaN(vd) || vd < 0) fe.volunteerFee = "Enter a dollar amount of 0 or more.";
     if (variantId.trim() !== "" && !/^\d+$/.test(variantId.trim())) fe.variantId = "Must be a numeric Shopify variant ID.";
     if (scholarshipGraceDays.trim() !== "") {
       const g = parseInt(scholarshipGraceDays.trim(), 10);
       if (!Number.isInteger(g) || g <= 0 || String(g) !== scholarshipGraceDays.trim()) fe.scholarshipGraceDays = "Enter a positive whole number of days, or leave blank to disable.";
     }
-    if (fe.normalDues || fe.volunteerDues || fe.variantId || fe.scholarshipGraceDays) { setFieldErrors(fe); return; }
+    if (fe.standardFee || fe.volunteerFee || fe.variantId || fe.scholarshipGraceDays) { setFieldErrors(fe); return; }
     setSaving(true);
     try {
       const res = await fetch("/api/settings/membership", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          normalDuesCents: Math.round(parseFloat(normalDues || "0") * 100),
-          volunteerDuesCents: Math.round(parseFloat(volunteerDues || "0") * 100),
+          standardMembershipFeeCents: Math.round(parseFloat(standardFee || "0") * 100),
+          volunteerMembershipFeeCents: Math.round(parseFloat(volunteerFee || "0") * 100),
           orgMembershipVariantId: variantId.trim() || null,
           orgMembershipProductUrl: productUrl.trim() || null,
           volunteerDiscountCode: discountCode.trim() || null,
@@ -182,7 +182,7 @@ export default function MembershipSettingsPage() {
 
   const isDirty =
     !!initial &&
-    !shallowEqual(initial, { normalDues, volunteerDues, bgRecheckMonths, scholarshipGraceDays, boundary, variantId, productUrl, discountCode, signingTarget });
+    !shallowEqual(initial, { standardFee, volunteerFee, bgRecheckMonths, scholarshipGraceDays, boundary, variantId, productUrl, discountCode, signingTarget });
   useUnsavedGuard(isDirty);
 
   return (
@@ -194,25 +194,25 @@ export default function MembershipSettingsPage() {
       ) : (
         <>
           <Card withBorder radius="md" padding="lg">
-            <Title order={3} mb="md">Dues &amp; configuration</Title>
+            <Title order={3} mb="md">Membership fees &amp; configuration</Title>
             <Group align="flex-end" gap="lg" wrap="wrap">
               <TextInput
-                label="Annual dues (normal)"
+                label="Standard annual membership fee"
                 leftSection="$"
                 inputMode="decimal"
                 w={160}
-                error={fieldErrors.normalDues}
-                value={normalDues}
-                onChange={(e) => { setNormalDues(e.currentTarget.value); setFieldErrors((f) => ({ ...f, normalDues: undefined })); }}
+                error={fieldErrors.standardFee}
+                value={standardFee}
+                onChange={(e) => { setStandardFee(e.currentTarget.value); setFieldErrors((f) => ({ ...f, standardFee: undefined })); }}
               />
               <TextInput
-                label="Annual dues (volunteer)"
+                label="Volunteer annual membership fee"
                 leftSection="$"
                 inputMode="decimal"
                 w={160}
-                error={fieldErrors.volunteerDues}
-                value={volunteerDues}
-                onChange={(e) => { setVolunteerDues(e.currentTarget.value); setFieldErrors((f) => ({ ...f, volunteerDues: undefined })); }}
+                error={fieldErrors.volunteerFee}
+                value={volunteerFee}
+                onChange={(e) => { setVolunteerFee(e.currentTarget.value); setFieldErrors((f) => ({ ...f, volunteerFee: undefined })); }}
               />
               <TextInput
                 label="Background check valid for"

--- a/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
@@ -100,8 +100,8 @@ const VOLUNTEER_CODE = "VOLFAM";
 beforeAll(async () => {
     await prisma.boardSettings.upsert({
         where: { id: 1 },
-        create: { id: 1, normalDuesCents: 5000, volunteerDuesCents: 2000, orgMembershipVariantId: MEMBERSHIP_VARIANT, volunteerDiscountCode: VOLUNTEER_CODE },
-        update: { normalDuesCents: 5000, volunteerDuesCents: 2000, orgMembershipVariantId: MEMBERSHIP_VARIANT, volunteerDiscountCode: VOLUNTEER_CODE, shopifyReconcileCursorAt: null },
+        create: { id: 1, standardMembershipFeeCents: 5000, volunteerMembershipFeeCents: 2000, orgMembershipVariantId: MEMBERSHIP_VARIANT, volunteerDiscountCode: VOLUNTEER_CODE },
+        update: { standardMembershipFeeCents: 5000, volunteerMembershipFeeCents: 2000, orgMembershipVariantId: MEMBERSHIP_VARIANT, volunteerDiscountCode: VOLUNTEER_CODE, shopifyReconcileCursorAt: null },
     });
 });
 

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -265,8 +265,8 @@ async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> 
         where: { id: 1 },
         select: {
             orgMembershipVariantId: true,
-            normalDuesCents: true,
-            volunteerDuesCents: true,
+            standardMembershipFeeCents: true,
+            volunteerMembershipFeeCents: true,
             volunteerDiscountCode: true,
         },
     });
@@ -292,7 +292,7 @@ async function reconcileForwardMembership(order: MirrorOrder): Promise<boolean> 
         // impossible — fall back to the old dues amount gate, made discount-aware by
         // adding the coupon back so a couponed pre-backfill order compares its GROSS
         // figure to gross dues and no longer false-raises AMOUNT_MISMATCH.
-        const expected = membership?.isVolunteer ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
+        const expected = membership?.isVolunteer ? settings?.volunteerMembershipFeeCents ?? 0 : settings?.standardMembershipFeeCents ?? 0;
         if (expected > 0 && order.totalCents + order.discountCents + AMOUNT_TOLERANCE_CENTS < expected) {
             await raisePaymentException("AMOUNT_MISMATCH", { shopifyOrderId: order.legacyId, processId: proc.id });
             return true;
@@ -459,7 +459,7 @@ async function reconcileReversals(): Promise<number> {
     // Expected dues per membership (for the "order edited down below dues" case).
     const settings = await prisma.boardSettings.findUnique({
         where: { id: 1 },
-        select: { normalDuesCents: true, volunteerDuesCents: true, volunteerDiscountCode: true },
+        select: { standardMembershipFeeCents: true, volunteerMembershipFeeCents: true, volunteerDiscountCode: true },
     });
     const memberIds = procs.map((p) => p.orgMembershipId).filter((v): v is number => v != null);
     const members = memberIds.length
@@ -477,7 +477,7 @@ async function reconcileReversals(): Promise<number> {
             // Discount-aware: add the coupon back so an ordinary couponed order (volunteer
             // rate, promo) isn't mistaken for a post-activation edit-down — only a real
             // shortfall below GROSS dues counts. Keeps the "edited down" purpose intact.
-            const expected = isVolunteerById.get(proc.orgMembershipId ?? -1) ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
+            const expected = isVolunteerById.get(proc.orgMembershipId ?? -1) ? settings?.volunteerMembershipFeeCents ?? 0 : settings?.standardMembershipFeeCents ?? 0;
             if (expected > 0 && o.totalCents + o.discountCents + AMOUNT_TOLERANCE_CENTS < expected) kind = "AMOUNT_MISMATCH";
         }
         if (!kind && usesVolunteerCodeUnentitled(o, settings?.volunteerDiscountCode, isVolunteerById.get(proc.orgMembershipId ?? -1) ?? false)) {

--- a/checkin-app/src/lib/membership/__tests__/payment.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/payment.test.ts
@@ -44,7 +44,7 @@ const MEMBERSHIP_ID = 9;
 
 beforeEach(() => {
     jest.clearAllMocks();
-    prisma.boardSettings.findUnique.mockResolvedValue({ normalDuesCents: 10000, volunteerDuesCents: 2500 });
+    prisma.boardSettings.findUnique.mockResolvedValue({ standardMembershipFeeCents: 10000, volunteerMembershipFeeCents: 2500 });
     prisma.orgMembership.findUnique.mockResolvedValue({ householdId: 3, isVolunteer: false });
 });
 

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -66,7 +66,7 @@ export async function ensurePaymentLink(processId: number): Promise<{ amountCent
     if (!membership) throw new PaymentError("not_found", "Membership not found.");
 
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
-    const amountCents = membership.isVolunteer ? settings?.volunteerDuesCents ?? 0 : settings?.normalDuesCents ?? 0;
+    const amountCents = membership.isVolunteer ? settings?.volunteerMembershipFeeCents ?? 0 : settings?.standardMembershipFeeCents ?? 0;
 
     const variantId = settings?.orgMembershipVariantId;
     const storeDomain = config.shopifyStoreDomain();

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -117,8 +117,8 @@ export const classifications = {
     },
     BoardSettings: {
         id: 'public',
-        normalDuesCents: 'public',
-        volunteerDuesCents: 'public',
+        standardMembershipFeeCents: 'public',
+        volunteerMembershipFeeCents: 'public',
         orgMembershipYearBoundary: 'public',
         orgMembershipVariantId: 'internal',
         orgMembershipProductUrl: 'internal',


### PR DESCRIPTION
Retires "dues" as a money word on `BoardSettings`. The canonical money word is
`fee`, and this one is the **membership fee** — the decision is recorded in
`checkin-app/docs/VOCABULARY.md`.

```
BoardSettings.normalDuesCents    -> standardMembershipFeeCents
BoardSettings.volunteerDuesCents -> volunteerMembershipFeeCents
```

The `normal` → `standard` half matters as much as the `dues` half: "normal"
reads as *non-member*, which is exactly the trap this kills.

## The DB columns are deliberately NOT renamed

**This is the part to review.** Both fields ship with an `@map` to their original
physical column, so the database columns are still `normalDuesCents` /
`volunteerDuesCents` after this merges:

```prisma
standardMembershipFeeCents  Int @default(0) @map("normalDuesCents")
volunteerMembershipFeeCents Int @default(0) @map("volunteerDuesCents")
```

A column rename is a contract-stage change under
`DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md` rule 3 ("a rename of anything old code
touches"). Migrations run to completion *before* `aws ecs update-service` starts
the rolling deploy, and old tasks keep serving live traffic for the whole drain
window. About 25 call sites read `BoardSettings` with a bare `findUnique`/`upsert`
and no `select`, so the previous release's Prisma client hand-selects
`"normalDuesCents"` by name — renaming the columns in this release would fail
every one of those reads with `42703 undefined column` for the entire drain.
Nav todo-counts, intake, renewal, payment, and the background-check triggers all
sit on that path. Same failure shape as #917.

Shipping the `@map` makes this release schema-compatible with the release it
replaces, at zero migration cost — hence **no migration file in this PR**. The
physical rename is tracked as the contract stage in #1583, to run once this
release is fully rolled out. Verified against a real Postgres: after
`prisma migrate deploy` the `BoardSettings` table still carries the old column
names, and the whole integration tier passes through the mapping.

## Breaking wire change (one caller)

The field names are the request/response keys on `/api/settings/membership`, and
the two validation error strings echo them (`"standardMembershipFeeCents must be
a number >= 0"`). The single caller — `src/app/settings/membership/page.tsx` —
moves in the same commit, so there is no window where the two disagree.

## Copy

Settings page now reads **"Membership fees & configuration"** with
"Standard annual membership fee" / "Volunteer annual membership fee". The
remaining user-facing "dues" strings on the membership review,
volunteer-memberships, finance-ops payment-plan and email-settings pages become
"membership fee", with the two matching test assertions updated.

## Security boundary

`src/security/generated/classifications.ts` is regenerated, not hand-edited, and
both fields keep `@sensitivity:public` — no re-tier. The isolation workflow pairs
*removed* field names against *added* field names to detect a re-tier, so a
rename produces no same-field tier move and `BOUNDARY_TOUCHED` stays 0. No
registry-first split needed.

## Verification

- `npx tsc --noEmit` clean, `npm run lint` clean.
- Both old names grep to zero across `src/`, `tests/`, `__tests__/`,
  `flow-tests/` and `scripts/` — the only surviving occurrences are the two
  deliberate `@map` strings in the schema.
- Unit: `settings/(membership|email)` 46/46, `membership/__tests__/payment` 5/5.
- Integration: full tier, serial, against a seeded Postgres — 138 suites,
  1428 passed, 3 skipped.

## Not in scope

Six user-facing "dues" strings remain outside `BoardSettings` (`membership/page.tsx`
body copy, the nav todo-counts label, `phases.ts`, the `review.ts` clearance email,
`scholarshipAckCopy.ts`, and the `/api/membership/payment` 403), along with the
`isDuesSettled` / `DUES_SETTLED_PERSON_WHERE` identifier family. Left for a
follow-up sweep so this PR stays a field rename.
