### PR TITLE
security(registry): correct the corrections-route comment

### DIFF
--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -133,10 +133,9 @@ defineRoute({
 // so no field distinguishes them. Array position is the only discriminator, and
 // it survives because stripValue maps arrays element-wise and preserves order.
 //
-// Registered ahead of the route per the boundary isolation rule (AGENTS.md);
-// GET /api/facility/corrections does not exist yet. Blocked on #1523 (persist
-// significance on every Visit audit write) — the review is only meaningful
-// once every write scores.
+// Served by src/app/api/facility/corrections/route.ts. Its flagged-only default
+// view is complete only once every Visit audit write persists
+// newData.significance (#1523, PR #1558) — an unscored write never surfaces.
 defineRoute({
     endpoint: 'GET /api/facility/corrections',
     authorize: { anyRole: ['isSysadmin', 'isBoardMember'] },


### PR DESCRIPTION
## What

Rewrites one comment block in `checkin-app/src/security/registry.ts`, above the
`GET /api/facility/corrections` entry that #1559 landed.

The old text said the route "does not exist yet". #1560 adds
`src/app/api/facility/corrections/route.ts` and the page, so that sentence stops
being true; the comment now names the file that serves the endpoint. The second
point is kept because it is still live: the flagged-only default view is only
complete once every Visit audit write persists `newData.significance`
(#1523, PR #1558).

## Scope

**Comment text only.** No grant change — the `defineRoute` call is
byte-identical: same `authorize`, `envelope`, `returns`, and `orderedView`. The
diff is 3 insertions / 4 deletions, all on `//` lines.

## Why it ships alone

`registry.ts` is a security-boundary file, so
`.github/workflows/security-boundary-isolation.yml` requires the change to be
the only file in its PR. That rules out folding it into #1560's feature diff,
which is route + page + tests.

## Merge order

Merge this **after** #1560. Until that route handler is on `main`, the file this
comment points at does not exist there.

Closes no issue.