### PR TITLE
fix(membership-ops): the check passed — it was not cleaned, and nothing was cleared

### DIFF
--- a/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
@@ -80,10 +80,10 @@ describe("membership-ops/review page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Attest — check is clean" }));
     // Pat already holds one approval, so naming Pat is the SECOND — the confirm names
     // the consequence of a clearing approve rather than a generic "are you sure?".
-    expect(await screen.findByText("Attest this background check is clean?")).toBeInTheDocument();
+    expect(await screen.findByText("Attest that this background check passed?")).toBeInTheDocument();
     expect(screen.getByText(/emails the family/)).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledTimes(1); // the queue GET only — nothing posted yet
-    fireEvent.click(screen.getByRole("button", { name: "Attest the check is clean" }));
+    fireEvent.click(screen.getByRole("button", { name: "Attest — the check passed" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
@@ -106,7 +106,7 @@ describe("membership-ops/review page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Attest — check is clean" }));
     fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
 
-    await waitFor(() => expect(screen.queryByText("Attest this background check is clean?")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText("Attest that this background check passed?")).not.toBeInTheDocument());
     expect(fetchMock).toHaveBeenCalledTimes(1); // the queue GET only
   });
 

--- a/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/review/__tests__/page.test.tsx
@@ -66,9 +66,9 @@ describe("membership-ops/review page", () => {
     renderPage();
     await screen.findByText("The Smiths");
 
-    expect(screen.getByRole("button", { name: "Attest — check is clean" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Attest — the check passed" })).toBeDisabled();
     nameSubject("Sam Smith");
-    expect(screen.getByRole("button", { name: "Attest — check is clean" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Attest — the check passed" })).toBeEnabled();
   });
 
   it("approves an attestation", async () => {
@@ -77,13 +77,13 @@ describe("membership-ops/review page", () => {
     renderPage();
     await screen.findByText("The Smiths");
 
-    fireEvent.click(screen.getByRole("button", { name: "Attest — check is clean" }));
+    fireEvent.click(screen.getByRole("button", { name: "Attest — the check passed" }));
     // Pat already holds one approval, so naming Pat is the SECOND — the confirm names
     // the consequence of a clearing approve rather than a generic "are you sure?".
     expect(await screen.findByText("Attest that this background check passed?")).toBeInTheDocument();
     expect(screen.getByText(/emails the family/)).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledTimes(1); // the queue GET only — nothing posted yet
-    fireEvent.click(screen.getByRole("button", { name: "Attest — the check passed" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm — the check passed" }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
@@ -103,7 +103,7 @@ describe("membership-ops/review page", () => {
     renderPage();
     await screen.findByText("The Smiths");
 
-    fireEvent.click(screen.getByRole("button", { name: "Attest — check is clean" }));
+    fireEvent.click(screen.getByRole("button", { name: "Attest — the check passed" }));
     fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
 
     await waitFor(() => expect(screen.queryByText("Attest that this background check passed?")).not.toBeInTheDocument());
@@ -117,7 +117,7 @@ describe("membership-ops/review page", () => {
     await screen.findByText("The Smiths");
 
     nameSubject("Pat Smith");
-    fireEvent.click(screen.getByRole("button", { name: "Attest — check is clean" }));
+    fireEvent.click(screen.getByRole("button", { name: "Attest — the check passed" }));
     expect(await screen.findByText("Record your approval?")).toBeInTheDocument();
     expect(screen.getByText(/A second\s+reviewer must also\s+approve/)).toBeInTheDocument();
     fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Approve" }));

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -135,7 +135,7 @@ export default function MembershipReviewPage() {
     // by then, so an existing attestation is enough to know this click is the last one.
     const clearing = result === "APPROVE" && item._count.attestations >= 1;
     modals.openConfirmModal({
-      title: result === "REJECT" ? "Reject this background check?" : clearing ? "Attest this background check is clean?" : "Record your approval?",
+      title: result === "REJECT" ? "Reject this background check?" : clearing ? "Attest that this background check passed?" : "Record your approval?",
       children: (
         <Text size="sm">
           {result === "REJECT" ? (
@@ -145,7 +145,7 @@ export default function MembershipReviewPage() {
             </>
           ) : clearing ? (
             <>
-              You are the second reviewer for <strong>{who}</strong>. Attesting the check is clean
+              You are the second reviewer for <strong>{who}</strong>. Attesting that the check passed
               records that against {item.subjectPerson ? "the subject" : leadName(item, chosenSubject(item)!)},
               opens payment (or activates the membership if dues are already paid), and emails the
               family. It cannot be undone.
@@ -154,12 +154,12 @@ export default function MembershipReviewPage() {
             <>
               This records your approval of <strong>{who}</strong>&apos;s background check
               {item.subjectPerson ? "" : ` for ${leadName(item, chosenSubject(item)!)}`}. A second
-              reviewer must also approve the same person before the check is attested clean.
+              reviewer must also approve the same person before the check passes.
             </>
           )}
         </Text>
       ),
-      labels: { confirm: result === "REJECT" ? "Reject" : clearing ? "Attest the check is clean" : "Approve", cancel: "Cancel" },
+      labels: { confirm: result === "REJECT" ? "Reject" : clearing ? "Attest — the check passed" : "Approve", cancel: "Cancel" },
       confirmProps: { color: result === "REJECT" ? "red" : clearing ? "orange" : undefined },
       onConfirm: () => submit(item.id, result),
     });

--- a/checkin-app/src/app/membership-ops/review/page.tsx
+++ b/checkin-app/src/app/membership-ops/review/page.tsx
@@ -125,8 +125,8 @@ export default function MembershipReviewPage() {
     return p?.name || p?.email || `Person #${personId}`;
   };
 
-  // Attesting is a one-click, two-of-two decision, and the SECOND approval clears the
-  // check outright — stamping the named adult, opening payment or activating, and
+  // Attesting is a one-click, two-of-two decision, and the SECOND approval
+  // completes the check — stamping the named adult, opening payment or activating, and
   // emailing the family. Confirm both actions, and say what the click actually does
   // rather than "are you sure?", which trains people to click through.
   const confirmSubmit = (item: QueueItem, result: "APPROVE" | "REJECT") => {
@@ -159,7 +159,7 @@ export default function MembershipReviewPage() {
           )}
         </Text>
       ),
-      labels: { confirm: result === "REJECT" ? "Reject" : clearing ? "Attest — the check passed" : "Approve", cancel: "Cancel" },
+      labels: { confirm: result === "REJECT" ? "Reject" : clearing ? "Confirm — the check passed" : "Approve", cancel: "Cancel" },
       confirmProps: { color: result === "REJECT" ? "red" : clearing ? "orange" : undefined },
       onConfirm: () => submit(item.id, result),
     });
@@ -288,7 +288,7 @@ export default function MembershipReviewPage() {
                   loading={busyId === item.id}
                   onClick={() => confirmSubmit(item, "APPROVE")}
                 >
-                  Attest — check is clean
+                  Attest — the check passed
                 </Button>
                 <Button color="red" variant="light" disabled={busyId === item.id || !reviewNotes[item.id]?.trim()} onClick={() => confirmSubmit(item, "REJECT")}>
                   Reject


### PR DESCRIPTION
## The word

"Clear the check" carries **two** wrong readings, not one. Beyond *erase the check*, it also reads as *clear the current state* — reset, discard, start over. On a screen whose other action is **Reject**, that is arguably the more natural reading.

#1575 replaced it with "clean", which fixed the erase sense but left an odd claim: a background check is not clean or dirty. It **passed**, or it did not.

| | Now |
|---|---|
| Title | Attest that this background check **passed**? |
| Body | Attesting that the check **passed** records that against… |
| Button | Attest — the check **passed** |
| First reviewer | …before the check **passes**. |

The act is still attestation and the row written is still an attestation; only the outcome is renamed.

## Correction to an earlier version of this description

This PR previously claimed #1582 "branched before #1575 merged" and "will conflict". **That is false.** #1575's merge commit `b3ae31f4` is an ancestor of #1582 — `git merge-base --is-ancestor b3ae31f4 <1582 head>` returns true — and `git merge-tree` against `origin/main` is clean. GitHub's `CONFLICTING` flag on #1582 is stale.

**The correction makes the hazard worse, not better.** #1582 rewrites the same four strings and merges **without a conflict**, so nothing warns a reviewer that #1575's wording is being replaced. A silent revert is harder to catch than a noisy one.

## Three live proposals for the same four strings

| | Title | Confirm button |
|---|---|---|
| **#1575** (merged) | Attest this background check is clean? | Attest the check is clean |
| **#1582** (open) | Attest — this completes the background clearance? | Attest — complete the clearance |
| **#1592** (this) | Attest that this background check passed? | Attest — the check passed |

**#1579** writes the dictionary that #1582 implements, and rules "clean is out" — agreed, and this removes it. Where it and this PR differ is whether `clear`/`clearance` is safe in the *button*. #1579's position is that `clear` is fine once defined as *grant a clearance*. The counter-argument is that a definition in `VOCABULARY.md` does not travel to the person reading a confirm dialog, and this is the one place where the wrong reading is destructive and irreversible.

`pass` has no second meaning here. `clear` and `clean` both do.

A resolution that satisfies both: keep #1579's model — a reviewer **reviews**, **attests**, and two attestations produce a **clearance** — so `clearance` stays the noun in prose and identifiers, while the *button* states what the reviewer is asserting. #1582's own body text ("Attesting clears the background check", line 148) would then be the only line left to settle.

**This needs one human decision before #1579, #1582 or #1592 merges.** Whichever lands last silently overwrites the others.

## Verified

`jest src/app/membership-ops/review` 9/9, lint clean. Behaviour unchanged; only strings and the two assertions that drive them by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
