### PR TITLE
refactor(payments): rename the out-of-band payment concept "certified" → "manual"

### DIFF
--- a/checkin-app/docs/VOCABULARY.md
+++ b/checkin-app/docs/VOCABULARY.md
@@ -103,7 +103,7 @@ Rules:
 **The canonical money word is `fee`.** Kinds: **membership fee** *(rename pending from "dues": `normalDuesCents`→`standardMembershipFeeCents`, `volunteerDuesCents`→`volunteerMembershipFeeCents`)*, **program fee** (`Fee`), plus **shop fee** and **facility fee** (shop and facility are billed separately). `price` = the cents **amount** on a fee, not a rival concept.
 
 **Payment vs relief** (keep separate):
-- **Manual payment** — payment landed **outside Shopify** (recorded in QuickBooks), so a membership activates without a Shopify order. `via: "manual"` / `manualPaymentById` *(rename pending from `"certified"` / `certifiedById` — which collided with tool certification)*. **Not** a comp.
+- **Manual payment** — payment landed **outside Shopify** (recorded in QuickBooks), so a membership activates without a Shopify order. `via: "manual"` / `manualPaymentById`. **Not** a comp.
 - **Payment Plan** — installments (`isPaymentPlanRequested`).
 - **Scholarship** — a board comp (fee waived). Unnamed in code today.
 - **Scholarship Review Team** — the board-designated recipients of scholarship / payment-plan

--- a/checkin-app/docs/designs/UNFINISHED.md
+++ b/checkin-app/docs/designs/UNFINISHED.md
@@ -122,21 +122,17 @@ Code uses both; policy canonical = **Tool Certifier**. Retire "Shop Certifier"
 
 ---
 
-## 🟢 Rename payment "certified" → "manual" (collides with tool certification)
+## 🟢 Name the relief types: Payment Plan / Scholarship
 
