### PR TITLE
fix(attendance): serialize conflict resolution so both halves can't be deleted

### DIFF
--- a/checkin-app/src/app/__tests__/visitWriteLockConcurrency.integration.test.ts
+++ b/checkin-app/src/app/__tests__/visitWriteLockConcurrency.integration.test.ts
@@ -2,16 +2,17 @@
  * @jest-environment node
  */
 /**
- * Concurrency regression tests for the two visit-write paths that had no
- * per-person advisory lock: PATCH /api/events/[id] (manualEditAttendance) and
- * DELETE /api/facility/visits.
+ * Concurrency regression tests for the visit-write paths that do a
+ * read-then-write on Visit: PATCH /api/events/[id] (manualEditAttendance),
+ * DELETE /api/facility/visits, and POST /api/my-programs/conflicts/resolve.
  *
- * Both did a read-then-write on Visit with nothing serializing them, so a
- * concurrent writer could invalidate the pre-check before the write landed:
- * two Present marks on different events both saw "no open visit" and both
- * created one (P2002 on Visit_one_open_per_participant → 500), and two deletes
- * both saw the row live and both tombstoned it, the second overwriting who
- * deleted it. Each now runs inside a $transaction that takes
+ * With nothing serializing them a concurrent writer could invalidate the
+ * pre-check before the write landed: two Present marks on different events both
+ * saw "no open visit" and both created one (P2002 on
+ * Visit_one_open_per_participant → 500), two deletes both saw the row live and
+ * both tombstoned it, and two conflict resolutions each saw the other half of
+ * the overlap still live and tombstoned both, erasing the session entirely.
+ * Each now runs inside a $transaction that takes
  * `pg_advisory_xact_lock(<the visit's personId>)` and re-checks under the lock,
  * matching /api/scan and /api/attendance/manual.
  *
@@ -22,6 +23,7 @@
  */
 import { PATCH as EVENT_PATCH } from '@/app/api/events/[id]/route';
 import { DELETE as VISIT_DELETE } from '@/app/api/facility/visits/route';
+import { POST as CONFLICT_RESOLVE } from '@/app/api/my-programs/conflicts/resolve/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 
@@ -48,6 +50,14 @@ function visitDelete(visitId: number) {
         body: JSON.stringify({ visitId }),
     });
     return VISIT_DELETE(req as unknown as import('next/server').NextRequest) as Promise<Response>;
+}
+
+function resolveConflict(visitId: number) {
+    const req = new Request('http://localhost:4000/api/my-programs/conflicts/resolve', {
+        method: 'POST',
+        body: JSON.stringify({ visitId }),
+    });
+    return CONFLICT_RESOLVE(req as unknown as import('next/server').NextRequest) as Promise<Response>;
 }
 
 describe('visit-write advisory locks', () => {
@@ -137,5 +147,26 @@ describe('visit-write advisory locks', () => {
         expect(after.deletedAt).not.toBeNull();
         expect(after.deletedById).toBe(adminId);
         expect(await prisma.visit.count({ where: { personId: subjectId, deletedAt: null } })).toBe(0);
+    });
+
+    it('two concurrent conflict resolutions on both halves of one overlap → one survives', async () => {
+        await prisma.visit.deleteMany({ where: { personId: subjectId } });
+        const [visitA, visitB] = await Promise.all([
+            prisma.visit.create({
+                data: { personId: subjectId, arrivedAt: new Date(Date.now() - 3 * HOUR), departedAt: new Date(Date.now() - HOUR) },
+            }),
+            prisma.visit.create({
+                data: { personId: subjectId, arrivedAt: new Date(Date.now() - 2 * HOUR), departedAt: new Date(Date.now() - HOUR) },
+            }),
+        ]);
+
+        const [resA, resB] = await Promise.all([resolveConflict(visitA.id), resolveConflict(visitB.id)]);
+
+        // Winner tombstones its half (200); the loser re-checks under the lock,
+        // finds its visit no longer overlaps anything live, and refuses (409).
+        expect([resA.status, resB.status].sort()).toEqual([200, 409]);
+
+        // The whole point: the participant keeps one visit for the session.
+        expect(await prisma.visit.count({ where: { personId: subjectId, deletedAt: null } })).toBe(1);
     });
 });

