### PR TITLE
security(isolation): terminate the scope-oracle pin's regress at a non-test check

### DIFF
--- a/.github/workflows/security-boundary-isolation.yml
+++ b/.github/workflows/security-boundary-isolation.yml
@@ -92,6 +92,18 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          # The scope-oracle pin (checkin-app/tests/security/scopeOracleSet.test.ts)
+          # is what makes a deleted oracle fail loudly, but a deleted test cannot
+          # fail, so the pin cannot guard itself. This is where that regress
+          # terminates: a check that is not a test. Deliberately against the
+          # checked-out merge ref (refs/pull/N/merge), not HEAD_SHA — that tree is
+          # what actually lands on main, and a branch cut before the pin existed
+          # would fail a HEAD_SHA check while removing nothing.
+          test -f checkin-app/tests/security/scopeOracleSet.test.ts || {
+            echo "::error::checkin-app/tests/security/scopeOracleSet.test.ts is missing — it pins the security scope-oracle set and cannot guard its own deletion."
+            exit 1
+          }
+
           # Diff the PR's OWN head, not the checked-out merge ref. On a
           # pull_request, checkout resolves refs/pull/N/merge — the branch
           # merged with the current tip of main — so HEAD carries main's newest

--- a/checkin-app/tests/security/scopeOracleSet.test.ts
+++ b/checkin-app/tests/security/scopeOracleSet.test.ts
@@ -15,6 +15,10 @@
  *
  * So the set is pinned here. Adding an oracle costs one line and makes a
  * reviewer see the new file; removing one has to be written down on purpose.
+ *
+ * This file cannot pin itself — a deleted test cannot fail — so its own
+ * existence is asserted by security-boundary-isolation.yml, which runs on every
+ * PR into main whether or not the Jest suite does.
  */
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';


### PR DESCRIPTION
Follows #1591, which is now merged; this branch is rebased onto `main`, so the diff is only the 16 lines added here.

## What this fixes

#1591 pins the set of per-model scope oracles under `checkin-app/src/security/__tests__/`, restoring the mechanical backstop that #1590 removed when it reclassified those oracles as companions rather than boundary files. That reclassification was correct; a decommission has to update its own oracle, and treating oracles as boundary files made the decommission exception refuse the very shape it exists for.

But the pin is itself unpinned, and it cannot pin itself: **a deleted test cannot fail**, so any self-reference inside `scopeOracleSet.test.ts` is vacuous. Deleting the pin inside a large feature diff trips neither the test suite nor boundary isolation, because `checkin-app/tests/security/*` matches `is_companion` and never `is_boundary`. The only guard left is CODEOWNERS: a human reading a large diff, which is exactly the failure the isolation machinery exists to stop.

The regress only terminates at a check that is **not a test**.

## What changed

**`.github/workflows/security-boundary-isolation.yml`** gains a `test -f` assertion at the top of the `Check boundary changes ship alone` step's `run:` block. Placement is deliberate: it sits above both the `CHANGED_RAW` empty-diff exit and the `BOUNDARY_TOUCHED` early exit, so it runs on every PR into `main` no matter what the PR touches. The workflow has no `paths:` filter, and the assertion is inside the step already gated on `pull_request && base_ref == 'main'`, so it inherits that gate and stays quiet on `merge_group` and `rel/**` runs where there is no PR shape to check.

**`checkin-app/tests/security/scopeOracleSet.test.ts`** gains two lines of docblock naming what guards the pin, so a later reader does not have to rediscover the regress.

## Reviewer notes

**Why `test -f` against the merge ref rather than `git cat-file -e` against `HEAD_SHA`.** The surrounding diff logic deliberately avoids the checked-out merge ref because it would sweep in main's advance and mis-attribute it to the PR. That hazard is specific to *diffing*. For a presence check the merged tree is the right question; it is what actually lands on `main`. A `HEAD_SHA` check would additionally fail every in-flight branch cut before the pin existed, none of which removes anything. The reasoning is recorded in a comment at the assertion.

**Why the workflow rather than `checkin-app/scripts/check-route-coverage.ts`.** The CI step that runs that script is gated on `needs.changes.outputs.app`, so it is conditional in a way this assertion must not be; a required-file check is also not what that script is about.

**Isolation status of this PR:** both changed files are `is_companion` and neither is `is_boundary`, so `BOUNDARY_TOUCHED=0`. Nothing under `checkin-app/src/security/` is touched.

## Verification

Re-run after the rebase onto `main`, not carried over from the pre-rebase branch:

- The workflow parses as YAML, and the assertion is confirmed to sit inside the main-only gated step rather than a sibling step.
- The guard was proven in both directions: with the pin moved aside the snippet exits 1 with the `::error::` line under `bash -euo pipefail`; restored, it exits 0. The snippet was extracted from the *parsed* YAML, so what ran is what CI runs.
- The pin test is still green, 12 of 12, narrowed with `--testPathPatterns scopeOracleSet` through the package script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