-`via: "certified"` / `MembershipProcess.certifiedById`
-([payment.ts:117](../../src/lib/membership/payment.ts#L117),
-[:236](../../src/lib/membership/payment.ts#L236),
-[schema.prisma:352](../../prisma/schema.prisma#L352)) = payment **landed outside
-Shopify** (recorded in QuickBooks), so the membership activates without a Shopify
-order. NOT a comp — they paid, through another channel. **✅ Decision:**
-- `via: "certified"` → **`via: "manual"`**
-- `certifiedById` → **`manualPaymentById`**
-
-Kills the tool-certification collision. Separately name the relief types (distinct
-from manual payment): **Payment Plan** (installments, `isPaymentPlanRequested`) and
-**Scholarship** (board comp, 0 code refs today) — one process handles either/both.
-_(VOCAB #17)_
+Distinct from a **manual payment** (already renamed — `via: "manual"` /
+`manualPaymentById`): **Payment Plan** (installments,
+`isPaymentPlanRequested`) and **Scholarship** (board comp, 0 code refs today)
+— one process handles either/both. The relief surfaces still say "certify":
+`certifyPaymentPlan()`
+([payment.ts:249](../../src/lib/membership/payment.ts#L249)), the route path
+`/api/membership-ops/applications/certify-payment`, and the
+`certificationNote` column, which now holds the note for BOTH a manual payment
+and a payment-plan approval. _(VOCAB #17)_
 
 ---
 

--- a/checkin-app/prisma/migrations/20260808120000_org_membership_process_manual_payment_by/migration.sql
+++ b/checkin-app/prisma/migrations/20260808120000_org_membership_process_manual_payment_by/migration.sql
@@ -1,0 +1,4 @@
+-- Hand-written RENAME (never Prisma's generated DROP+ADD, which would silently
+-- drop the recorded actor on a populated table — see
+-- docs/DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md rule 4).
+ALTER TABLE "OrgMembershipProcess" RENAME COLUMN "certifiedById" TO "manualPaymentById";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -504,7 +504,7 @@ model OrgMembershipProcess {
   /// @sensitivity:internal
   paidAt                DateTime?
   /// @sensitivity:internal
-  certifiedById         Int?
+  manualPaymentById     Int?
   /// @sensitivity:internal
   certificationNote     String?
   /// Write-never as of the outreach engine (PR-2): the renewal sweep and the go-live

--- a/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/householdsMembershipAuditAPI.integration.test.ts
@@ -303,7 +303,7 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         const process = await prisma.orgMembershipProcess.findUnique({ where: { id: grantableProcessId } });
         expect(process?.status).toBe('ACTIVE');
         expect(process?.paidAt).not.toBeNull();
-        expect(process?.certifiedById).toBe(boardId);
+        expect(process?.manualPaymentById).toBe(boardId);
         expect(process?.certificationNote).toBe('Family confirmed dues in person at the board meeting.');
         const processCount = await prisma.orgMembershipProcess.count({ where: { orgMembershipId: grantableMembershipId } });
         expect(processCount).toBe(1);
@@ -317,7 +317,7 @@ describe('POST /api/membership-ops/households — grant/revoke audit logging', (
         });
         const activateAudit = audits.find(a => (a.newData as { status?: string })?.status === 'ACTIVE');
         expect(activateAudit).toBeTruthy();
-        expect((activateAudit!.newData as { via: string }).via).toBe('certified');
+        expect((activateAudit!.newData as { via: string }).via).toBe('manual');
         expect((activateAudit!.newData as { certificationNote?: string }).certificationNote).toBe('Family confirmed dues in person at the board meeting.');
         const grantAudit = audits.find(a => (a.newData as { comingYearGrant?: boolean })?.comingYearGrant === true);
         expect(grantAudit).toBeTruthy();

--- a/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentAPI.integration.test.ts
@@ -215,10 +215,10 @@ describe('Membership payment API', () => {
         expect(res.status).toBe(200);
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: certProc } });
         expect(proc?.status).toBe('ACTIVE');
-        expect(proc?.certifiedById).toBe(leadId);
+        expect(proc?.manualPaymentById).toBe(leadId);
         expect(proc?.certificationNote).toBe('Paid by check, deposited manually');
 
-        // The audit row records WHO certified — the acting board member, not SYSTEM_ACTOR.
+        // The audit row records WHO recorded the payment — the acting board member, not SYSTEM_ACTOR.
         const audit = await prisma.auditLog.findFirst({ where: { tableName: 'OrgMembershipProcess', affectedEntityId: certProc }, orderBy: { id: 'desc' } });
         expect(audit?.actorId).toBe(leadId);
         expect(normalizeAuditData(audit?.newData)).toMatchObject({ status: 'ACTIVE', certificationNote: 'Paid by check, deposited manually' });

--- a/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipPaymentPlansAPI.integration.test.ts
@@ -185,7 +185,7 @@ describe('Membership payment-plan routes', () => {
             const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: leadProcessId } });
             expect(proc?.status).toBe('ACTIVE'); // bgClearedAt was set, so certify -> ACTIVE
             expect(proc?.isPaymentPlanRequested).toBe(false);
-            expect(proc?.certifiedById).toBe(boardId);
+            expect(proc?.manualPaymentById).toBe(boardId);
             expect(proc?.certificationNote).toBe('Board approved scholarship');
 
             const membership = await prisma.orgMembership.findUnique({ where: { id: leadMembershipId } });
@@ -197,7 +197,7 @@ describe('Membership payment-plan routes', () => {
             });
             expect(audits.length).toBeGreaterThan(0);
             // Written inside activate() (via certifyPaymentPlan) — carries the reason.
-            const certifyAudit = audits.find(a => (a.newData as { via?: string })?.via === 'certified');
+            const certifyAudit = audits.find(a => (a.newData as { via?: string })?.via === 'manual');
             expect(certifyAudit).toBeTruthy();
             expect((certifyAudit!.newData as { certificationNote?: string }).certificationNote).toBe('Board approved scholarship');
             // Supplementary marker written by the route itself.
@@ -236,7 +236,7 @@ describe('Membership payment-plan routes', () => {
             const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: leadProcessId } });
             expect(proc?.isPaymentPlanRequested).toBe(false);
             expect(proc?.status).toBe('PENDING_PAYMENT'); // stays awaiting payment — no seat, no grace, pay-to-activate
-            expect(proc?.certifiedById).toBeNull(); // denial never certifies/activates
+            expect(proc?.manualPaymentById).toBeNull(); // denial never records a payment/activates
 
             const membership = await prisma.orgMembership.findUnique({ where: { id: leadMembershipId } });
             expect(membership?.status).toBe('NONE'); // untouched by denial

--- a/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
@@ -170,7 +170,7 @@ describe('PERSON_BG triggers + subject-scoped clear + gate', () => {
             data: { orgMembershipId: membership.id, kind: 'INITIAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() },
         });
 
-        await activate(proc.id, { via: 'certified', actorId: lead.id });
+        await activate(proc.id, { via: 'manual', actorId: lead.id });
 
         expect((await prisma.orgMembership.findUnique({ where: { id: membership.id } }))?.status).toBe('ACTIVE');
         expect(await personBgCountFor(joiner.id)).toBe(1); // Trigger C fired for the program adult

--- a/checkin-app/src/app/api/finance-ops/s-read/match-audit/track/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/match-audit/track/__tests__/route.test.ts
@@ -175,9 +175,9 @@ describe('kind: order', () => {
 describe('kind: membership', () => {
     beforeEach(asBoard);
 
-    it('active, no order, no certification → 200 tracked, raises ACTIVE_WITHOUT_PAYMENT keyed by processId', async () => {
+    it('active, no order, no manual payment → 200 tracked, raises ACTIVE_WITHOUT_PAYMENT keyed by processId', async () => {
         prismaMock.orgMembershipProcess.findUnique.mockResolvedValue({
-            status: 'ACTIVE', kind: 'INITIAL', shopifyOrderId: null, certifiedById: null,
+            status: 'ACTIVE', kind: 'INITIAL', shopifyOrderId: null, manualPaymentById: null,
         });
         const res = await POST(req({ kind: 'membership', processId: 42 }));
         expect(res.status).toBe(200);
@@ -185,9 +185,9 @@ describe('kind: membership', () => {
         expect(raisePaymentExceptionMock).toHaveBeenCalledWith('ACTIVE_WITHOUT_PAYMENT', { processId: 42 });
     });
 
-    it('409 when since certified', async () => {
+    it('409 when the payment has since been recorded manually', async () => {
         prismaMock.orgMembershipProcess.findUnique.mockResolvedValue({
-            status: 'ACTIVE', kind: 'INITIAL', shopifyOrderId: null, certifiedById: 7,
+            status: 'ACTIVE', kind: 'INITIAL', shopifyOrderId: null, manualPaymentById: 7,
         });
         const res = await POST(req({ kind: 'membership', processId: 42 }));
         expect(res.status).toBe(409);
@@ -196,7 +196,7 @@ describe('kind: membership', () => {
 
     it('409 when the order is now present in the mirror', async () => {
         prismaMock.orgMembershipProcess.findUnique.mockResolvedValue({
-            status: 'ACTIVE', kind: 'INITIAL', shopifyOrderId: '800', certifiedById: null,
+            status: 'ACTIVE', kind: 'INITIAL', shopifyOrderId: '800', manualPaymentById: null,
         });
         mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set(['800']));
         const res = await POST(req({ kind: 'membership', processId: 42 }));
@@ -206,7 +206,7 @@ describe('kind: membership', () => {
 
     it('recorded order absent from the mirror → PAYMENT_UNVERIFIABLE, not ACTIVE_WITHOUT_PAYMENT', async () => {
         prismaMock.orgMembershipProcess.findUnique.mockResolvedValue({
-            status: 'ACTIVE', kind: 'RENEWAL', shopifyOrderId: '801', certifiedById: null,
+            status: 'ACTIVE', kind: 'RENEWAL', shopifyOrderId: '801', manualPaymentById: null,
         });
         mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set()); // 801 not present
         const res = await POST(req({ kind: 'membership', processId: 42 }));
@@ -217,7 +217,7 @@ describe('kind: membership', () => {
 
     it('409 for a process outside the audit-swept status/kind population', async () => {
         prismaMock.orgMembershipProcess.findUnique.mockResolvedValue({
-            status: 'PENDING_PAYMENT', kind: 'INITIAL', shopifyOrderId: null, certifiedById: null,
+            status: 'PENDING_PAYMENT', kind: 'INITIAL', shopifyOrderId: null, manualPaymentById: null,
         });
         const res = await POST(req({ kind: 'membership', processId: 42 }));
         expect(res.status).toBe(409);

--- a/checkin-app/src/app/api/finance-ops/s-read/match-audit/track/route.ts
+++ b/checkin-app/src/app/api/finance-ops/s-read/match-audit/track/route.ts
@@ -16,9 +16,9 @@ import { isPaid, raisePaymentException } from "@/lib/finance/reconcile";
  * so a track request only ever reaches here after a successful audit.
  *
  * The gap predicate is re-run server-side from the raw Prisma columns (status,
- * kind, shopifyOrderId, certifiedById, wasOrgMemberAtApproval, mirror presence)
+ * kind, shopifyOrderId, manualPaymentById, wasOrgMemberAtApproval, mirror presence)
  * — NEVER from a bucket enum value — so a stale panel (a row already
- * activated/certified/refunded/scholarship-approved since the audit ran)
+ * activated/manually-paid/refunded/scholarship-approved since the audit ran)
  * cannot mint an exception. This keeps the route independent of whatever
  * bucket set matchAudit.ts happens to have (see that file's P2 buckets):
  * the only gaps this route ever promotes are the ones that re-derive true
@@ -82,7 +82,7 @@ async function trackOrder(shopifyOrderId: string): Promise<NextResponse> {
 async function trackMembership(processId: number): Promise<NextResponse> {
     const p = await prisma.orgMembershipProcess.findUnique({
         where: { id: processId },
-        select: { status: true, kind: true, shopifyOrderId: true, certifiedById: true },
+        select: { status: true, kind: true, shopifyOrderId: true, manualPaymentById: true },
     });
     if (!p) return apiError("Membership process not found", 404);
     // Only the population the audit sweeps: ACTIVE/PENDING_BG_CLEARANCE, INITIAL/RENEWAL.
@@ -98,7 +98,7 @@ async function trackMembership(processId: number): Promise<NextResponse> {
         await raisePaymentException("PAYMENT_UNVERIFIABLE", { processId });
         return NextResponse.json({ tracked: true });
     }
-    if (p.certifiedById != null) return apiError("Membership is no longer a gap (certified since the audit)", 409);
+    if (p.manualPaymentById != null) return apiError("Membership is no longer a gap (payment recorded manually since the audit)", 409);
     // ponytail: for the null-order kinds the @@unique(kind, shopifyOrderId) index does
     // NOT dedup (NULLs are distinct — no NULLS NOT DISTINCT), so two *concurrent*
     // clicks on the same row could create two ACTIVE_WITHOUT_PAYMENT rows.

--- a/checkin-app/src/components/admin/MatchAuditPanel.tsx
+++ b/checkin-app/src/components/admin/MatchAuditPanel.tsx
@@ -19,7 +19,7 @@ import type { TrackBody } from "@/app/api/finance-ops/s-read/match-audit/track/r
  * Rendering rule: clean buckets collapse to a one-line count; only the gap
  * buckets (unclaimed paid orders, activations with no payment basis, order ids
  * missing from the mirror) get row-level tables. Manual/scholarship rows are
- * listed too — they are legitimate, but "who certified what" is exactly what an
+ * listed too — they are legitimate, but "who recorded what" is exactly what an
  * auditor is here to see.
  */
 
@@ -105,7 +105,7 @@ export function MatchAuditPanel() {
     }
     for (const m of result?.memberships ?? []) {
       if (m.bucket === 'NO_PAYMENT_BASIS' || m.bucket === 'ORDER_NOT_IN_MIRROR' || m.bucket === 'NO_PROCESS') groups.membershipGaps.push(m);
-      else if (m.bucket === 'MANUAL_CERTIFIED') groups.manual.push(m);
+      else if (m.bucket === 'MANUAL_PAYMENT') groups.manual.push(m);
       else if (m.bucket === 'ORDER_REVERSED') groups.reversedMemberships.push(m);
       else if (m.bucket === 'PRE_MIRROR') preMirrorCount++;
       else if (m.bucket === 'TRACKED_EXCEPTION') matchedCounts.tracked++;
@@ -136,7 +136,7 @@ export function MatchAuditPanel() {
       </Group>
       <Text size="sm" c="dimmed">
         Checks that every membership/program purchase (matched by variant) has an activation, and every
-        activation has an order, a board certification, or an approved scholarship behind it. Donations and
+        activation has an order, a manually recorded payment, or an approved scholarship behind it. Donations and
         merchandise never match a known variant and are not expected to reconcile.
       </Text>
 
@@ -173,7 +173,7 @@ export function MatchAuditPanel() {
             {count('Tracked as exceptions', matched.tracked)}
             {count('Memberships matched', matched.memberships)}
             {count('Enrollments matched', matched.enrollments)}
-            {count('Board-certified', manual.length)}
+            {count('Manually recorded payments', manual.length)}
             {count('Scholarships', scholarships.length)}
             {count('Comped', comped.length)}
             {preMirrorCount > 0 && count('Pre-mirror (before mirror history)', preMirrorCount)}
@@ -256,7 +256,7 @@ export function MatchAuditPanel() {
                       <Table.Td>{m.processId != null ? `Membership process ${m.processId}` : `Membership — ${m.householdName ?? m.membershipId}`}</Table.Td>
                       <Table.Td>{m.householdName}</Table.Td>
                       <Table.Td>{
-                        m.bucket === 'NO_PAYMENT_BASIS' ? 'No order and no certification'
+                        m.bucket === 'NO_PAYMENT_BASIS' ? 'No order and no manually recorded payment'
                         : m.bucket === 'NO_PROCESS' ? 'Active membership with no INITIAL/RENEWAL process'
                         : `Order ${m.shopifyOrderId} not in the mirror`
                       }</Table.Td>
@@ -308,7 +308,7 @@ export function MatchAuditPanel() {
                     <Table.Tr key={`man-${m.processId}`}>
                       <Table.Td>Membership process {m.processId}</Table.Td>
                       <Table.Td>{m.householdName}</Table.Td>
-                      <Table.Td>Certified by {m.certifiedByName}</Table.Td>
+                      <Table.Td>Payment recorded manually by {m.manualPaymentByName}</Table.Td>
                     </Table.Tr>
                   ))}
                   {scholarships.map((e) => (

--- a/checkin-app/src/components/admin/__tests__/MatchAuditPanel.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/MatchAuditPanel.test.tsx
@@ -19,10 +19,10 @@ describe("MatchAuditPanel", () => {
           { bucket: "UNCLAIMED_PAID", orderLegacyId: "2", name: "#2", customerEmail: "b@x.com", financialStatus: "PAID", totalCents: 7500, discountCodes: ["VOL50"], expected: ["program: Robotics"] },
         ],
         memberships: [
-          { bucket: "MANUAL_CERTIFIED", processId: 3, membershipId: null, householdName: "The Larks", shopifyOrderId: null, certifiedByName: "Board Bob" },
-          { bucket: "NO_PAYMENT_BASIS", processId: 4, membershipId: null, householdName: "The Wrens", shopifyOrderId: null, certifiedByName: null },
-          { bucket: "NO_PROCESS", processId: null, membershipId: 5, householdName: "The Finches", shopifyOrderId: null, certifiedByName: null },
-          { bucket: "ORDER_REVERSED", processId: 6, membershipId: null, householdName: "The Sparrows", shopifyOrderId: "801", certifiedByName: null },
+          { bucket: "MANUAL_PAYMENT", processId: 3, membershipId: null, householdName: "The Larks", shopifyOrderId: null, manualPaymentByName: "Board Bob" },
+          { bucket: "NO_PAYMENT_BASIS", processId: 4, membershipId: null, householdName: "The Wrens", shopifyOrderId: null, manualPaymentByName: null },
+          { bucket: "NO_PROCESS", processId: null, membershipId: 5, householdName: "The Finches", shopifyOrderId: null, manualPaymentByName: null },
+          { bucket: "ORDER_REVERSED", processId: 6, membershipId: null, householdName: "The Sparrows", shopifyOrderId: "801", manualPaymentByName: null },
         ],
         enrollments: [
           { bucket: "SCHOLARSHIP_APPROVED", programId: 7, programName: "Robotics", personId: 9, personName: "Kid Nine", shopifyOrderId: null, compedByName: null },
@@ -45,10 +45,10 @@ describe("MatchAuditPanel", () => {
     expect(screen.getByText("#2")).toBeInTheDocument();
     expect(screen.getByText("program: Robotics")).toBeInTheDocument();
     expect(screen.getByText("VOL50")).toBeInTheDocument();
-    expect(screen.getByText("No order and no certification")).toBeInTheDocument();
+    expect(screen.getByText("No order and no manually recorded payment")).toBeInTheDocument();
     expect(screen.getByText("Active membership with no INITIAL/RENEWAL process")).toBeInTheDocument();
     // ...and the manual/scholarship/comped classes are listed with WHO, not flagged as gaps.
-    expect(screen.getByText("Certified by Board Bob")).toBeInTheDocument();
+    expect(screen.getByText("Payment recorded manually by Board Bob")).toBeInTheDocument();
     expect(screen.getByText("Scholarship / payment plan approved")).toBeInTheDocument();
     expect(screen.getByText("Comped by Admin Amy")).toBeInTheDocument();
     // Reversed rows render informationally, not as a gap.
@@ -148,7 +148,7 @@ describe("MatchAuditPanel", () => {
           { bucket: "UNCLAIMED_PAID", orderLegacyId: "2", name: "#2", customerEmail: "b@x.com", financialStatus: "PAID", totalCents: 7500, discountCodes: [], expected: ["membership"] },
         ],
         memberships: [
-          { bucket: "NO_PAYMENT_BASIS", processId: 4, membershipId: null, householdName: "The Wrens", shopifyOrderId: null, certifiedByName: null },
+          { bucket: "NO_PAYMENT_BASIS", processId: 4, membershipId: null, householdName: "The Wrens", shopifyOrderId: null, manualPaymentByName: null },
         ],
         enrollments: [],
       },

--- a/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/matchAudit.test.ts
@@ -196,18 +196,18 @@ describe('membership buckets (activation → Shopify)', () => {
     const proc = (id: number, over: Partial<Record<string, unknown>> = {}) => ({
         id,
         shopifyOrderId: null,
-        certifiedById: null,
+        manualPaymentById: null,
         orgMembership: { household: { name: `House ${id}` } },
         ...over,
     });
 
-    it('classifies all four buckets, resolving certifier names', async () => {
+    it('classifies all four buckets, resolving manual-payment actor names', async () => {
         prismaMock.orgMembershipProcess.findMany
             .mockResolvedValueOnce([]) // claim lookup
             .mockResolvedValueOnce([
                 proc(1, { shopifyOrderId: '800' }),
                 proc(2, { shopifyOrderId: '801' }),
-                proc(3, { certifiedById: 42 }),
+                proc(3, { manualPaymentById: 42 }),
                 proc(4),
             ]);
         mirrorMock.orderLegacyIdsPresent.mockResolvedValue(new Set(['800']));
@@ -217,10 +217,10 @@ describe('membership buckets (activation → Shopify)', () => {
         expect(r.memberships.map((m) => m.bucket)).toEqual([
             'ORDER_MATCHED',
             'ORDER_NOT_IN_MIRROR',
-            'MANUAL_CERTIFIED',
+            'MANUAL_PAYMENT',
             'NO_PAYMENT_BASIS',
         ]);
-        expect(r.memberships[2].certifiedByName).toBe('Board Bob');
+        expect(r.memberships[2].manualPaymentByName).toBe('Board Bob');
     });
 
     it('sweeps only payment-bearing kinds — PERSON_BG processes must never appear as gaps', async () => {
@@ -265,7 +265,7 @@ describe('PRE_MIRROR vs ORDER_NOT_IN_MIRROR', () => {
     const proc = (id: number, shopifyOrderId: string) => ({
         id,
         shopifyOrderId,
-        certifiedById: null,
+        manualPaymentById: null,
         orgMembership: { household: { name: `House ${id}` } },
     });
 
@@ -390,7 +390,7 @@ describe('tracked-exception override (P3 gap → exception promotion)', () => {
     const proc = (id: number, over: Partial<Record<string, unknown>> = {}) => ({
         id,
         shopifyOrderId: null,
-        certifiedById: null,
+        manualPaymentById: null,
         orgMembership: { household: { name: `House ${id}` } },
         ...over,
     });
@@ -446,16 +446,16 @@ describe('tracked-exception override (P3 gap → exception promotion)', () => {
         expect(enrollmentCall![0].where.status).toEqual({ not: 'RESOLVED' });
     });
 
-    it('a stray open exception on a MANUAL_CERTIFIED row is not overridden — the override is gap-only', async () => {
+    it('a stray open exception on a MANUAL_PAYMENT row is not overridden — the override is gap-only', async () => {
         prismaMock.orgMembershipProcess.findMany
             .mockResolvedValueOnce([])
-            .mockResolvedValueOnce([proc(1, { certifiedById: 42 })]); // MANUAL_CERTIFIED, not a gap
+            .mockResolvedValueOnce([proc(1, { manualPaymentById: 42 })]); // MANUAL_PAYMENT, not a gap
         prismaMock.person.findMany.mockResolvedValue([{ id: 42, name: 'Board Bob' }]);
         prismaMock.paymentException.findMany.mockImplementation(async ({ where }: { where: Record<string, unknown> }) =>
             isMembershipLookup(where) ? [{ processId: 1 }] : [],
         );
         const r = await runMatchAudit();
-        expect(r.memberships[0].bucket).toBe('MANUAL_CERTIFIED');
+        expect(r.memberships[0].bucket).toBe('MANUAL_PAYMENT');
     });
 
     it('a stray open exception on an ORDER_MATCHED enrollment is not overridden — the override is gap-only', async () => {

--- a/checkin-app/src/lib/finance/matchAudit.ts
+++ b/checkin-app/src/lib/finance/matchAudit.ts
@@ -17,7 +17,7 @@ import { LIVE_PERSON } from "@/lib/person/filters";
  *   - activations with NO payment basis at all (access, no money) — the
  *     ACTIVE_WITHOUT_PAYMENT case that has had an enum value and board-alert
  *     copy since the reconciler shipped, but which nothing ever computed,
- *   - the legitimately-manual class (board-certified memberships, approved
+ *   - the legitimately-manual class (manually-recorded memberships, approved
  *     scholarships) that an auditor must see separated, not buried.
  *
  * "Should reconcile" is decided by VARIANT ID, the same key the storefront
@@ -58,7 +58,7 @@ export interface AuditOrderRow {
 
 export type MembershipBucket =
     | "ORDER_MATCHED"
-    | "MANUAL_CERTIFIED"
+    | "MANUAL_PAYMENT"
     | "ORDER_NOT_IN_MIRROR"
     | "PRE_MIRROR"
     | "ORDER_REVERSED"
@@ -86,8 +86,8 @@ export interface AuditMembershipRow {
     membershipId: number | null;
     householdName: string | null;
     shopifyOrderId: string | null;
-    /** Who certified, for the MANUAL_CERTIFIED rows — the "what is in audit as manual" answer. */
-    certifiedByName: string | null;
+    /** Who recorded the payment, for the MANUAL_PAYMENT rows — the "what is in audit as manual" answer. */
+    manualPaymentByName: string | null;
 }
 
 export interface AuditEnrollmentRow {
@@ -262,7 +262,7 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
             select: {
                 id: true,
                 shopifyOrderId: true,
-                certifiedById: true,
+                manualPaymentById: true,
                 orgMembership: { select: { household: { select: { name: true } } } },
             },
         }),
@@ -340,12 +340,12 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
     const createdActive = (e: { personId: number; programId: number; shopifyOrderId: string | null; wasOrgMemberAtApproval: boolean | null }) =>
         !e.shopifyOrderId && e.wasOrgMemberAtApproval == null && createByKey.get(`${e.personId}:${e.programId}`)?.status === "ACTIVE";
 
-    // certifiedById / comp actor ids have no Prisma relation — resolve every name in one batch.
-    const certifierIds = [...new Set(procs.map((p) => p.certifiedById).filter((v): v is number => v != null))];
+    // manualPaymentById / comp actor ids have no Prisma relation — resolve every name in one batch.
+    const manualPaymentActorIds = [...new Set(procs.map((p) => p.manualPaymentById).filter((v): v is number => v != null))];
     const comperActorIds = compCandidates
         .map((e) => (createByKey.get(`${e.personId}:${e.programId}`)?.status === "ACTIVE" ? compActorId(e) : null))
         .filter((v): v is number => v != null);
-    const nameIds = [...new Set([...certifierIds, ...comperActorIds])];
+    const nameIds = [...new Set([...manualPaymentActorIds, ...comperActorIds])];
     const people = nameIds.length
         ? await prisma.person.findMany({ where: { id: { in: nameIds } }, select: { id: true, name: true } })
         : [];
@@ -407,8 +407,8 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
                 : reversedIds.has(p.shopifyOrderId)
                     ? "ORDER_REVERSED"
                     : "ORDER_MATCHED"
-            : p.certifiedById != null
-                ? "MANUAL_CERTIFIED"
+            : p.manualPaymentById != null
+                ? "MANUAL_PAYMENT"
                 : "NO_PAYMENT_BASIS";
         // Override only the two trackable gaps — literal bucket names, so a P2
         // bucket this PR doesn't know about is never touched (see file header).
@@ -422,7 +422,7 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
             membershipId: null,
             householdName: p.orgMembership?.household?.name ?? null,
             shopifyOrderId: p.shopifyOrderId,
-            certifiedByName: p.certifiedById != null ? (personName.get(p.certifiedById) ?? `person ${p.certifiedById}`) : null,
+            manualPaymentByName: p.manualPaymentById != null ? (personName.get(p.manualPaymentById) ?? `person ${p.manualPaymentById}`) : null,
         };
     });
 
@@ -432,7 +432,7 @@ export async function runMatchAudit(): Promise<MatchAuditResult> {
         membershipId: m.id,
         householdName: m.household?.name ?? null,
         shopifyOrderId: null,
-        certifiedByName: null,
+        manualPaymentByName: null,
     }));
 
     const enrollmentRows: AuditEnrollmentRow[] = enrolls.map((e) => {

--- a/checkin-app/src/lib/membership/__tests__/payment.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/payment.test.ts
@@ -7,7 +7,7 @@
  * product (its Shopify variant) before a PENDING_PAYMENT process activates.
  *   - no membership variant in the order -> NOT activated, no paidAt, board alerted (notifyBoardPaidReject).
  *   - membership variant present         -> activates as before (status ACTIVE, membership ACTIVE).
- *   - a "certified" (board) activation never had an order to check, so it's exempt regardless.
+ *   - a "manual" (board) activation never had an order to check, so it's exempt regardless.
  *
  * Also covers the activation email's INITIAL/RENEWAL split: a renewing household
  * is thanked for renewing, not welcomed as if it were new.
@@ -108,14 +108,14 @@ it('thanks a RENEWAL household for renewing instead of welcoming it', async () =
     expect(body).toContain('Thank you for renewing');
 });
 
-it('a certified (board) activation is exempt from the membership-item check', async () => {
+it('a manual (board) activation is exempt from the membership-item check', async () => {
     // certifyPaymentPlan never has a Shopify order to check (via !== "payment"),
     // so it activates even though no hasMembershipItem is passed at all.
     prisma.orgMembershipProcess.findUnique.mockResolvedValue({
         id: PROCESS_ID, status: 'PENDING_PAYMENT', paidAt: null, bgClearedAt: new Date(), orgMembershipId: MEMBERSHIP_ID,
     });
 
-    await activate(PROCESS_ID, { via: 'certified', actorId: 1 });
+    await activate(PROCESS_ID, { via: 'manual', actorId: 1 });
 
     expect(prisma.orgMembershipProcess.update).toHaveBeenCalledWith(
         expect.objectContaining({ data: expect.objectContaining({ status: 'ACTIVE' }) }),

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -17,7 +17,7 @@ import { systemActor, personOrSystemActor } from "@/lib/auditActor";
  * at checkout — our dues figures are only what applicants *see*. The membership
  * process id rides along as a cart attribute so the orders/paid webhook can
  * match the payment back to this application. Payment (orders/paid webhook) OR a
- * board "payment-plan certified" override both converge on activate(): one place
+ * board manual-payment override both converge on activate(): one place
  * that flips the membership ACTIVE, records how, and sends one congrats email.
  */
 
@@ -119,7 +119,7 @@ export async function ensurePaymentLinkForUser(userId: number) {
  */
 export async function activate(
     processId: number,
-    opts: { via: "payment" | "certified"; actorId?: number; shopifyOrderId?: string; hasMembershipItem?: boolean; reason?: string },
+    opts: { via: "payment" | "manual"; actorId?: number; shopifyOrderId?: string; hasMembershipItem?: boolean; reason?: string },
 ) {
     const result = await prisma.$transaction(async (tx) => {
         await tx.$queryRaw`SELECT id FROM "OrgMembershipProcess" WHERE id = ${processId} FOR UPDATE`;
@@ -137,10 +137,10 @@ export async function activate(
         const now = new Date();
         // Recorded atomically with paidAt — the lib stays permissive (a certify with
         // no reason still goes through); the API boundary is where it's required.
-        const certificationNote = opts.via === "certified" && opts.reason && opts.reason.trim() !== "" ? opts.reason : undefined;
+        const certificationNote = opts.via === "manual" && opts.reason && opts.reason.trim() !== "" ? opts.reason : undefined;
         const payMeta = {
             ...(opts.shopifyOrderId ? { shopifyOrderId: opts.shopifyOrderId } : {}),
-            ...(opts.via === "certified" && opts.actorId ? { certifiedById: opts.actorId } : {}),
+            ...(opts.via === "manual" && opts.actorId ? { manualPaymentById: opts.actorId } : {}),
             ...(certificationNote ? { certificationNote } : {}),
         };
 
@@ -178,7 +178,7 @@ export async function activate(
         // Shopify's real price and doesn't stop someone paying for unrelated items
         // that happen to add up to the right amount (see #625 for the systemic
         // price/settings-alignment fix, including volunteer-discount eligibility).
-        // A board "certified" payment-plan override has no Shopify order at all, so
+        // A board manual-payment override has no Shopify order at all, so
         // it's exempt (opts.via !== "payment"). Only runs when hasMembershipItem is
         // actually supplied: activateByProcessId (the only production caller of the
         // "payment" path) always passes it, so this only skips for callers that
@@ -262,7 +262,7 @@ export async function certifyPaymentPlan(processId: number, actorId: number, opt
     if (await hasHouseholdConflict(prisma, actorId, process.orgMembership?.householdId)) {
         throw new PaymentError("forbidden", "You cannot certify your own household's membership — someone outside your household must.");
     }
-    return activate(processId, { via: "certified", actorId, reason: opts?.reason });
+    return activate(processId, { via: "manual", actorId, reason: opts?.reason });
 }
 
 /** Webhook path: activate the process tied to a paid Shopify draft order. */

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -94,7 +94,7 @@ export const classifications = {
         shopifyInvoiceUrl: 'personal',
         shopifyOrderId: 'internal',
         paidAt: 'internal',
-        certifiedById: 'internal',
+        manualPaymentById: 'internal',
         certificationNote: 'internal',
         renewalReminderSentAt: 'internal',
         isPaymentPlanRequested: 'internal',

--- a/checkin-app/tests/security/scopeValidators.test.ts
+++ b/checkin-app/tests/security/scopeValidators.test.ts
@@ -45,7 +45,7 @@ describe('validateBindings — coverage (forgotten-model catcher)', () => {
         // createdById FK; with an empty queue it must error. (MembershipProcess
         // was the old exemplar but is now un-scopable by the direct-FK heuristic
         // once bare `id` left SCOPABLE_FIELDS — it has only membershipId/
-        // certifiedById, neither a recognised actor FK.)
+        // manualPaymentById, neither a recognised actor FK.)
         const errs = validateBindings(SCOPE_BINDINGS, CLS, new Set());
         expect(errs.some(e => e.startsWith('VolunteerDesignation is sensitive and scopable'))).toBe(true);
     });


### PR DESCRIPTION
## What

Renames the out-of-band payment concept from "certified" to "manual". `via: "certified"` / `OrgMembershipProcess.certifiedById` record that a household **paid through another channel** (recorded in QuickBooks, no Shopify order), so the membership activates without an order. It is not a comp — they paid. The name collided head-on with **tool certification** (Shop Safety), an unrelated concept.

- `via: "certified"` → `via: "manual"`
- `OrgMembershipProcess.certifiedById` → `manualPaymentById`
- match-audit wire key `certifiedByName` → `manualPaymentByName`
- match-audit bucket `MANUAL_CERTIFIED` → `MANUAL_PAYMENT`
- board-facing copy now says the payment was recorded manually rather than "certified"
- `@sensitivity:internal` unchanged; `classifications.ts` regenerated from the schema (not hand-edited)

The decision was already recorded in `checkin-app/docs/designs/UNFINISHED.md`; this implements it and removes that section. The residual open work — naming the **relief** types (Payment Plan / Scholarship), which are a different concept — stays in UNFINISHED, shrunk to just that question.

## Deploy sequencing — please read before releasing

This is a **contract-class** migration under rule 3 of `checkin-app/docs/DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md`, and it is **not** split into expand/contract. Migrations complete before the rolling deploy starts, so for the drain window old tasks serve traffic against the renamed column.

Exposed surfaces during the drain window:

| Surface | Old-code behavior post-migration |
| --- | --- |
| `GET /api/finance-ops/s-read/match-audit` | 500 — selects `certifiedById` |
| `POST .../match-audit/track` (kind: membership) | 500 — same select |
| `certify-payment` / payment-plan approve | 500 — the write is inside `$transaction`, so it rolls back; no partial state |

All three are board/sysadmin-gated. **No member-facing surface is affected, and the Shopify `orders/paid` webhook path never touches this column** (`via: "payment"` doesn't write it). No data loss in any case — `ALTER TABLE ... RENAME COLUMN` preserves every value. Net exposure is a few minutes of board-only 500s that self-heal when the new tasks take over.

Two zero-exposure alternatives if that window isn't acceptable:

1. **Expand/contract, two releases** — add `manualPaymentById` + backfill + dual-write, drop `certifiedById` next release. Correct by the book; roughly 3x this diff and leaves a follow-on.
2. **`@map("certifiedById")` on the Prisma field** — kills the code-level collision with no migration and no drain window, at the cost of a DB column name that drifts from the field name. One-line pivot from where this branch sits.

Happy to reshape into either; flagging rather than deciding unilaterally.

## Migration

`checkin-app/prisma/migrations/20260808120000_org_membership_process_manual_payment_by/migration.sql`

```sql
ALTER TABLE "OrgMembershipProcess" RENAME COLUMN "certifiedById" TO "manualPaymentById";
```

Hand-written `RENAME` (rule 4) — Prisma's diff engine would generate `DROP COLUMN` + `ADD COLUMN`, which silently drops the recorded actor on a populated table. The DB holds real data. Single statement, so no `BEGIN`/`COMMIT` wrapper needed (rule 5). Verified: `prisma migrate deploy` applies the full chain including this one, and `\d "OrgMembershipProcess"` shows `manualPaymentById` with no `certifiedById` remaining.

## Persisted audit values

`via` is written into `AuditLog.newData`. Historical rows are **not** rewritten and there is deliberately no data-migration for them: pre-rename rows keep reading `certified`, post-rename rows read `manual`. Nothing reads `.via` back today, so this is inert — noting it so a future consumer of that field knows to handle both.

## Security boundary

Regenerating `classifications.ts` does **not** trip `security-boundary-isolation.yml`, so this ships as one PR:

- `src/security/generated/*` is explicitly excluded from the workflow's `is_boundary` check.
- The re-tier detector matches on **field name** — `certifiedById` disappears and `manualPaymentById` appears, so no existing field moves between tiers. Purely a rename, and the tier stays `internal`.

No registry grant, token grammar, handler, stripper, or scope-binding change. `manualPaymentById` is not in `SCOPE_BINDINGS` (the model is un-scopable by the direct-FK heuristic — only a stale comment in `scopeValidators.test.ts` named the old field, updated here).

## Out of scope (deliberately untouched)

- `certificationNote` — the adjacent column, which now carries the note for **both** a manual payment and a payment-plan approval. Noted in UNFINISHED as a follow-on.
- `certifyPaymentPlan()` and the route path `/api/membership-ops/applications/certify-payment` — payment-plan approval is a separate concept (Payment Plan / Scholarship relief); renaming a live route path is its own task.
- Everything in Shop Safety / tool certification (`ToolLevel`, `MAY_CERTIFY_OTHERS`, the `'certifier'` token in `security/core.ts`).

## Verification

- `npx tsc --noEmit` — clean. Necessary but not sufficient here: Prisma's recursive `WhereInput` lets a stale field name in a variable-held `where` compile clean and throw at runtime, so:
- Grepped `certifiedById` / `certifiedByName` / `MANUAL_CERTIFIED` / `via: 'certified'` to **zero** across `src/`, `tests/`, `__tests__/`, `flow-tests/`, and `docs/`. The only surviving `'certified'` is `ToolLevelBadge`'s tool-certification level, which is correct.
- **Integration** (the real net for a Prisma rename), `--runInBand` against a real Postgres — `membershipPaymentAPI`, `membershipPaymentPlansAPI`, `householdsMembershipAuditAPI`, `personBgTriggers`: 4 suites / 67 tests pass.
- **Unit**: 52 suites / 526 tests pass (`finance|membership|Membership` scope, covering `matchAudit`, `payment`, `MatchAuditPanel`, the track route).
- **Security suite**: 8 suites / 599 tests pass.

Also renamed the bucket to `MANUAL_PAYMENT` rather than `MANUAL` — it reads consistently next to `NO_PAYMENT_BASIS` and `manualPaymentByName`. Easy to shorten if reviewers prefer `MANUAL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
