### PR TITLE
fix(security): all_current_visitors must not count tombstoned visits

### DIFF
--- a/checkin-app/src/__tests__/liveVisitDriftGuard.test.ts
+++ b/checkin-app/src/__tests__/liveVisitDriftGuard.test.ts
@@ -26,7 +26,6 @@ import { join, relative, sep } from 'node:path';
 const SRC = join(__dirname, '..');
 
 const ALLOWLIST: Record<string, string> = {
-    'security/access-resolvers.ts': 'Boundary file (security-boundary-isolation.yml): the keyholder-scope query gains its LIVE_VISIT filter in an isolated boundary PR, not in the feature PR that introduced the tombstone. Remove this entry in that PR.',
     'app/api/facility/trends/route.ts': 'Scanner is textually blind to the variable-held where: the findMany passes `whereClause`, which is built a few lines up WITH `deletedAt: null`.',
     'app/api/membership-ops/participants/merge/analyze/route.ts': 'Merge PREVIEW: `_count.visits` counts the rows the merge will move, and a merge moves tombstoned visits with the person (provenance travels). Filtering would understate the preview against the actual move.',
     'app/api/membership-ops/participants/merge/route.ts': 'The merge itself: tombstoned visits travel with the person, same rule the PREVIEW counts by — filtering would strand them on the merged-away tombstone.',

--- a/checkin-app/src/security/__tests__/active-visitors-tombstone.test.ts
+++ b/checkin-app/src/security/__tests__/active-visitors-tombstone.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * all_current_visitors must not count a tombstoned visit (#1503).
+ *
+ * A Visit is tombstoned, never removed (deletedAt + deletedById). Deleting an
+ * OPEN visit therefore leaves departedAt null forever, so `departedAt: null`
+ * alone reads the row as "this person is currently in the building" for the
+ * rest of time. The keyholder grant fails OPEN on that row, which is why both
+ * halves of the scope are pinned here:
+ *
+ *   - the context prefetch that builds ctx.activeVisitorIds
+ *     (buildCallerContext, access-resolvers.ts), and
+ *   - the per-row Visit predicate (SCOPE_BINDINGS, scopeBindings.ts).
+ *
+ * Person.all_current_visitors keys on ctx.activeVisitorIds, so it is fixed by
+ * the prefetch rather than by its own binding — the last describe pins that so
+ * the transitive path cannot silently regress.
+ */
+import prisma from '@/lib/prisma';
+import { buildCallerContext, scopesHeld, type CallerContext } from '../access-resolvers';
+import { LIVE_PERSON } from '@/lib/person/filters';
+import { LIVE_VISIT } from '@/lib/visit/filters';
+import type { CtxNeeds } from '../core';
+import type { AuthResult } from '@/types/auth';
+
+const keyholderAuth: AuthResult = {
+    type: 'session',
+    user: {
+        id: 12,
+        householdId: 6,
+        isSysadmin: false,
+        isBoardMember: false,
+        isKeyholder: true,
+        isBackgroundCheckReviewer: false,
+        isOperations: false,
+    },
+};
+
+// What deriveCtxNeeds yields for a route whose only row-scoped grant is
+// all_current_visitors: the visitor prefetch and nothing else.
+const VISITORS_ONLY: CtxNeeds = {
+    programs: false,
+    programHouseholds: false,
+    programEvents: false,
+    activeVisitors: true,
+    ledHouseholdMembers: false,
+};
+
+function ctx(opts: Partial<CallerContext> = {}): CallerContext {
+    return {
+        selfId: undefined,
+        householdId: undefined,
+        isKeyholder: false,
+        isKiosk: false,
+        programsLed: new Set(),
+        programsCoreVolIn: new Set(),
+        participantIdsInScopePrograms: new Set(),
+        householdIdsInScopePrograms: new Set(),
+        eventIdsInScopePrograms: new Set(),
+        activeVisitorIds: new Set(),
+        ledHouseholdMemberIds: new Set(),
+        ...opts,
+    };
+}
+
+describe('activeVisitorIds prefetch excludes tombstoned visits and merged-away people', () => {
+    it('filters the query by LIVE_VISIT and LIVE_PERSON, not departedAt alone', async () => {
+        // The prefetch is a single findMany, so the `where` IS the filter: a
+        // tombstoned open visit reaches activeVisitorIds iff the database is
+        // asked for it. Asserting the query is what makes this a unit test.
+        const findMany = jest.fn().mockResolvedValue([{ personId: 9 }]);
+        prisma.visit.findMany = findMany;
+
+        const built = await buildCallerContext(keyholderAuth, VISITORS_ONLY);
+
+        expect(findMany).toHaveBeenCalledWith({
+            where: { departedAt: null, ...LIVE_VISIT, person: LIVE_PERSON },
+            select: { personId: true },
+        });
+        expect([...built.activeVisitorIds]).toEqual([9]);
+    });
+});
+
+describe('Visit.all_current_visitors — the per-row predicate', () => {
+    const keyholder = ctx({ selfId: 12, householdId: 6, isKeyholder: true });
+    const openVisit = { id: 1, personId: 9, departedAt: null, deletedAt: null };
+
+    it('grants it on a live open visit', () => {
+        expect(scopesHeld('Visit', openVisit, keyholder).has('all_current_visitors')).toBe(true);
+    });
+
+    it('does NOT grant it on a tombstoned open visit', () => {
+        const tombstoned = { ...openVisit, deletedAt: new Date() };
+        expect(scopesHeld('Visit', tombstoned, keyholder).has('all_current_visitors')).toBe(false);
+    });
+
+    it('still does not grant it on a departed visit, or to a non-keyholder', () => {
+        const departed = { ...openVisit, departedAt: new Date() };
+        expect(scopesHeld('Visit', departed, keyholder).has('all_current_visitors')).toBe(false);
+        expect(scopesHeld('Visit', openVisit, ctx({ selfId: 12 })).has('all_current_visitors')).toBe(
+            false,
+        );
+    });
+});
+
+describe('Person.all_current_visitors — fixed transitively by the prefetch', () => {
+    it('holds only for people the prefetch put in activeVisitorIds', () => {
+        // The Person binding reads ctx.activeVisitorIds and nothing else, so a
+        // person whose only open visit was tombstoned is absent from the set
+        // and holds nothing — no second binding change needed.
+        const keyholder = ctx({ selfId: 12, isKeyholder: true, activeVisitorIds: new Set([9]) });
+        expect(scopesHeld('Person', { id: 9 }, keyholder).has('all_current_visitors')).toBe(true);
+        expect(scopesHeld('Person', { id: 7 }, keyholder).has('all_current_visitors')).toBe(false);
+    });
+});

--- a/checkin-app/src/security/access-resolvers.ts
+++ b/checkin-app/src/security/access-resolvers.ts
@@ -18,6 +18,7 @@ import { config, isStagingAccessAllowed } from '@/lib/config';
 import type { AuthResult } from '@/types/auth';
 import type { Authorize, CtxNeeds, Role } from './core';
 import { LIVE_PERSON } from '@/lib/person/filters';
+import { LIVE_VISIT } from '@/lib/visit/filters';
 
 export interface CallerContext {
     selfId?: number;
@@ -91,9 +92,11 @@ export async function buildCallerContext(auth: AuthResult, needs: CtxNeeds): Pro
                   },
               })
             : [],
