### PR TITLE
fix(membership): close the two background-check clearance gaps

### DIFF
--- a/checkin-app/src/app/__tests__/bgPerAdultSubject.integration.test.ts
+++ b/checkin-app/src/app/__tests__/bgPerAdultSubject.integration.test.ts
@@ -12,7 +12,7 @@
 import { POST as ATTEST } from '@/app/api/membership/reviews/route';
 import { POST as OVERRIDE } from '@/app/api/membership-ops/applications/review-override/route';
 import { GET as COMPLIANCE } from '@/app/api/membership-audit/compliance/route';
-import { eligibleReviewProcessIds } from '@/lib/membership/review';
+import { eligibleReviewProcessIds, overrideBlocked } from '@/lib/membership/review';
 import { bgFreshThreshold, personBgVerdict } from '@/lib/membership/personBgCheck';
 import { householdBgIsFresh } from '@/lib/membership/renewal';
 import prisma from '@/lib/prisma';
@@ -218,42 +218,58 @@ describe('Per-adult background-check subjects', () => {
     });
 
     // ── An approval that names nobody ────────────────────────────────────────
-    it('an approval naming nobody counts toward the adult the second reviewer names', async () => {
+    it('an approval naming nobody counts toward nobody, and reports the count it counted', async () => {
         const hh = await twoLeadHousehold('Legacy');
-        // An approval whose subject column is null: what every review in flight across
-        // the subject migration carries, since the column was added without a backfill.
+        // An approval whose subject column is null: what a review in flight across the
+        // subject migration (20260802120000, nullable, no backfill) carries.
         await prisma.backgroundCheckAttestation.create({ data: { processId: hh.processId, reviewerId: rev1, result: 'APPROVE', subjectPersonId: null } });
-        (sendEmail as jest.Mock).mockClear();
 
         as(rev2, { isBackgroundCheckReviewer: true });
         const res = await ATTEST(req({ processId: hh.processId, result: 'APPROVE', subjectPersonIds: [hh.alex] }) as never);
         expect(res.status).toBe(200);
 
-        // Two distinct reviewers approved and exactly one adult was named, so the review
-        // is complete and stamps that adult only.
+        // GUARD. Alex holds one approval, not two — the subject-less row vouches for no
+        // one, so nothing clears and nobody is stamped. Nothing records whose report rev1
+        // read; counting it would date Alex's clearance on rev2's reading alone.
+        const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: hh.processId } });
+        expect(proc?.bgClearedAt).toBeNull();
+        expect(await bgDate(hh.alex)).toBeNull();
+        expect(await bgDate(hh.sam)).toBeNull();
+
+        // The reported defect: attest() answered `approvals: 2` here while nothing
+        // cleared, telling the reviewer the review was done. The count it reports is now
+        // the count that decided `clears`, so the two can never disagree.
+        expect((await res.json()).outcome.approvals).toBe(1);
+    });
+
+    it('a review holding an approval that named nobody exits by board reset, then clears on two real readings', async () => {
+        const hh = await twoLeadHousehold('LegacyReset');
+        await prisma.backgroundCheckAttestation.create({ data: { processId: hh.processId, reviewerId: rev1, result: 'APPROVE', subjectPersonId: null } });
+        as(rev2, { isBackgroundCheckReviewer: true });
+        await ATTEST(req({ processId: hh.processId, result: 'APPROVE', subjectPersonIds: [hh.alex] }) as never);
+        (sendEmail as jest.Mock).mockClear();
+
+        // Both reviewers have spent their one attestation, so neither queue offers it —
+        // but the board sees it on /api/membership-ops/applications and `reset` reaches a
+        // review still in progress, not only a BLOCKED one. GUARD on that escape hatch:
+        // it is why the unnamed approval can be refused rather than counted.
+        expect(await eligibleReviewProcessIds(rev1)).not.toContain(hh.processId);
+        expect(await eligibleReviewProcessIds(rev2)).not.toContain(hh.processId);
+        await overrideBlocked(hh.processId, board, 'reset');
+        expect(await prisma.backgroundCheckAttestation.count({ where: { processId: hh.processId } })).toBe(0);
+
+        as(rev1, { isBackgroundCheckReviewer: true });
+        await ATTEST(req({ processId: hh.processId, result: 'APPROVE', subjectPersonIds: [hh.alex] }) as never);
+        as(rev2, { isBackgroundCheckReviewer: true });
+        await ATTEST(req({ processId: hh.processId, result: 'APPROVE', subjectPersonIds: [hh.alex] }) as never);
+
+        // Two people read Alex's report, and only Alex is stamped.
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: hh.processId } });
         expect(proc?.bgClearedAt).not.toBeNull();
         expect(proc?.status).toBe('PENDING_PAYMENT');
         expect(await bgDate(hh.alex)).not.toBeNull();
         expect(await bgDate(hh.sam)).toBeNull();
-        // The clearance owes the family the payment-open notice.
         expect((sendEmail as jest.Mock).mock.calls.some((c: unknown[]) => String(c[1]).includes('you can now pay your membership dues'))).toBe(true);
-    });
-
-    it('leaves no review that reports two approvals with nobody left able to finish it', async () => {
-        const hh = await twoLeadHousehold('NoDeadEnd');
-        await prisma.backgroundCheckAttestation.create({ data: { processId: hh.processId, reviewerId: rev1, result: 'APPROVE', subjectPersonId: null } });
-
-        as(rev2, { isBackgroundCheckReviewer: true });
-        const outcome = (await (await ATTEST(req({ processId: hh.processId, result: 'APPROVE', subjectPersonIds: [hh.alex] }) as never)).json()).outcome;
-
-        // Both reviewers have now spent their one attestation, so the process is gone from
-        // both queues. A reported approval count of 2 has to mean cleared, or the review
-        // is stranded with no one able to act on it.
-        expect(await eligibleReviewProcessIds(rev1)).not.toContain(hh.processId);
-        expect(await eligibleReviewProcessIds(rev2)).not.toContain(hh.processId);
-        expect(outcome.approvals ?? 0).toBeLessThan(2);
-        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: hh.processId } }))?.bgClearedAt).not.toBeNull();
     });
 
     // ── Board force-approve ──────────────────────────────────────────────────

