### PR TITLE
fix(membership-ops): refuse a person merge in the actor's own household

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -58,11 +58,24 @@ describe("Merge Participants API", () => {
     let createdProcessIds: number[];
 
     beforeEach(async () => {
+        extraPersonIds = [];
+        extraHouseholdIds = [];
+        createdProgramId = undefined;
+        createdToolId = undefined;
+        createdEventId = undefined;
+        createdCorporationId = undefined;
+        createdProcessIds = [];
+
         const hh = await prisma.household.create({ data: { name: "Merge Test Household" } });
         householdId = hh.id;
 
+        // The actor lives OUTSIDE the merge subjects' household: the route refuses any
+        // merge touching the actor's own household (conflict of interest, #1588).
         const actor = await prisma.person.create({
-            data: { name: "Board Actor", email: "actor@example.com", householdId: hh.id, isBoardMember: true }
+            data: {
+                name: "Board Actor", email: "actor@example.com", isBoardMember: true,
+                householdId: await makeHousehold("Merge Test Actor Household"),
+            }
         });
         actorId = actor.id;
 
@@ -79,14 +92,6 @@ describe("Merge Participants API", () => {
             data: { name: "Merge User", email: "merge@example.com", phone: "123-456-7890", householdId: hh.id }
         });
         pMergeId = pMerge.id;
-
-        extraPersonIds = [];
-        extraHouseholdIds = [];
-        createdProgramId = undefined;
-        createdToolId = undefined;
-        createdEventId = undefined;
-        createdCorporationId = undefined;
-        createdProcessIds = [];
     });
 
     /** A second household for the membership-guard tests; no OrgMembership row reads as NONE. */
@@ -503,6 +508,55 @@ describe("Merge Participants API", () => {
             await prisma.person.update({ where: { id: pMergeId }, data: { householdId } });
             const clean = await analyzeGET(analyzeReq(pKeepId, pMergeId));
             expect((await clean.json()).membershipBlock).toEqual({ aAsKeeper: null, bAsKeeper: null });
+        });
+    });
+
+    // The merge takes the newer lastBackgroundCheck of the two records, so merging is a
+    // way to seat a background-check date on a person — with no second actor. Both
+    // subjects are checked: the two need not share a household (#1588).
+    describe("conflict of interest", () => {
+        it("403s when the actor shares a household with the kept record", async () => {
+            const tombstoneHh = await makeHousehold("Tombstone Household");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: tombstoneHh } });
+            await prisma.person.update({ where: { id: actorId }, data: { householdId } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(403);
+            expect((await res.json()).error).toContain("your own household");
+
+            // Refused before the transaction — nothing moved.
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBeNull();
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.email).toBe("merge@example.com");
+        });
+
+        it("403s when the actor shares a household with the merged-away record only", async () => {
+            const keeperHh = await makeHousehold("Keeper Household");
+            await prisma.person.update({ where: { id: pKeepId }, data: { householdId: keeperHh } });
+            await prisma.person.update({ where: { id: actorId }, data: { householdId } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(403);
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBeNull();
+        });
+
+        it("403s a sysadmin too — no role bypasses the rule", async () => {
+            await prisma.person.update({ where: { id: actorId }, data: { householdId } });
+            mockGetServerSession.mockResolvedValue({
+                user: { id: actorId, email: "actor@example.com", isSysadmin: true, isBoardMember: true }
+            });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(403);
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBeNull();
+        });
+
+        it("allows the merge when the actor is outside both households", async () => {
+            const tombstoneHh = await makeHousehold("Unrelated Household");
+            await prisma.person.update({ where: { id: pMergeId }, data: { householdId: tombstoneHh } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBe(pKeepId);
         });
     });
 

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -4,6 +4,7 @@ import type { Person } from "@/generated/prisma/client";
 import { withAuth } from "@/lib/auth";
 import { logBackendError } from "@/lib/logger";
 import { apiError } from "@/lib/api-response";
+import { hasHouseholdConflict } from "@/lib/conflictOfInterest";
 import { personBgOpen } from "@/lib/membership/lifecycle";
 import { LIVE_PERSON } from "@/lib/person/filters";
 import type { TxClient } from "@/lib/db-client";
@@ -243,6 +244,20 @@ export const POST = withAuth(
             // Double-merge / merge-a-tombstone guard — either side, before opening the tx.
             if (keepParticipant.mergedIntoId != null || mergeParticipant.mergedIntoId != null) {
                 return apiError("Cannot merge: one of these participants has already been merged.", 409);
+            }
+
+            // Conflict of interest: no actor may merge a record in their OWN household.
+            // The merge takes the newer of the two lastBackgroundCheck dates
+            // (resolveKeeperUpdate), so without this an actor can seat a background-check
+            // date on their own family with no second actor — the thing attest() and
+            // overrideBlocked refuse. Both subjects count: the tombstone's household is
+            // where the carried date comes from, the keeper's is where it lands, and the
+            // two need not be the same household. No role bypasses this.
+            if (auth.type === 'session' && (
+                await hasHouseholdConflict(prisma, auth.user.id, keepParticipant.householdId)
+                || await hasHouseholdConflict(prisma, auth.user.id, mergeParticipant.householdId)
+            )) {
+                return apiError("You cannot merge a record in your own household — someone outside your household must.", 403);
             }
 
             const isLead = mergeParticipant.isHouseholdLead;


### PR DESCRIPTION
Fixes #1588

## The gap

`POST /api/membership-ops/participants/merge` was gated on `withAuth({ roles: ['isSysadmin', 'isBoardMember'] })` and called `hasHouseholdConflict` nowhere. `resolveKeeperUpdate` takes the newer of the two records' `lastBackgroundCheck`, so a board member could merge a record to seat a background-check date on a person in their own household — with no second actor. That is the action `attest()` and `overrideBlocked` both refuse, and six other call sites already guard this way. The merge route was the outlier.

## The change

A pre-transaction guard, next to the route's existing household-lead and membership-state guards:

```ts
if (auth.type === 'session' && (
    await hasHouseholdConflict(prisma, auth.user.id, keepParticipant.householdId)
    || await hasHouseholdConflict(prisma, auth.user.id, mergeParticipant.householdId)
)) {
    return apiError("You cannot merge a record in your own household — someone outside your household must.", 403);
}
```

Shape matches `membership-ops/households/route.ts:304` — 403, `auth.type === 'session'` gate, resolve the actor's household from the DB rather than the JWT snapshot. The short-circuit means one `findUnique` in the common case. The merge page already renders `data.error` in its AlertBanner, so no client change was needed.

## The three decisions the issue asked for

**Both subjects are checked.** #1451's `membershipMergeBlock` refuses merges across mismatched `OrgMembership.status`, not across households — two `NONE` households merge fine today. So the keeper and the merged-away record can still sit in different households and either one can be the actor's. The two-subject case does not collapse.

**No sysadmin exemption.** Matches `conflictOfInterest.ts`'s module contract ("No role is exempt... a break-glass path needs its own audited, multi-actor mechanism") and the privileged-actor case in `conflictOfInterest.test.ts`. Pinned by a test here too.

**Refuse the merge rather than withhold the compliance dates** — a deliberate deviation from `MERGE_BG_CARRYOVER.md`, which prefers shape 1 (withhold the privileged effect, let the merge proceed). That preference was written for the carryover, where the privileged effect is one separable write. Here it is not:

- three privileged effects ride the same one-shot transaction — `lastBackgroundCheck`, `lastWaiverSign`, and `archiveDuplicatePersonBg` closing the person's own open background-check review;
- a half-merge cannot be completed later. The tombstone CAS throws `AlreadyMergedError` on a second attempt, so a merge that silently dropped the dates would leave the pair permanently unmergeable and the dates recoverable only by hand.

Refusing is recoverable: another board member runs the merge.

## Boundary isolation

Route-level guard over an existing `lib/` helper. Two files touched, neither under `checkin-app/src/security/`, so `security-boundary-isolation.yml` does not apply.

## Tests

Four cases added to the merge integration suite — actor shares the keeper's household → 403; shares only the merged-away record's household → 403; sysadmin → 403; actor outside both → 200. Each 403 case asserts `mergedIntoId` is still null, proving the refusal lands before the transaction.

**Reviewer note on the fixture change.** The suite's `beforeEach` created the actor in the *same* household as both merge subjects, so all 48 existing tests would have started 403ing. The actor moves to its own household via the existing `makeHousehold` helper, which required hoisting the `extraPersonIds`/`extraHouseholdIds` resets to the top of `beforeEach` so the helper's push survives. No test's intent changed.

## Verification

Run from `checkin-app/` against a throwaway Postgres with `prisma migrate deploy` applied.

- `npm run test:integration -- --testPathPatterns "participants/merge"` → 52/52
- `npm run test:integration -- --testPathPatterns "auditLog|authzRoleRejection"` → 130/130 — the only other integration files that import the merge POST
- `npm run test:ci` → 272 suites, 2621/2621
- `npx tsc --noEmit` → clean

The full integration suite was not run; the change is route-local and both other merge-route consumers are covered above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)