--- a/checkin-app/src/app/api/my-programs/conflicts/resolve/route.ts
+++ b/checkin-app/src/app/api/my-programs/conflicts/resolve/route.ts
@@ -47,24 +47,34 @@ export const POST = withAuth({}, async (req, auth) => {
     return apiError("Forbidden: not authorized to resolve this visit", 403);
   }
 
-  // Guard: only delete a visit that genuinely overlaps another of the same
-  // participant's visits. Refuse to delete an isolated, legitimate visit.
-  const siblings = await prisma.visit.findMany({
-    where: { personId: visit.personId, id: { not: visit.id }, deletedAt: null },
-    select: { arrivedAt: true, departedAt: true },
-  });
-  const isConflicting = siblings.some((s) => intervalsOverlap(visit, s));
-  if (!isConflicting) {
-    return apiError("Visit is not part of an attendance conflict", 409);
-  }
+  // Per-person advisory xact lock, as /api/scan and /api/facility/visits take:
+  // the overlap guard and the tombstone must be one atomic step. Two leads
+  // resolving opposite halves of the same overlap each see the other still live
+  // otherwise, and both tombstone — erasing the session outright.
+  const failure = await prisma.$transaction(async (tx): Promise<{ error: string; status: number } | null> => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${visit.personId})`;
 
-  await prisma.$transaction(async (tx) => {
+    const current = await tx.visit.findUnique({ where: { id: visit.id } });
+    if (!current || current.deletedAt) {
+      return { error: "Visit not found", status: 404 };
+    }
+
+    // Only delete a visit that genuinely overlaps another of the same
+    // participant's live visits. Refuse to delete an isolated, legitimate one.
+    const siblings = await tx.visit.findMany({
+      where: { personId: current.personId, id: { not: current.id }, deletedAt: null },
+      select: { arrivedAt: true, departedAt: true },
+    });
+    if (!siblings.some((s) => intervalsOverlap(current, s))) {
+      return { error: "Visit is not part of an attendance conflict", status: 409 };
+    }
+
     // Tombstone, never a row removal — the same reversible delete every other
     // visit-write path takes (design §3). Resolving a conflict is a judgement
     // about which of two overlapping records is real; it must be possible to
     // back that judgement out.
     await tx.visit.update({
-      where: { id: visit.id },
+      where: { id: current.id },
       data: { deletedAt: new Date(), deletedById: user.id },
     });
     await tx.auditLog.create({
@@ -72,21 +82,24 @@ export const POST = withAuth({}, async (req, auth) => {
         actorId: user.id,
         action: "DELETE",
         tableName: "Visit",
-        affectedEntityId: visit.id,
+        affectedEntityId: current.id,
         // The subject, not the event — the event is in oldData below.
-        secondaryAffectedEntity: visit.personId,
+        secondaryAffectedEntity: current.personId,
         oldData: {
-          personId: visit.personId,
-          arrivedAt: visit.arrivedAt,
-          departedAt: visit.departedAt,
-          arrivedVia: visit.arrivedVia,
-          departedVia: visit.departedVia,
-          associatedEventId: visit.associatedEventId,
+          personId: current.personId,
+          arrivedAt: current.arrivedAt,
+          departedAt: current.departedAt,
+          arrivedVia: current.arrivedVia,
+          departedVia: current.departedVia,
+          associatedEventId: current.associatedEventId,
           reason: "duplicate-attendance-conflict",
         },
       },
     });
-  });
+    return null;
+  }, { maxWait: 5000, timeout: 15000 });
+
+  if (failure) return apiError(failure.error, failure.status);
 
   return NextResponse.json({ success: true, deletedVisitId: visit.id });
 });


### PR DESCRIPTION
Three defects were assigned across the visit-write paths. **Two of the three are
already fixed by open PR #1558** (`claude/1523-significance`), which I verified
by running my reproductions against that branch's code rather than by reading
its description. This PR therefore ships only the third, which nothing else
covers. Detail and evidence below — if #1558 is abandoned, say so and I will
add the other two here.

## What this PR fixes — concurrent conflict resolution deleted both halves

`POST /api/my-programs/conflicts/resolve` took no per-person advisory lock and
evaluated its "is this visit actually part of an overlap" guard *outside* the
transaction. Two leads resolving opposite halves of the same overlap each saw
the other half still live — because neither had committed — and both
tombstoned. The participant's attendance for that session disappeared entirely.
This is exactly the kiosk-race case the route exists to clean up, so two leads
on the screen at once is how it gets used, not a corner case.

**Reproduction** (new test, run against unmodified `origin/main`):

```
✕ two concurrent conflict resolutions on both halves of one overlap → one survives

    - Expected  - 1
    + Received  + 1

      Array [
        200,
    -   409,
    +   200,
      ]
```

Both requests returned 200 and the participant was left with **zero** live
visits.

**Fix.** The guard and the tombstone are now one atomic step inside a
`$transaction` that takes `pg_advisory_xact_lock(personId)` and re-reads the
visit under it — the house pattern already used by `/api/scan`,
`/api/facility/visits` (PATCH and DELETE) and `/api/attendance/manual`, with the
same `{ maxWait: 5000, timeout: 15000 }`. The loser re-checks under the lock,
finds its visit no longer overlaps anything live, and gets a 409 instead of
deleting. `oldData` and the tombstone now come from the in-lock re-read rather
than the stale pre-lock row, so a racing close cannot leave the audit snapshot
disagreeing with what was actually deleted. The outer overlap pre-check is
dropped rather than duplicated — the in-lock one is authoritative and was its
only consumer.

**Proof the test fails without the fix.** The assertion above is the failure on
`origin/main` with only the test applied. With the route change it passes, along
with the existing `myProgramsConflictsResolveAPI` suite (10 tests, 2 suites
green). The test lives in `visitWriteLockConcurrency.integration.test.ts`, which
`jest.setup.js` already grants `TEST_DB_POOL_MAX=2`, so the two transactions run
on separate connections and the advisory lock is the only thing serializing
them — as in production. Deleting the `pg_advisory_xact_lock` line makes it fail
again.

## The two defects already fixed by #1558

I reproduced both against `origin/main`, then re-ran the same probes with
#1558's `events/[id]/route.ts` checked out in place. Both flipped to passing.

**Corrections review hides every privileged edit.** On `origin/main` the Absent
tombstone writes:

```
newData = {"type":"lead_attendance_correction","status":"Absent"}
rows matching the corrections flaggedOnly filter = 0
```

With #1558's route:

```
newData = {"type":"lead_attendance_correction","status":"Absent","significance":{"score":360,"flagged":true}}
rows matching the corrections flaggedOnly filter = 1
```

**Present with a blank departure reopens a closed visit.** On `origin/main` the
request returns `200` and the closed visit's `departedAt` becomes `null` — the
person is back on the safety roster and in the two-deep count having left hours
earlier. With #1558's route the request returns `400` and `departedAt` is
preserved.

### Per-path decision on significance

#1558 already emits `significance` on five of the six paths named in the brief,
and its rules-register entry (`docs/rules/attendance-checkin.md`) says every
correction or removal is weighed the same whoever made it, while only a
member's own change or their household lead's reaches the board *as it happens*.
My reading agrees with that division and I found nothing to contradict:

| Path | Scores? | Why |
|---|---|---|
| `events/[id]` Absent tombstone | yes, `deleteSignificance` | a delete always flags — the floor |
| `events/[id]` Present rewrite | yes, `editSignificance` | overwrites arrivedAt/departedAt; there is a before-state to weigh |
| `facility/visits` PATCH | yes, `editSignificance` off the in-lock re-read | same |
| `facility/visits` DELETE | yes, `deleteSignificance` | delete floor |
| `conflicts/resolve` | yes, `deleteSignificance` | delete floor |
| `facility/visits/insert` | **no** | a CREATE has no prior value to weigh, so there is no score to compute; it is an insertion, not a correction of something the record already claimed |

The sixth — `facility/visits/insert` (`staff_entry`) — is the one path I agree
should stay unscored, and it is the one #1558 leaves alone. Consequence worth
naming: with the page defaulting `flaggedOnly` to true, staff-entered past
visits remain invisible until the reviewer clears the toggle. That is the
design's intent (a board-gated insert would be the board flagging itself), not
a residual bug, but it is the kind of thing worth a second opinion.

## Verification

- `npm run lint` — clean.
- `npx tsc --noEmit --pretty false` — only the two known environmental
  `@aws-sdk/client-lambda` errors in the `s-read` routes.
- Unit suite — 2656 tests passed. The only two failing *suites* are the same
  `@aws-sdk/client-lambda` missing-module problem, same root cause as the tsc
  errors.
- Integration suite against a Docker Postgres — 136 suites, 1441 tests, all
  passing.
- `git diff --name-only origin/main...HEAD -- checkin-app/src/security/` is
  empty.

## Could not verify

- **Flow tests were not run.** They need the docker-compose dev-server stack;
  nothing here touches a route a flow test drives, but I did not confirm that by
  running them.
- **The interaction with #1558 is untested as a merge.** Both branches change
  `conflicts/resolve/route.ts` — #1558 adds a `significance` field to the audit
  row's `newData`, this PR moves that same `auditLog.create` inside the locked
  transaction and repoints its snapshot at the in-lock re-read. Whichever lands
  second needs a small manual conflict resolution: keep the in-lock `current`
  snapshot and add `newData` with `deleteSignificance(current, ...)`. Scoring off
  `current` rather than the pre-lock row is strictly more correct, and matches
  the reasoning #1558 already applies to `facility/visits` PATCH.
- **No lock-contention timeout testing.** The transaction inherits the 15s
  timeout the other visit-write paths use; I did not probe what happens when a
  lock holder blocks for longer than that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