--- a/checkin-app/src/app/__tests__/bgPerAdultSubject.integration.test.ts
+++ b/checkin-app/src/app/__tests__/bgPerAdultSubject.integration.test.ts
@@ -16,6 +16,7 @@ import { eligibleReviewProcessIds } from '@/lib/membership/review';
 import { bgFreshThreshold, personBgVerdict } from '@/lib/membership/personBgCheck';
 import { householdBgIsFresh } from '@/lib/membership/renewal';
 import prisma from '@/lib/prisma';
+import { sendEmail } from '@/lib/email';
 import { getServerSession } from 'next-auth/next';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
@@ -216,22 +217,43 @@ describe('Per-adult background-check subjects', () => {
         expect((await dup.json()).code).toBe('already_attested');
     });
 
-    // ── Legacy rows name nobody ──────────────────────────────────────────────
-    it('an attestation carrying no subject counts toward nobody', async () => {
+    // ── An approval that names nobody ────────────────────────────────────────
+    it('an approval naming nobody counts toward the adult the second reviewer names', async () => {
         const hh = await twoLeadHousehold('Legacy');
-        // A pre-deploy approval: recorded before checks named their subject.
+        // An approval whose subject column is null: what every review in flight across
+        // the subject migration carries, since the column was added without a backfill.
         await prisma.backgroundCheckAttestation.create({ data: { processId: hh.processId, reviewerId: rev1, result: 'APPROVE', subjectPersonId: null } });
+        (sendEmail as jest.Mock).mockClear();
 
         as(rev2, { isBackgroundCheckReviewer: true });
         const res = await ATTEST(req({ processId: hh.processId, result: 'APPROVE', subjectPersonIds: [hh.alex] }) as never);
         expect(res.status).toBe(200);
 
-        // Alex holds one approval, not two — the subject-less row vouches for no one, so
-        // nothing clears and nobody is stamped. Conservative on purpose.
+        // Two distinct reviewers approved and exactly one adult was named, so the review
+        // is complete and stamps that adult only.
         const proc = await prisma.orgMembershipProcess.findUnique({ where: { id: hh.processId } });
-        expect(proc?.bgClearedAt).toBeNull();
-        expect(await bgDate(hh.alex)).toBeNull();
+        expect(proc?.bgClearedAt).not.toBeNull();
+        expect(proc?.status).toBe('PENDING_PAYMENT');
+        expect(await bgDate(hh.alex)).not.toBeNull();
         expect(await bgDate(hh.sam)).toBeNull();
+        // The clearance owes the family the payment-open notice.
+        expect((sendEmail as jest.Mock).mock.calls.some((c: unknown[]) => String(c[1]).includes('you can now pay your membership dues'))).toBe(true);
+    });
+
+    it('leaves no review that reports two approvals with nobody left able to finish it', async () => {
+        const hh = await twoLeadHousehold('NoDeadEnd');
+        await prisma.backgroundCheckAttestation.create({ data: { processId: hh.processId, reviewerId: rev1, result: 'APPROVE', subjectPersonId: null } });
+
+        as(rev2, { isBackgroundCheckReviewer: true });
+        const outcome = (await (await ATTEST(req({ processId: hh.processId, result: 'APPROVE', subjectPersonIds: [hh.alex] }) as never)).json()).outcome;
+
+        // Both reviewers have now spent their one attestation, so the process is gone from
+        // both queues. A reported approval count of 2 has to mean cleared, or the review
+        // is stranded with no one able to act on it.
+        expect(await eligibleReviewProcessIds(rev1)).not.toContain(hh.processId);
+        expect(await eligibleReviewProcessIds(rev2)).not.toContain(hh.processId);
+        expect(outcome.approvals ?? 0).toBeLessThan(2);
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: hh.processId } }))?.bgClearedAt).not.toBeNull();
     });
 
     // ── Board force-approve ──────────────────────────────────────────────────

--- a/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
@@ -246,6 +246,41 @@ describe('PERSON_BG triggers + subject-scoped clear + gate', () => {
         expect(ids).toContain(household.id); // household review is unaffected
     });
 