+        // A tombstoned visit keeps departedAt null forever, so LIVE_VISIT is what
+        // stops a deleted open visit from reading as "still in the building".
         needs.activeVisitors && ctx.isKeyholder
             ? prisma.visit.findMany({
-                  where: { departedAt: null },
+                  where: { departedAt: null, ...LIVE_VISIT, person: LIVE_PERSON },
                   select: { personId: true },
               })
             : [],

--- a/checkin-app/src/security/scopeBindings.ts
+++ b/checkin-app/src/security/scopeBindings.ts
@@ -101,8 +101,15 @@ export const SCOPE_BINDINGS = {
     Visit: {
         their_own: { field: 'personId', eqCtx: 'selfId' },
         led_households: { field: 'personId', inCtx: 'ledHouseholdMemberIds' },
+        // deletedAt is a conjunct, not a nicety: a tombstoned visit keeps
+        // departedAt null forever, so without it a deleted open visit reads as
+        // an active one for the rest of time.
         all_current_visitors: {
-            all: [{ flag: 'isKeyholder' }, { field: 'departedAt', isNull: true }],
+            all: [
+                { flag: 'isKeyholder' },
+                { field: 'departedAt', isNull: true },
+                { field: 'deletedAt', isNull: true },
+            ],
         },
     },
     RawBadgeLog: { their_own: { field: 'personId', eqCtx: 'selfId' } },

--- a/checkin-app/tests/security/scopeOracleSet.test.ts
+++ b/checkin-app/tests/security/scopeOracleSet.test.ts
@@ -27,6 +27,7 @@ const ORACLE_DIR = path.join(__dirname, '..', '..', 'src', 'security', '__tests_
 
 // Each entry is a model or route whose visibility nothing else asserts.
 const ORACLES = [
+    'active-visitors-tombstone.test.ts',
     'emergency-contact-program-scope.test.ts',
     'household-lead-program-scope.test.ts',
     'impersonatedBy-inertness.test.ts',


### PR DESCRIPTION
Fixes #1503

## What

A `Visit` is tombstoned, not removed (`deletedAt` + `deletedById`), so deleting an **open** visit leaves `departedAt` null forever and the row reads as "this person is currently in the building" for the rest of time. Three places in the boundary took `departedAt` alone as proof of presence:

**1. The `activeVisitorIds` prefetch** (`src/security/access-resolvers.ts`) queried `{ departedAt: null }` with no `LIVE_VISIT` and no `person: LIVE_PERSON`, so the set carried people whose open visit was deleted and people since merged away. The `programVolunteer` query two entries above and the `led_households` query below it both already applied `LIVE_PERSON` — the file was inconsistent with itself.

```diff
-      where: { departedAt: null },
+      where: { departedAt: null, ...LIVE_VISIT, person: LIVE_PERSON },
```

**2. The Visit binding** (`src/security/scopeBindings.ts`) — a tombstoned open row satisfied the `all` list. Third conjunct added in the existing term grammar, same shape as the `departedAt` term beside it:

```diff
 all_current_visitors: {
-    all: [{ flag: 'isKeyholder' }, { field: 'departedAt', isNull: true }],
+    all: [
+        { flag: 'isKeyholder' },
+        { field: 'departedAt', isNull: true },
+        { field: 'deletedAt', isNull: true },
+    ],
 },
```

**3. `Person.all_current_visitors`** keys on `ctx.activeVisitorIds` and nothing else, so it inherited (1) transitively. Fixed by the prefetch filter with no binding change — pinned by a test rather than edited.

## Why now

Latent, not live: **no route grants `all_current_visitors`** (it does not appear in `registry.ts`), so nothing is leaking today. It fails **open**, which is why it is worth closing before the first consumer arrives rather than after. AT3 (#1254 / #1478) gives members and household leads a self-service delete on their own visits, which makes deleting an open visit a routine action.

## The drift-guard allowlist entry

`src/__tests__/liveVisitDriftGuard.test.ts` walks all of `src/`, so `src/security/` was already in its scan scope. The defect survived because it was parked in that guard's ALLOWLIST with a justification naming this exact PR:

> "Boundary file (security-boundary-isolation.yml): the keyholder-scope query gains its LIVE_VISIT filter in an isolated boundary PR, not in the feature PR that introduced the tombstone. **Remove this entry in that PR.**"

Entry removed. The guard's stale-entry test is what surfaced it on the full run.

## Tests

New oracle `src/security/__tests__/active-visitors-tombstone.test.ts` (5 tests), in the existing oracle directory. It pins both halves of the scope — the prefetch query and the per-row predicate — plus the transitive `Person` path.

With the two source files stashed and the test kept: **2 failed, 3 passed** — the prefetch `where` assertion, and `does NOT grant it on a tombstoned open visit` (`Expected: false / Received: true`). With them restored: 5 passed.

Two pins the new file forces:
- `tests/security/scopeOracleSet.test.ts` — pins the oracle-file set by name.
- `src/__tests__/liveVisitDriftGuard.test.ts` — the allowlist removal above.

`scopeBindingsEquivalence` needed no change: its Visit fixture rows carry no `deletedAt`, and `isNull` is `== null`, so the new conjunct is vacuous against the frozen oracle.

## Boundary isolation

Two boundary files, three companions (`src/security/*`, `tests/security/*`, `*/__tests__/*`). No app/feature code, no route, no grant, no registry entry, no classifications diff — so no re-tier. #1502 would have been the natural host but merged on 2026-08-05, so this stands alone.

## For the reviewer

`isNull` is `row[field] == null`, so an **unselected** `deletedAt` column (`undefined`) satisfies the term. A future route serving Visit rows without selecting `deletedAt` re-opens the hole at the binding layer. The existing `departedAt` term has the same weakness, and closing it needs either a strict-null matcher (new grammar) or a `ROW_SCOPE_KEY`-style fail-closed entry for Visit — deliberately out of scope here. The prefetch fix has no such caveat: it is a real SQL predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)