### PR TITLE
docs(unfinished): audit the ledger down to what is still a gap

### DIFF
--- a/checkin-app/docs/designs/UNFINISHED.md
+++ b/checkin-app/docs/designs/UNFINISHED.md
@@ -4,6 +4,8 @@ Open decisions, deferred fixes, and not-yet-built items surfaced during the
 2026-07-02 vocabulary sweep. Decided terms are recorded in
 [../VOCABULARY.md](../VOCABULARY.md); this doc holds what's left to *act on*. Add
 sections freely — we'll find more. Nothing here is implemented; investigation only.
+(Audited against `main` 2026-08-08: everything below is still open. Items that
+resolved have been moved to *Considered and dismissed*.)
 
 **Legend:** 🔴 high-priority / risky · 🟡 decision needed · 🟢 mechanical fix ·
 🔵 aspirational (not-yet-built) · 📖 record-in-dictionary only
@@ -88,26 +90,13 @@ _(VOCAB #2)_
 
 ---
 
-## ✅ Certifier "any-tool → global" widening — ACCEPTED (not a security issue)
-
-**Decision (2026-07-02): fine as-is.** Certifiers are a small group; wide
-access/visibility is acceptable. The `isCertifier` nav/access checks that fire on
-holding `MAY_CERTIFY_OTHERS` on **any** tool (shopNav.ts:31,
-access-resolvers.ts:135, pageRegistry.ts:36, AppFrame.tsx:101,
-ToolManagementPanel.tsx:525) are intended convenience, not an over-grant. The
-**actual grant action stays per-tool**
-([certifications/route.ts:100](../../src/app/api/shop/certifications/route.ts#L100)) —
-you can only certify others on a tool you're a certifier for — which is the part
-that matters. No change needed. _(VOCAB #2)_
-
----
-
 ## 🟢 "Tool Certifier" vs "Shop Certifier" label
 
-Code uses both; policy canonical = **Tool Certifier**. Retire "Shop Certifier"
-([ToolLevelBadge.tsx:22](../../src/components/ToolLevelBadge.tsx#L22),
-[RoleBadge.tsx:23](../../src/components/ui/RoleBadge.tsx#L23),
-[security/core.ts:125](../../src/security/core.ts#L125)). _(VOCAB #2)_
+Code uses both; policy canonical = **Tool Certifier**. One user-visible "Shop
+Certifier" label left ([ToolLevelBadge.tsx:22](../../src/components/ToolLevelBadge.tsx#L22),
+plus its doc comment `:32`); `RoleBadge.tsx` and `security/core.ts` already say
+"certifier" (two prose comments in core.ts still read "shop certifier").
+_(VOCAB #2)_
 
 ---
 
@@ -136,26 +125,18 @@ _(VOCAB #6)_
 
 ## 🟢 Dedup `SessionUser` type
 
-`type SessionUser` redeclared inline in ≥4 places
-([types/participant.ts:5](../../src/types/participant.ts#L5),
-[attendance/current/page.tsx:42](../../src/app/attendance/current/page.tsx#L42),
-[programs/[id]/page.tsx:36](../../src/app/programs/[id]/page.tsx#L36),
-[AppFrame.tsx:53](../../src/components/AppFrame.tsx#L53)). Consolidate to one export;
-rename the stale-named `types/participant.ts`. _(VOCAB #8)_
+`SessionUser` declared 4 times: the one export
+([types/participant.ts:5](../../src/types/participant.ts#L5), role booleans
+**required**, stale "Prisma Participant model" comment) plus 3 local structural
+subsets ([attendance/current/page.tsx:50](../../src/app/attendance/current/page.tsx#L50),
+[programs/[id]/page.tsx:50](../../src/app/programs/[id]/page.tsx#L50),
+[AppFrame.tsx:54](../../src/components/AppFrame.tsx#L54)). Real source of truth is
+`Session["user"]` in [next-auth.d.ts](../../src/types/next-auth.d.ts). Consolidate to
+one export in `types/auth.ts`; rename the Participant-era `types/participant.ts`.
+Watch the optionality gap — `lib/auth.ts` consumes the required-flag shape.
+_(VOCAB #8)_
 
 ---
-
-## 🟡 `household` vs `family` — keep the split, or unify?
-
-Code is all `Household`; UI intermittently says "family" (and `TrustedAdult.familyContext`).
-**Default = keep the split** — code `Household`, "family" allowed as warm user copy
-(already recorded in VOCABULARY). To **unify** instead: rename field
-`TrustedAdult.familyContext` → `householdContext` (`prisma/schema.prisma`) + consumers
-(`api/safety/trusted-adults`, `api/trusted-adults/*`, `safety/trusted-adults/page.tsx`,
-security registry + strip tests); "family" → "household" copy across
-my-household / review / register / volunteer-memberships / my-activities;
-`memberFamilies` → `memberHouseholds`. DB wiped on deploy → no data care.
-_(was proposal Phase 5)_
 
 ## 🟢 Retire `dependent` + fix intake `children` bucket (BUG-2)
 
@@ -186,13 +167,12 @@ separate `'member'` **security field-visibility tier**, which is a different axi
 (a typed access contract, not the membership noun):
 
 - `Tier = 'public' | 'member' | SensitiveTier | 'secret'` and
-  `Token = 'public' | 'member' | …` ([security/core.ts:41,55](../../src/security/core.ts#L41)).
+  `Token = 'public' | 'member' | …` ([security/core.ts:55,74](../../src/security/core.ts#L55)).
   Semantics: a `member`-tier field is visible to a member view; a member view holds
-  BOTH `'member'` and `'public'`, anon holds only `'public'`
-  ([core.ts:6-10,241](../../src/security/core.ts#L6)).
-- Surface if ever renamed to `'orgMember'`: ~34 `'member'` tokens across
+  BOTH `'member'` and `'public'`, anon holds only `'public'`.
+- Surface if ever renamed to `'orgMember'`: ~43 `'member'` tokens across
   [registry.ts](../../src/security/registry.ts) scope arrays; the one
-  `@sensitivity:member` schema tag ([schema.prisma:144](../../prisma/schema.prisma#L144),
+  `@sensitivity:member` schema tag ([schema.prisma:254](../../prisma/schema.prisma#L254),
   on `ToolStatus`); `level: 'member'` in generated
   [classifications.ts](../../src/security/generated/classifications.ts); parser
   guards ([scopes.ts:260](../../src/security/scopes.ts#L260), core.ts).
@@ -211,9 +191,6 @@ bless it as-is and record that in VOCABULARY. _(Phase 4 OQ-1)_
 
 ## 🔵 Aspirational — not built yet (enforced by policy / no data today)
 
-- **Tool categories + per-level/per-category age gates** (10/13/21; Certified =
-  category-based). `Tool` has no `category`, no age checks. Enforced by policy
-  outside the software for now. _(VOCAB #2)_
 - **Corporation / Organizational Partner Member** — no corporate partners today.
   Keep `Corporation`/`CorporationLead`/`CorporationMember` as scaffolding; when
   built, define the concept and qualify the bare `CorporationMember`. _(VOCAB #5)_
@@ -229,45 +206,12 @@ from the vocabulary sweep above. **Everything else that audit flagged has
 shipped** — the P0-B auth-consolidation buckets, the P1 near-neighbor fixes, P3-1
 error-path (`apiError` + lint, #728), P3-2 logger (#727), P1-2/6/7/8, P2-1 Person
 rename, P2-2 counterparty→trustedAdult (#734), and the GAP-1 program-roster leak.
-These four are what remain.
-
-## 🔴 Program → Instance → Event — 3-tier restructure (IN DESIGN, do NOT start code)
-
-Domain is **definition → offering → occurrence** but the schema is 2-tier
-(`Program` → `Event`, [schema.prisma:586](../../prisma/schema.prisma#L586)/[:702](../../prisma/schema.prisma#L702)).
-**Decided:** insert `ProgramInstance` between them — `Program` = reusable definition,
-`Instance` = one concrete offering, `Event` = today's leaf (attendance stays on
-`Event`; `RSVP`/`Visit` do not move). Model name `ProgramInstance` in code (never bare
-`instance`; `Session` is off-limits — NextAuth owns it).
-
-**Core open decision:** because `Program` becomes a template, its children
-(`ProgramParticipant` roster, `ProgramVolunteer`, `Fee`, `leadMentorId`, capacity,
-dates) likely **move down to Instance** — you enroll in an offering, not a definition.
-The per-child placement table is the heart of the design.
-
-**Security ripple (large):** the `programsLed` session claim (auth-options / authClaims
-/ next-auth.d.ts, added for the program-ops row gate) becomes `instancesLed`; the
-event→program authorize hop (`access-resolvers`, `events/[id]` inline gate, the GAP-1
-roster gate in `programs/[id]`) becomes event→instance→program. Full design proposal:
-[PROGRAM_INSTANCE_RESTRUCTURE.md](../../../docs/designs/PROGRAM_INSTANCE_RESTRUCTURE.md);
-**do not write code until the child-placement table + phasing are reviewed.**
-Supersedes the P2-3 Event/session naming item (naming resolves as an output).
-
-## 🟡 GAP-2 drift-guard — ban auth/route drift in CI (validators already armed)
-
-The scope validators are **armed + green** ([scopeValidators.test.ts](../../src/security/__tests__/scopeValidators.test.ts),
-#733): they prove every sensitive field is bound and every route grant resolves. The
-**second half is unbuilt by choice** — a CI drift-guard that fails on any new
-`getServerSession`/`authenticateRequest` import outside the wrapper libs
-([lib/auth.ts](../../src/lib/auth.ts)), and any `src/app/api/**` route that calls
-`prisma` without a registered policy. Today: 2 legit `getServerSession`
-(`dev-personas`, `shop/tools`, both optional-session). Without the guard the IDOR/drift
-class can regrow (it already went 2→6→2 once). Re-armable anytime.
-Ref: [auth-consistency-analysis.md](../../../docs/security/auth-consistency-analysis.md) §9 Step 7.
+Two remain here; the 3-tier restructure and the GAP-2 drift-guard have graduated to
+issues (see *Tracked as issues* below).
 
 ## 🔵 `handler()` consolidation — the "one authorization rule" end-state
 
-~13 of ~101 routes use the security `handler()` runtime; ~75 use `withAuth` (admission
+~13 of ~144 routes use the security `handler()` runtime; ~118 use `withAuth` (admission
 only, no field stripping) with row-authorization hand-rolled inline. End-state:
 `handler()` becomes the default, `withAuth` collapses into a degenerate `handler()`
 (permissive `orderedView` → no-op stripper), `withCron`/`withWebhook`/`withKiosk` stay
@@ -278,9 +222,28 @@ Ref: [auth-consistency-analysis.md](../../../docs/security/auth-consistency-anal
 ## 🟢 Response envelope — phase 2 (success bodies)
 
 Error responses route through `apiError()` + a lint guard (#728). **Success** bodies are
-still ad-hoc (~547 raw `NextResponse.json`, varied shapes: `{data}`, `{household}`,
+still ad-hoc (~252 raw `NextResponse.json`, varied shapes: `{data}`, `{household}`,
 `{Person}`, …). Standardizing them is deliberately deferred to **ride the `handler()`
 migration** (handler owns the success `envelope`), not a parallel rewrite. Ref: P3-1.
+
+---
+
+## Tracked as issues — removed from this ledger (do not re-add)
+
+These were surfaced here, then graduated to the issue tracker. The issue is the
+live record; this doc no longer carries them.
+
+- **Program → Instance → Event, 3-tier restructure** — **#1361** (phase 1: additive
+  tier + backfill). Design: [PROGRAM_INSTANCE_RESTRUCTURE.md](../../../docs/designs/PROGRAM_INSTANCE_RESTRUCTURE.md).
+  Related: #1243 (volunteer↔instance assignment).
+- **GAP-2 drift-guard CI ban** (fail on new `getServerSession` / unregistered prisma
+  route) — **#1320**. Ref: [auth-consistency-analysis.md](../../../docs/security/auth-consistency-analysis.md) §9 Step 7.
+- **Tool categories not modelled** — **#1440**.
+- **Per-level / per-category age gates** (10/13/21) — **#1439**.
+
+The vocab renames still listed above are the body of the umbrella issue **#1322**
+(*Vocab rename ledger (UNFINISHED.md)*), which points back at this doc — so they stay
+here rather than graduating.
 
 ---
 
@@ -319,6 +282,19 @@ migration** (handler owns the success `envelope`), not a parallel rewrite. Ref: 
   `security/handler.ts`), then re-wraps under the route's `envelope` for the wire
   (e.g. `/api/shop/org-members` → `{ org-members: [...] }`). The bag key reading
   differently from the wire key is **intentional**, not a mismatch — do not "fix" it.
+- **Certifier "any-tool → global" widening — ACCEPTED (2026-07-02), not a security
+  issue.** Certifiers are a small group; the `isCertifier` nav/access checks that
+  fire on holding `MAY_CERTIFY_OTHERS` on **any** tool (`shopNav`,
+  `access-resolvers`, `pageRegistry`, `AppFrame`, `ToolManagementPanel`) are
+  intended convenience, not an over-grant. The **grant action itself stays
+  per-tool** ([shop/certifications/route.ts](../../src/app/api/shop/certifications/route.ts)) —
+  you can only certify others on a tool you're a certifier for. No change needed.
+- **`household` vs `family` — split kept, decided.** Code is `Household`; "family"
+  is allowed as warm user copy, and `TrustedAdult.familyContext` is a distinct
+  *attribute* (the board-facing explanation), not a stale alias — both recorded in
+  [VOCABULARY.md](../VOCABULARY.md). The unify option (`familyContext` →
+  `householdContext`, `memberFamilies` → `memberHouseholds`) is **not** being taken.
+  _(was proposal Phase 5)_
 - **`student` / `youth` == non-lead** — checked, **NOT** a logic conflation. It
   lives only in vocabulary (`dependent` ≈ non-lead; old `student` ≈ minor);
   promotion allows a non-lead **adult** → lead (`my-household`). Behavior preserves


### PR DESCRIPTION
Every item in `UNFINISHED.md` re-verified against `main` (ec70d930). The ledger had drifted three ways: decided items still listed as open, items that had graduated to the issue tracker still carried here, and file:line references gone stale as the schema and routes moved.

## Resolved — moved to "Considered and dismissed"

Not deleted, so nobody re-audits them back in.

- **Certifier "any-tool → global" widening.** Already marked ACCEPTED in its own body; no action was left in it.
- **`household` vs `family`.** Decided, and recorded in `VOCABULARY.md`. Worth flagging: the unify path this doc still offered now **contradicts** that glossary, which states `familyContext` is a distinct attribute (the board-facing explanation), not a stale alias for `householdContext`.

## Removed — an open issue owns them now

New *Tracked as issues* section carries a pointer line each, rather than dropping them silently.

| Item | Issue |
|---|---|
| Program → Instance → Event, 3-tier restructure | #1361 (related: #1243) |
| GAP-2 drift-guard CI ban | #1320 |
| Tool categories not modelled | #1440 |
| Per-level / per-category age gates | #1439 |

The vocab renames **deliberately stay**. Umbrella issue #1322 is titled *"Vocab rename ledger (UNFINISHED.md)"* and points back at this doc — graduating them would empty out the thing that issue tracks. Said so in the doc explicitly.

## Corrections to items that are still open

- **"staff" (program sense)** — no user-visible copy left. What remains is code prose plus one nav search keyword; the four cited line numbers were all wrong. Rewritten to name the real sites, and to keep the privileged/admin sense of the word visibly out of scope.
- **"Shop Certifier"** — survives in one place, not three. `RoleBadge.tsx` and `security/core.ts` already say "certifier".
- **`SessionUser`** — declared **four** times, not three. `types/participant.ts` exports one whose role booleans are **required**, and `lib/auth.ts` consumes it; that optionality gap is what makes the consolidation non-mechanical, so it is now called out.
- **Stale references refreshed** — `schema.prisma` 352→507, 144→254, 586/702→888/1049.
- **Drifted counts corrected** — registry `'member'` tokens 34→43; `handler()` 13 of **144** routes with **118** `withAuth` (was 13/101, ~75); raw `NextResponse.json` ~547→~252; non-wrapper `getServerSession` 2→3 (`lib/dev/guard.ts` joined `dev-personas` and `shop/tools`).

## For the reviewer

- **Doc only.** No source, schema, or `src/security/` files touched.
- **Overlaps #1579.** That PR rewrites the `## 🟡 "Review" / "Reviewer"` section into a decided 🟢 item. This PR does not touch those lines, so it merges clean either way — but **#1579's version of that section is the one to keep**.
- The `## 🔴 Admin role ambiguity` section is untouched, still unresolved, still "do not touch inline".

🤖 Generated with [Claude Code](https://claude.com/claude-code)