+    /** A household lead — a signing adult, whether or not they join a program. */
+    async function makeLead(slug: string, householdId: number, data: Parameters<typeof makePerson>[2] = {}) {
+        const p = await makePerson(slug, householdId, data);
+        await prisma.person.update({ where: { id: p.id }, data: { isHouseholdLead: true } });
+        return p;
+    }
+
+    it('Trigger C covers the signing adult the household clearance did not name', async () => {
+        const hh = await makeHousehold('secondLeadHh');
+        // Clearance names one adult and stamps only them; the other signing adult holds
+        // no check and is attached to no program, so program attachment cannot find them.
+        const named = await makeLead('secondlead-named', hh.id, { dateOfBirth: ADULT_DOB, lastBackgroundCheck: new Date() });
+        const unnamed = await makeLead('secondlead-unnamed', hh.id, { dateOfBirth: ADULT_DOB });
+        const membership = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'NONE' } });
+        const proc = await prisma.orgMembershipProcess.create({
+            data: { orgMembershipId: membership.id, kind: 'INITIAL', status: 'PENDING_PAYMENT', bgClearedAt: new Date() },
+        });
+
+        await activate(proc.id, { via: 'manual', actorId: named.id });
+
+        expect(await personBgCountFor(unnamed.id)).toBe(1);
+        expect(await personBgCountFor(named.id)).toBe(0); // already fresh
+    });
+
+    it('Trigger A covers a household lead with no program attachment', async () => {
+        const hh = await makeHousehold('sweepLeadHh');
+        const lead = await makeLead('sweep-lead', hh.id, { dateOfBirth: ADULT_DOB });
+        // Not a lead and in no program: an adult child the household never put forward.
+        const bystander = await makePerson('sweep-bystander', hh.id, { dateOfBirth: ADULT_DOB });
+
+        await runPersonBgAnnualSweep(new Date());
+        expect(await personBgCountFor(lead.id)).toBe(1);
+        expect(await personBgCountFor(bystander.id)).toBe(0);
+    });
+
     it('gate: a REJECT moves the PERSON_BG to BLOCKED', async () => {
         const hh = await makeHousehold('rejectHh');
         const subject = await makePerson('reject-subject', hh.id, { dateOfBirth: ADULT_DOB });

--- a/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
+++ b/checkin-app/src/app/__tests__/personBgTriggers.integration.test.ts
@@ -270,8 +270,9 @@ describe('PERSON_BG triggers + subject-scoped clear + gate', () => {
         expect(await personBgCountFor(named.id)).toBe(0); // already fresh
     });
 
-    it('Trigger A covers a household lead with no program attachment', async () => {
+    it('Trigger A covers a member household lead with no program attachment', async () => {
         const hh = await makeHousehold('sweepLeadHh');
+        await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
         const lead = await makeLead('sweep-lead', hh.id, { dateOfBirth: ADULT_DOB });
         // Not a lead and in no program: an adult child the household never put forward.
         const bystander = await makePerson('sweep-bystander', hh.id, { dateOfBirth: ADULT_DOB });
@@ -279,6 +280,34 @@ describe('PERSON_BG triggers + subject-scoped clear + gate', () => {
         await runPersonBgAnnualSweep(new Date());
         expect(await personBgCountFor(lead.id)).toBe(1);
         expect(await personBgCountFor(bystander.id)).toBe(0);
+    });
+
+    it('Trigger A leaves alone the leads of households that never became members', async () => {
+        // isHouseholdLead marks the lead of EVERY household the app creates. A bare lead
+        // arm on the daily cron would open a PERSON_BG — closable only by a board member
+        // recording an external check and two reviewers attesting — on people who never
+        // applied. startIntake anchors an abandoned application's membership at NONE; a
+        // denial writes DENIED; an import-only or program-only household has none at all.
+        const abandoned = await makeHousehold('sweepAbandonedHh');
+        await prisma.orgMembership.create({ data: { householdId: abandoned.id, status: 'NONE' } });
+        const abandonedLead = await makeLead('sweep-abandoned-lead', abandoned.id, { dateOfBirth: ADULT_DOB });
+
+        const denied = await makeHousehold('sweepDeniedHh');
+        await prisma.orgMembership.create({ data: { householdId: denied.id, status: 'DENIED' } });
+        const deniedLead = await makeLead('sweep-denied-lead', denied.id, { dateOfBirth: ADULT_DOB });
+
+        const revoked = await makeHousehold('sweepRevokedHh');
+        await prisma.orgMembership.create({ data: { householdId: revoked.id, status: 'REVOKED' } });
+        const revokedLead = await makeLead('sweep-revoked-lead', revoked.id, { dateOfBirth: ADULT_DOB });
+
+        const noMembership = await makeHousehold('sweepNoMembershipHh');
+        const strangerLead = await makeLead('sweep-stranger-lead', noMembership.id, { dateOfBirth: ADULT_DOB });
+
+        await runPersonBgAnnualSweep(new Date());
+        expect(await personBgCountFor(abandonedLead.id)).toBe(0);
+        expect(await personBgCountFor(deniedLead.id)).toBe(0);
+        expect(await personBgCountFor(revokedLead.id)).toBe(0);
+        expect(await personBgCountFor(strangerLead.id)).toBe(0);
     });
 
     it('gate: a REJECT moves the PERSON_BG to BLOCKED', async () => {

--- a/checkin-app/src/app/api/membership-audit/compliance/route.ts
+++ b/checkin-app/src/app/api/membership-audit/compliance/route.ts
@@ -26,10 +26,12 @@ const utcDay = (d: Date) => d.toISOString().slice(0, 10);
  *
  * Also returns two PERSON-scoped lists (program people may not sit in a member
  * household, so they can't key on householdId):
- *   peopleNeedingBgCheck — program-attached people ≥18 (as of the boundary) with
- *                          no fresh check. Skipped when the policy is unset.
- *   peopleMissingDob     — program-attached people whose age is unknown (no DOB,
+ *   peopleNeedingBgCheck — check-obligated people ≥18 (as of the boundary) with no
+ *                          fresh check. Skipped when the policy is unset.
+ *   peopleMissingDob     — check-obligated people whose age is unknown (no DOB,
  *                          not declared 25+): data hygiene, NOT bg-needed.
+ * Check-obligated = BG_OBLIGATED_WHERE: program-attached, or a signing adult (lead)
+ * of an ACTIVE member household.
  *
  * And two lists of background-check dates that trace to no named person (#1260):
  *   blanketStamped          — households cleared before per-adult subjects existed,
@@ -86,8 +88,9 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
     // PENDING_BG_CLEARANCE is a household-process status; orgMembership is always set.
     for (const p of stuck) if (p.orgMembership) add(p.orgMembership.householdId, "STUCK_BG_CLEARANCE");
 
-    // 4. Program-attached people ≥18 without a fresh background check (warn-only).
-    //    Subject = union of ProgramParticipant / ProgramVolunteer / Program.leadMentor.
+    // 4. Check-obligated people ≥18 without a fresh background check (warn-only).
+    //    Subject = BG_OBLIGATED_WHERE: (ProgramParticipant ∪ ProgramVolunteer ∪
+    //    Program.leadMentor) ∪ the leads of ACTIVE member households.
     //    A program lead/volunteer may sit in a household that isn't a member household,
     //    so these are person-scoped, NOT folded into the householdId reason map above.
     //    Skip the whole bucket when the board hasn't set a recheck window or a

--- a/checkin-app/src/app/api/membership-audit/compliance/route.ts
+++ b/checkin-app/src/app/api/membership-audit/compliance/route.ts
@@ -4,7 +4,7 @@ import { withAuth } from "@/lib/auth";
 import { householdBgIsFresh, nextBoundary } from "@/lib/membership/renewal";
 import { bgFreshThreshold, personBgVerdict } from "@/lib/membership/personBgCheck";
 import { agreementCycleFloor, autoPopulationWhere } from "@/lib/membership/personAgreementTriggers";
-import { LIVE_PERSON } from "@/lib/person/filters";
+import { BG_OBLIGATED_WHERE, LIVE_PERSON } from "@/lib/person/filters";
 
 export const dynamic = "force-dynamic";
 
@@ -104,15 +104,10 @@ export const GET = withAuth({ roles: ["isSysadmin", "isBoardMember"] }, async (r
     const peopleMissingDob: PersonRow[] = [];
     if (bgRecheckMonths > 0 && boundary) {
         const threshold = bgFreshThreshold(boundary, bgRecheckMonths);
+        // Same population the PERSON_BG triggers open for, so every obligation they
+        // create has a row here with a submit action behind it.
         const people = await prisma.person.findMany({
-            where: {
-                OR: [
-                    { programParticipants: { some: {} } },
-                    { programVolunteers: { some: {} } },
-                    { programsLed: { some: {} } },
-                ],
-                ...LIVE_PERSON,
-            },
+            where: { ...BG_OBLIGATED_WHERE, ...LIVE_PERSON },
             select: {
                 id: true,
                 name: true,

--- a/checkin-app/src/app/membership-audit/compliance/page.tsx
+++ b/checkin-app/src/app/membership-audit/compliance/page.tsx
@@ -303,7 +303,7 @@ export default function CompliancePage() {
 
       <PersonSection
         title="Background check needed"
-        description="Program-attached people 18 or older with no current background check. Warn-only — nothing is blocked. Once an external check exists, submit it below for two-reviewer approval."
+        description="People 18 or older with no current background check: anyone attached to a program, plus the signing adults on an active member household. Warn-only — nothing is blocked. Once an external check exists, submit it below for two-reviewer approval."
         color="orange"
         people={peopleNeedingBgCheck}
         renderAction={(p) =>
@@ -414,7 +414,7 @@ export default function CompliancePage() {
 
       <PersonSection
         title="Missing date of birth"
-        description="Program-attached people with no recorded age. Confirm their date of birth before a background check can be assessed."
+        description="Program-attached people and member-household signing adults with no recorded age. Confirm their date of birth before a background check can be assessed."
         color="grape"
         people={peopleMissingDob}
       />

--- a/checkin-app/src/lib/membership/payment.ts
+++ b/checkin-app/src/lib/membership/payment.ts
@@ -236,7 +236,7 @@ export async function activate(
     if (result.kind === "active") {
         await sendCongrats(result.householdId, result.isInitial);
         // Trigger C: a brand-new (INITIAL) member just activated (bg cleared before
-        // payment landed) — open PERSON_BG for the household's program-attached adults.
+        // payment landed) — open PERSON_BG for the household's check-obligated adults.
         if (result.isInitial) await openPersonBgForNewMember(result.householdId, new Date());
         // Same activation, the agreement side — an adult child signs their own.
         if (result.isInitial) await openPersonAgreementForNewMember(result.householdId, new Date());

--- a/checkin-app/src/lib/membership/personBgTriggers.ts
+++ b/checkin-app/src/lib/membership/personBgTriggers.ts
@@ -2,17 +2,16 @@ import prisma from "@/lib/prisma";
 import { bgFreshThreshold, personBgVerdict } from "@/lib/membership/personBgCheck";
 import { nextBoundary } from "@/lib/membership/renewal";
 import { personBgOpen } from "@/lib/membership/lifecycle";
-import { LIVE_PERSON, PROGRAM_ATTACHED_WHERE } from "@/lib/person/filters";
+import { BG_OBLIGATED_WHERE, LIVE_PERSON } from "@/lib/person/filters";
 import { systemActor } from "@/lib/auditActor";
 
 /**
  * Triggers that OPEN a per-person background-check obligation (PERSON_BG process,
  * Phase 2 — warn-only). Two triggers, both keyed on the SAME "who needs a check"
- * rule as the compliance dashboard: personBgVerdict === "NEEDED" over the
- * program-attached population (ProgramParticipant ∪ ProgramVolunteer ∪
- * Program.leadMentor). Deliberately NOT triggered by role-assignment: age is
- * judged as-of a boundary, so someone who turns 18 mid-year is caught at the next
- * annual run, not when they take a role.
+ * rule as the compliance dashboard: personBgVerdict === "NEEDED" over
+ * BG_OBLIGATED_WHERE (program-attached ∪ household leads). Deliberately NOT
+ * triggered by role-assignment: age is judged as-of a boundary, so someone who
+ * turns 18 mid-year is caught at the next annual run, not when they take a role.
  */
 
 
@@ -65,7 +64,7 @@ export async function openPersonBg(personId: number, asOf: Date, threshold: Date
 }
 
 /**
- * Trigger A — annual cohort. For every program-attached person NEEDED as of the
+ * Trigger A — annual cohort. For every check-obligated person NEEDED as of the
  * membership-year boundary, open a PERSON_BG. Idempotent: re-running opens none
  * (dedup guard), so the cron is safe to run daily. Skips entirely when the board
  * hasn't set bgRecheckMonths (policy unset) or has no membership-year boundary.
@@ -78,7 +77,7 @@ export async function runPersonBgAnnualSweep(now: Date) {
 
     const boundary = nextBoundary(settings.orgMembershipYearBoundary, now);
     const threshold = bgFreshThreshold(boundary, months);
-    const people = await prisma.person.findMany({ where: { ...PROGRAM_ATTACHED_WHERE, ...LIVE_PERSON }, select: { id: true } });
+    const people = await prisma.person.findMany({ where: { ...BG_OBLIGATED_WHERE, ...LIVE_PERSON }, select: { id: true } });
 
     let opened = 0;
     for (const p of people) {
@@ -90,13 +89,14 @@ export async function runPersonBgAnnualSweep(now: Date) {
 
 /**
  * Trigger C — new-member activation. When a brand-new membership (INITIAL) first
- * goes ACTIVE, open a PERSON_BG for each program-attached person in that household
+ * goes ACTIVE, open a PERSON_BG for each check-obligated person in that household
  * who is ≥18 as of activation and not fresh. Age is judged as-of `asOf` (join),
  * NOT the annual boundary — this is what catches a just-turned-18 joiner the
- * boundary run would still classify as a minor. Household leads freshly stamped by
- * the INITIAL check are skipped by the dedup guard. Population is program-attached
- * only — the same set as Trigger A / the dashboard (one source of "who needs a
- * check"). No-op when bgRecheckMonths is unset.
+ * boundary run would still classify as a minor. The lead the INITIAL check named is
+ * freshly stamped and skipped by the dedup guard; the lead it did not name is
+ * exactly who this opens for. Population is BG_OBLIGATED_WHERE — the same set as
+ * Trigger A / the dashboard (one source of "who needs a check"). No-op when
+ * bgRecheckMonths is unset.
  */
 export async function openPersonBgForNewMember(householdId: number, asOf: Date) {
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 } });
@@ -104,7 +104,7 @@ export async function openPersonBgForNewMember(householdId: number, asOf: Date) 
     if (months <= 0) return;
     const threshold = bgFreshThreshold(asOf, months);
     const people = await prisma.person.findMany({
-        where: { householdId, ...PROGRAM_ATTACHED_WHERE, ...LIVE_PERSON },
+        where: { householdId, ...BG_OBLIGATED_WHERE, ...LIVE_PERSON },
         select: { id: true },
     });
     for (const p of people) await openPersonBg(p.id, asOf, threshold);

--- a/checkin-app/src/lib/membership/personBgTriggers.ts
+++ b/checkin-app/src/lib/membership/personBgTriggers.ts
@@ -9,7 +9,9 @@ import { systemActor } from "@/lib/auditActor";
  * Triggers that OPEN a per-person background-check obligation (PERSON_BG process,
  * Phase 2 — warn-only). Two triggers, both keyed on the SAME "who needs a check"
  * rule as the compliance dashboard: personBgVerdict === "NEEDED" over
- * BG_OBLIGATED_WHERE (program-attached ∪ household leads). Deliberately NOT
+ * BG_OBLIGATED_WHERE (program-attached ∪ leads of ACTIVE member households — Trigger
+ * A is a daily cron over all Persons, so that membership bound is what keeps it off
+ * the leads of imports, abandoned intakes and denials). Deliberately NOT
  * triggered by role-assignment: age is judged as-of a boundary, so someone who
  * turns 18 mid-year is caught at the next annual run, not when they take a role.
  */

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -174,17 +174,23 @@ export function establishedSubject(attestations: { result: string; subjectPerson
 }
 
 /**
+ * Approvals standing behind `subject`. An approval that names nobody counts toward
+ * it: it vouched for the household's one report, and holding it back strands the
+ * review on a third reviewer the two-reviewer rule does not require to exist.
+ */
+function approvalsForSubject(attestations: { result: string; subjectPersonId: number | null }[], subject: number): number {
+    return attestations.filter((a) => a.result === "APPROVE" && (a.subjectPersonId === null || a.subjectPersonId === subject)).length;
+}
+
+/**
  * The adult a household process has cleared: the established subject, once two
  * reviewers have approved it. Returned as a list because it drives an `in` write
  * and is empty until the second approval lands.
  */
 export function subjectsWithTwoApprovals(attestations: { result: string; subjectPersonId: number | null }[]): number[] {
-    const approvals = new Map<number, number>();
-    for (const a of attestations) {
-        if (a.result !== "APPROVE" || a.subjectPersonId === null) continue;
-        approvals.set(a.subjectPersonId, (approvals.get(a.subjectPersonId) ?? 0) + 1);
-    }
-    return [...approvals].filter(([, n]) => n >= REQUIRED_APPROVALS).map(([id]) => id);
+    const subject = establishedSubject(attestations);
+    if (subject === null) return [];
+    return approvalsForSubject(attestations, subject) >= REQUIRED_APPROVALS ? [subject] : [];
 }
 
 /**
@@ -321,10 +327,14 @@ export async function attest(
         }
 
         const withThis = [...process.attestations, { result: "APPROVE", subjectPersonId }];
-        const approvals = withThis.filter((a) => a.result === "APPROVE").length;
-        // A household clears when its named adult reaches two approvals (one checked
-        // adult satisfies membership); a PERSON_BG counts the process as it always has.
-        const clears = isHousehold ? subjectsWithTwoApprovals(withThis).length > 0 : approvals >= REQUIRED_APPROVALS;
+        // A household clears when the adult it named reaches two approvals (one checked
+        // adult satisfies membership); a PERSON_BG counts the process as a whole. Both
+        // report the very count that decided it, so a reported 2 always means cleared —
+        // a reviewer is never told the review is done while it silently stays open.
+        const approvals = isHousehold && subjectPersonId !== null
+            ? approvalsForSubject(withThis, subjectPersonId)
+            : withThis.filter((a) => a.result === "APPROVE").length;
+        const clears = approvals >= REQUIRED_APPROVALS;
         if (clears) {
             const { activated, householdId, isInitial } = await clearBackgroundCheck(tx, processId, reviewerId);
             // A cleared PERSON_BG resolves to ACTIVE too; only a household process
@@ -383,8 +393,8 @@ export async function clearBackgroundCheck(tx: TxClient, processId: number, acto
     const paid = !!process.paidAt;
 
     // Stamp only the adults this review actually covered — the subjects the reviewers
-    // read off the Averity reports. A legacy process names nobody and so stamps nobody:
-    // better a household that reads stale than another unchecked adult marked cleared.
+    // read off the Averity reports. A process where no approval named anyone stamps
+    // nobody: better a household that reads stale than another unchecked adult cleared.
     // Expiry is derived from this plus BoardSettings.bgRecheckMonths at read time (see
     // householdBgIsFresh) — not stored.
     const cleared = subjectOverride ?? subjectsWithTwoApprovals(process.attestations);

--- a/checkin-app/src/lib/membership/review.ts
+++ b/checkin-app/src/lib/membership/review.ts
@@ -174,12 +174,13 @@ export function establishedSubject(attestations: { result: string; subjectPerson
 }
 
 /**
- * Approvals standing behind `subject`. An approval that names nobody counts toward
- * it: it vouched for the household's one report, and holding it back strands the
- * review on a third reviewer the two-reviewer rule does not require to exist.
+ * Approvals standing behind `subject` — NAMED ones only. An approval that named
+ * nobody counts toward nobody: nothing records whose report it read, so counting it
+ * would date a clearance on a single reviewer's reading. A review carrying one takes
+ * a board reset and two fresh attestations, which is what the two-reviewer rule asks.
  */
 function approvalsForSubject(attestations: { result: string; subjectPersonId: number | null }[], subject: number): number {
-    return attestations.filter((a) => a.result === "APPROVE" && (a.subjectPersonId === null || a.subjectPersonId === subject)).length;
+    return attestations.filter((a) => a.result === "APPROVE" && a.subjectPersonId === subject).length;
 }
 
 /**
@@ -327,10 +328,10 @@ export async function attest(
         }
 
         const withThis = [...process.attestations, { result: "APPROVE", subjectPersonId }];
-        // A household clears when the adult it named reaches two approvals (one checked
-        // adult satisfies membership); a PERSON_BG counts the process as a whole. Both
-        // report the very count that decided it, so a reported 2 always means cleared —
-        // a reviewer is never told the review is done while it silently stays open.
+        // A household clears when the adult it named reaches two NAMED approvals (one
+        // checked adult satisfies membership); a PERSON_BG counts the process as a whole.
+        // Both report the very count that decided it, so a reported 2 always means
+        // cleared — a reviewer is never told the review is done while it stays open.
         const approvals = isHousehold && subjectPersonId !== null
             ? approvalsForSubject(withThis, subjectPersonId)
             : withThis.filter((a) => a.result === "APPROVE").length;
@@ -393,8 +394,8 @@ export async function clearBackgroundCheck(tx: TxClient, processId: number, acto
     const paid = !!process.paidAt;
 
     // Stamp only the adults this review actually covered — the subjects the reviewers
-    // read off the Averity reports. A process where no approval named anyone stamps
-    // nobody: better a household that reads stale than another unchecked adult cleared.
+    // read off the Averity reports. A legacy process names nobody and so stamps nobody:
+    // better a household that reads stale than another unchecked adult marked cleared.
     // Expiry is derived from this plus BoardSettings.bgRecheckMonths at read time (see
     // householdBgIsFresh) — not stored.
     const cleared = subjectOverride ?? subjectsWithTwoApprovals(process.attestations);

--- a/checkin-app/src/lib/person/filters.ts
+++ b/checkin-app/src/lib/person/filters.ts
@@ -29,14 +29,21 @@ export const PROGRAM_ATTACHED_WHERE: Prisma.PersonWhereInput = {
 };
 
 /**
- * Person who owes a background check of their own: program-attached, or a household
- * lead. Clearing a household review stamps only the one adult its reviewers named, so
- * without the lead arm the other signing adult — the parent who signs and drops off,
- * attached to no program — is covered by no track at all.
+ * Person who owes a background check of their own: program-attached, or a signing
+ * adult of an ACTIVE member household. Clearing a household review stamps only the one
+ * adult its reviewers named, so without the lead arm the other signing adult — the
+ * parent who signs and drops off, attached to no program — is on no track at all.
+ *
+ * The ACTIVE bound is load-bearing, not decoration. `isHouseholdLead` marks the lead of
+ * EVERY household the app creates: imported legacy, program-only, abandoned intakes
+ * (startIntake anchors a membership at status NONE), DENIED and REVOKED. A bare lead arm
+ * would open a PERSON_BG on the daily cron for people who never became members. Mirrors
+ * the agreement track's autoPopulationWhere, and matches the rule the obligation states
+ * ("activating a membership opens...").
  *
  * The PERSON_BG openers and the board's compliance worklist share it, so what the
  * triggers open is what the board can act on.
  */
 export const BG_OBLIGATED_WHERE: Prisma.PersonWhereInput = {
-    OR: [PROGRAM_ATTACHED_WHERE, { isHouseholdLead: true }],
+    OR: [PROGRAM_ATTACHED_WHERE, { isHouseholdLead: true, household: { orgMembership: { status: "ACTIVE" } } }],
 };

--- a/checkin-app/src/lib/person/filters.ts
+++ b/checkin-app/src/lib/person/filters.ts
@@ -27,3 +27,16 @@ export const PROGRAM_ATTACHED_WHERE: Prisma.PersonWhereInput = {
         { programsLed: { some: {} } },
     ],
 };
+
+/**
+ * Person who owes a background check of their own: program-attached, or a household
+ * lead. Clearing a household review stamps only the one adult its reviewers named, so
+ * without the lead arm the other signing adult — the parent who signs and drops off,
+ * attached to no program — is covered by no track at all.
+ *
+ * The PERSON_BG openers and the board's compliance worklist share it, so what the
+ * triggers open is what the board can act on.
+ */
+export const BG_OBLIGATED_WHERE: Prisma.PersonWhereInput = {
+    OR: [PROGRAM_ATTACHED_WHERE, { isHouseholdLead: true }],
+};

--- a/docs/rules/membership.md
+++ b/docs/rules/membership.md
@@ -313,11 +313,17 @@ Procedure below is built on them.
 - Nobody is removed for falling out of compliance. The view reports and sends
   nothing, so a violation waits until a person looks.  [Decision — deliberate limit; *Principle: people decide about people*]
 
-### Background checks for program-attached adults
+### Background checks for individual adults
 
 - Activating a membership opens a background-check obligation for that
-  household's program-attached adults. It is surfaced for follow-up and gates
-  nothing — chasing it is a conversation, not a refusal at the door.  [Decision — deliberate limit; *Policy: Volunteer Policy, Art. IV*]
+  household's program-attached adults and for its signing adults. It is surfaced
+  for follow-up and gates nothing — chasing it is a conversation, not a refusal
+  at the door.  [Decision — deliberate limit; *Policy: Volunteer Policy, Art. IV*]
+
+- A signing adult whom the household's own review did not name is covered here
+  rather than by that review, because a clearance covers only the adult who took
+  the check. Otherwise the second parent on the application — often the one
+  holding a key — belongs to no track at all.  [Decision — *Policy: Membership Policy, Art. VI §VI.1*]
 
 - The annual sweep judges age as of the membership-year boundary, which counts as
   inside it: turning 18 afterwards waits for the next sweep rather than firing on

--- a/docs/rules/membership.md
+++ b/docs/rules/membership.md
@@ -208,6 +208,12 @@ Procedure below is built on them.
   reviewer who believes the named person is wrong rejects, rather than naming
   someone else.  [Decision]
 
+- An approval that named nobody counts toward nobody, including toward the adult a
+  later reviewer names. Nothing records whose report it read, so counting it would
+  date a clearance on one reviewer's reading and leave a row no worklist can tell
+  from a real one. A review carrying one is reset by the board and re-reviewed by
+  two.  [Decision — *Principle: fail closed*]
+
 - A board override names the adult it covers. It cannot infer one: a blocked
   application never holds the second approval that would identify a subject, so
   an override naming nobody would date a clearance against no one.  [Decision]
@@ -324,6 +330,11 @@ Procedure below is built on them.
   rather than by that review, because a clearance covers only the adult who took
   the check. Otherwise the second parent on the application — often the one
   holding a key — belongs to no track at all.  [Decision — *Policy: Membership Policy, Art. VI §VI.1*]
+
+- The obligation follows an active membership. Leads of households that only ever
+  started an application, were denied or revoked, or were created by an import owe
+  nothing: they never became members, and the annual sweep must not open a check on
+  someone who did not apply.  [Decision — deliberate limit]
 
 - The annual sweep judges age as of the membership-year boundary, which counts as
   inside it: turning 18 afterwards waits for the next sweep rather than firing on


### PR DESCRIPTION
Two release-blocking gaps in the background-check tracks. They share a root — clearance now covers one named adult instead of a household — so they ship together.

> **Revised after review (c19d3d2a).** thpr's blocking finding was correct and the fix for defect 1 has been replaced, not patched. The full reasoning is in "Which path was taken, and why" below. The short version: the earlier revision made a subject-less approval count toward the adult a second reviewer named. That minted a clearance backed by one reviewer's reading, with no provenance on the audit row, invisible to the `blanketStamped` worklist, and suppressing the next real check. **It is gone.** The genuine half — `attest()` answering `approvals: 2` while nothing cleared — is fixed by keeping the reported count subject-scoped. Defect 2's bound was also tightened past the review's own suggestion; see below.

## Defect 1 — `attest()` reported a clearance that had not happened

**Reproduction** (real Postgres, `bgPerAdultSubject.integration.test.ts`): a two-lead household INITIAL at PENDING_PAYMENT with `bgConsentAt` set, carrying one APPROVE whose `subjectPersonId` is null. A second eligible reviewer approves and names the lead.

On `main`: `attest()` returns `{ status: 'PENDING_PAYMENT', approvals: 2 }` — it tells the reviewer two approvals are recorded — while `bgClearedAt` stays null and the named lead's `lastBackgroundCheck` stays null. `approvals` counted every APPROVE on the process; `clears` required two approvals on the *same named* subject. The two could disagree, and did.

Null-subject approvals are not a corner case: migration `20260802120000` adds the column nullable with no backfill, so this is what a review in flight across that deploy looks like.

**The fix.** `approvals` is derived from the same subject-scoped count that decides `clears`, so the two cannot disagree. A reported 2 always means cleared; the reviewer in this scenario is told **1**, which is true — one person has read that adult's report.

`approvalsForSubject` counts **named** approvals only. An approval that named nobody counts toward nobody, including toward the adult a later reviewer names. That preserves what the column's own migration comment already promised ("its rows read as legacy — clearance stamps nobody for them") and what `docs/rules/membership.md` already stated ("Whoever approves first names the person whose report they read, and a later reviewer confirms that same person").

**How such a review finishes.** The board resets it and two reviewers redo it. `reset` reaches a review that is still in progress, not only a BLOCKED one (`review.ts:508`), and the board can see the process on `/api/membership-ops/applications`, which returns every non-ACTIVE process with its attestations. With three or more non-cohabiting reviewers a third simply approves the named adult and it clears normally; the deadlock binds only when the pool is effectively two. A new integration test walks that recovery end to end.

## Which path was taken, and why

Two paths were on the table. **This PR takes the first.**

| | Path A — refuse the unnamed approval (**taken**) | Path B — count it, with provenance |
|---|---|---|
| In-flight cohort | board reset + two fresh attestations | clears with no redo |
| Record left behind | two real attestations, one named adult | one reviewer's reading, tagged `via: "unnamed-approval"` |
| Rule change needed | none — the rule already says this | an exception written into `membership.md` |

Path B was rejected on the evidence, not on taste:

- **The redo is small and bounded.** The subject column landed 2026-08-02 with no backfill. The affected set is household reviews holding exactly one APPROVE at that moment that are *still uncleared* — a week's worth of half-attested applications. Anything that already had two approvals cleared under the old counting before the column existed.
- **The dead end it was meant to escape is not one.** The board sees the process and can reset it, and reset reaches an in-progress review. Both were verified on `origin/main`, and the reset path already has a test (`membershipBgNonBlocking.integration.test.ts:361`).
- **Path B reaches an outcome `overrideBlocked` explicitly refuses the board** — "`approve` stays BLOCKED-only — force-clearing a review still open to its second reviewer is what the two-reviewer rule forbids" (`review.ts:479`). The board has full authority, a named subject, a conflict-of-interest gate and an audit trail, and still may not do it. Counting would have done it with no board involvement and no record.
- **Its own defence relied on the artifact we already called untrustworthy.** "The legacy approval covered a household check that blanket-stamped both leads, so attributing it to one adult is strictly narrower" takes the blanket stamp as evidence — the exact thing `blanketStamped` exists to remediate.
- **The three compounding harms are all real**, verified against `origin/main`: `clearBackgroundCheck` was called without `provenance`, whose own comment says the row is then indistinguishable from a real two-reviewer clearance (`mergeBgAdvance.ts:158` passes it for exactly this situation); `blanketStamped` filters on `attestations.every(a => a.subjectPersonId === null)` and `stamped.length > 1` (`compliance/route.ts:195`), and a Path-B clearance carries one *named* attestation and stamps one lead, so it fails both; and `householdBgIsFresh` reads `lastBackgroundCheck`, so the stamp suppresses the next real check for `bgRecheckMonths`.

Because Path A is what the rule already says, no exception is written into `membership.md`. One bullet is **added** recording the decision positively, so the next reader does not have to re-derive it.

## Defect 2 — the second signing adult belonged to no track

**Reproduction** (`personBgTriggers.integration.test.ts`): a household with two leads, neither in any program. The review names and stamps one. On activation, `openPersonBgForNewMember` runs.

On `main` the unnamed lead gets `personBgCountFor(...) === 0` — no stamp and no PERSON_BG row. Both openers filter on `PROGRAM_ATTACHED_WHERE`, and the parent who signs, drops off, and may hold a keyholder role is in no program.

**The fix.** A new `BG_OBLIGATED_WHERE` in `lib/person/filters.ts` — program-attached **or** a signing adult of an **ACTIVE member household** — used by both openers and by the compliance worklist.

**The membership bound, and why it is tighter than the review's suggestion.** The review is plainly right that a bare `{ isHouseholdLead: true }` is unbounded: `runPersonBgAnnualSweep` runs it over all Persons on a daily cron, and `isHouseholdLead` marks the lead of every household the app creates. Its suggested bound was `household: { orgMembership: { isNot: null } }`. Verified against `origin/main`, that is too loose for the very population the finding names:

- `startIntake` **anchors an OrgMembership at status NONE** the moment a household begins an application (`intake.ts:157`), so every abandoned intake has a row.
- Denying a household writes `status: "DENIED"` (`households/route.ts:251`); revocation writes `REVOKED`.
- The bulk import creates them wholesale (`participants/import/route.ts:111`).

`isNot: null` would still sweep in the leads of abandoned, denied and revoked applications — the exact people the finding says should owe nothing. The bound taken is `orgMembership: { status: "ACTIVE" }`, which mirrors the sibling agreement track's `autoPopulationWhere` (`personAgreementTriggers.ts:188`) and matches the rule the obligation states: *activating a membership* opens it.

Trigger C is safe under this bound on both activation paths — `payment.ts:215` and `clearBackgroundCheck` each set `OrgMembership.status = "ACTIVE"` inside the transaction, before the opener runs after commit.

**Why not stamp both leads.** That is what the narrowed stamp exists to prevent. *"A check covers the adult who took it. One person's clearance never satisfies another's."* The lead the review named is stamped and therefore FRESH, so `openPersonBg`'s dedup guard skips them — only the unnamed lead gets an obligation.

**Why the compliance route is in this diff.** `peopleNeedingBgCheck` is the only surface with the "Record external check & submit" button, i.e. the only way a PERSON_BG ever reaches `bgConsentAt` and becomes queue-visible. It inlined the same program-attached OR. It now shares `BG_OBLIGATED_WHERE`, so what the triggers open is what the board can act on.

## Defect 3 — board-facing copy described the old population

`compliance/route.ts` (the header list and the section-4 comment) and the user-visible `compliance/page.tsx` both said "program-attached". A board member would have read that over a list that now includes household leads. Both now name the real population.

## Proof each test fails without the fix

Run against a Docker `postgres:15`, tests held fixed while the source is swapped.

**Against `origin/main`'s source** — 3 failed, 27 passed:

| test | failure |
|---|---|
| `an approval naming nobody counts toward nobody, and reports the count it counted` | `Expected: 1 / Received: 2` — the reported symptom exactly |
| `Trigger C covers the signing adult the household clearance did not name` | `Expected: 1 / Received: 0` |
| `Trigger A covers a member household lead with no program attachment` | `Expected: 1 / Received: 0` |

**Against this PR's own previous revision (755b2434)** — 3 failed, 27 passed, i.e. the review's findings are now regression-tested:

| test | failure |
|---|---|
| `an approval naming nobody counts toward nobody…` | `bgClearedAt` set — the one-reviewer clearance |
| `a review holding an approval that named nobody exits by board reset…` | reset rejected: the review had already been force-cleared |
| `Trigger A leaves alone the leads of households that never became members` | `Expected: 0 / Received: 1` — the unbounded lead arm |

Guards (green both ways, labelled as guards in-file): nobody but the named adult is ever stamped; the board-reset escape hatch reaches an in-progress review and two fresh attestations then clear it.

## Verification

- `npm ci` from clean, then `npx prisma generate`.
- `npx tsc --noEmit --pretty false` — **no errors** (the two `@aws-sdk/client-lambda` errors reported on the previous revision were stale `node_modules`, not real).
- `npm run lint` — clean.
- `npm run test:ci` — **276 suites, 2691 tests, all pass.** No suite fails to load.
- `npm run test:integration` against Docker `postgres:15` — **136 suites, 1444 tests, all pass.**
- `git diff --name-only origin/main...HEAD -- checkin-app/src/security/` is empty.

## Not verified

- No manual UI pass. The compliance page renders `{p.programName && ...}`, so a lead with no program degrades to "Household #N" — read, not exercised.
- Production volume of the widened worklist is still unmeasured, but it is now bounded by ACTIVE membership rather than by nothing: `peopleNeedingBgCheck` and `peopleMissingDob` grow by the signing adults of current member households who are stale or have no recorded age. Both are warn-only and gate nothing. The first `person-bg-annual` cron run after deploy opens a backlog for those leads; idempotent, so re-runs add none.
- The migration is untouched; nothing here needs a backfill or a schema change.

## Not undone

The four items the review checked and found correct are unchanged: `attest`'s `clears` and `clearBackgroundCheck`'s stamp still cannot disagree; two approvals still means two distinct, non-cohabiting reviewers; no new null-subject household approvals are creatable; and `submitPersonBgForReview` remains population-agnostic.
