### PR TITLE
fix(migrations): keep OrgMembershipProcess.certifiedById on disk through the drain window

### DIFF
--- a/checkin-app/docs/designs/UNFINISHED.md
+++ b/checkin-app/docs/designs/UNFINISHED.md
@@ -125,12 +125,15 @@ and a payment-plan approval. _(VOCAB #17)_
 
 ---
 
-## 🟢 Drop the `BoardSettings` membership-fee `@map` shims (contract stage)
+## 🟢 Drop the vocabulary-rename `@map` shims (contract stage)
 
-"dues" → "membership fee" shipped the Prisma/API/UI half; both fields still `@map`
-to the old physical columns, which a rolling deploy can't rename in the same
-release. Rename them once that release is out — [#1583](https://github.com/innovationtreehouse/checkin/issues/1583).
-_(VOCAB #6)_
+"dues" → "membership fee" (`BoardSettings.standardMembershipFeeCents`,
+`.volunteerMembershipFeeCents`) and "certified" → "manual"
+(`OrgMembershipProcess.manualPaymentById`) shipped the Prisma/API/UI half; all
+three fields still `@map` to the old physical columns, which a rolling deploy
+can't rename in the same release. Rename them once that release is out —
+[#1583](https://github.com/innovationtreehouse/checkin/issues/1583).
+_(VOCAB #6, #17)_
 
 ---
 

--- a/checkin-app/prisma/migrations/20260808120100_org_membership_process_restore_certified_by_column/migration.sql
+++ b/checkin-app/prisma/migrations/20260808120100_org_membership_process_restore_certified_by_column/migration.sql
@@ -2,4 +2,9 @@
 -- `manualPaymentById` and reaches it through @map, so the previous release —
 -- which serves traffic against this schema for the whole rolling-deploy drain
 -- window — keeps reading OrgMembershipProcess (rule 3).
+--
+-- Timestamp deliberately sorts immediately after 20260808120000 (the forward
+-- rename), not at the end of the chain: `migrate deploy` runs the chain
+-- sequentially and unwrapped, so anything in between — a DROP, an index build —
+-- leaves the column on its new name for that long, and old code 500s meanwhile.
 ALTER TABLE "OrgMembershipProcess" RENAME COLUMN "manualPaymentById" TO "certifiedById";

--- a/checkin-app/prisma/migrations/20260809120000_org_membership_process_restore_certified_by_column/migration.sql
+++ b/checkin-app/prisma/migrations/20260809120000_org_membership_process_restore_certified_by_column/migration.sql
@@ -1,0 +1,5 @@
+-- Puts the column back on its original name. The Prisma field stays
+-- `manualPaymentById` and reaches it through @map, so the previous release —
+-- which serves traffic against this schema for the whole rolling-deploy drain
+-- window — keeps reading OrgMembershipProcess (rule 3).
+ALTER TABLE "OrgMembershipProcess" RENAME COLUMN "manualPaymentById" TO "certifiedById";

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -502,8 +502,11 @@ model OrgMembershipProcess {
   shopifyOrderId        String?
   /// @sensitivity:internal
   paidAt                DateTime?
+  // The @map holds the physical column on its old name: most reads of this model
+  // carry no select, so the previous release reads it through a rolling deploy's
+  // drain window. Rename it in a later release (contract stage).
   /// @sensitivity:internal
-  manualPaymentById     Int?
+  manualPaymentById     Int?                    @map("certifiedById")
   /// @sensitivity:internal
   certificationNote     String?
   /// Write-never as of the outreach engine (PR-2): the renewal sweep and the go-live


### PR DESCRIPTION
`20260808120000_org_membership_process_manual_payment_by` (#1586) renames
`OrgMembershipProcess.certifiedById` to `manualPaymentById` with a bare
`ALTER TABLE ... RENAME COLUMN`, in the same release as the code that reads the new
name. That is release-blocking: `deploy-prod.yml` runs `prisma migrate deploy` to
completion *before* `aws ecs update-service`, so the previous release serves live
traffic against the renamed column for the entire drain window.

This PR holds the physical column on its old name with `@map` and adds a
compensating migration that renames it back. The Prisma field stays
`manualPaymentById`; nothing else in the app changes.

## The evidence

On a real Postgres 15: a fresh database migrated to **v1.1.1**'s chain, then main's
19 pending migrations, then **v1.1.1's own generated Prisma client** run against it.

| Probe (v1.1.1 client) | origin/main | this branch |
|---|---|---|
| `orgMembershipProcess.findMany()` | **THROW** — `The column OrgMembershipProcess.certifiedById does not exist in the current database.` | OK — row returned, `certifiedById: 4242` |
| `orgMembershipProcess.findUnique({id:1})` | **THROW** — same error | OK |
| `boardSettings.findUnique({id:1})` | OK | OK |
| `person.findMany({take:1})` | OK | OK |

`boardSettings` reading fine on both sides is the control: those two fields went
through the *same* vocabulary rename one PR earlier (#1585) and shipped `@map`
shims, so they survive the drain window. `OrgMembershipProcess` is the only model
that breaks.

The blast radius is wide because almost none of v1.1.1's ~83 `OrgMembershipProcess`
call sites narrow with a `select` — a bare `findMany`/`findUnique` names every
column in the client's model, `certifiedById` included. The payment and
Shopify-webhook paths are among them.

This branch's own client was also checked against the same database:
`findMany` with and without a `select`, a `where: { manualPaymentById }` filter, and
an `update` of the field all succeed and round-trip the value. New code is unaffected
by the `@map`.

## The rule it violates

`docs/DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md` **rule 3 — "Contract last, in a
separate, later release"**, which names "a rename of anything old code touches" as
destructive and forbids shipping it alongside the cutover that feeds it. #1586's own
commit message acknowledges being contract-class and ships anyway.

Rule 4 is satisfied by that migration (it is a hand-written `RENAME`, not Prisma's
generated `DROP`+`ADD`) — rule 4 is about not losing data, rule 3 is about
sequencing, and only rule 3 is broken here. `migration-safety.yml` is green on
#1586 for the same reason: it replays migrations on a populated DB, which is not a
sequencing test. The doc says so explicitly.

## Why `@map`

`@map` decouples the logical field name from the physical column, so both releases
read the same disk. Old code selects `certifiedById` and finds it; new code writes
`manualPaymentById` and Prisma translates. The physical rename becomes a
contract-stage change for a release after this one, when nothing reading the old
name is still running.

This is the shape #1585 already used for `BoardSettings.normalDuesCents` /
`volunteerDuesCents`, for the identical reason. Its contract-stage follow-up is
tracked as #1583; `docs/designs/UNFINISHED.md` now lists `manualPaymentById`
alongside those two in the same ledger entry.

## What happens to the offending migration — it is NOT deleted

Deleting the directory is unsafe here, and quietly so. #1586 merged at 01:21 UTC on
2026-08-09 and dev auto-deploys from `main`; commit `08c7b84e` (02:49 UTC) has
`831c7162` as an ancestor and its **Deploy dev** run succeeded, so
`20260808120000` is already applied to dev and its column is already renamed there.

I built a database in exactly that state and tried the deletion:

- `prisma migrate deploy` **passes** — "34 migrations found ... No pending
  migrations to apply." A ledger row whose directory is gone raises nothing.
- But dev's physical column stays `manualPaymentById` while `schema.prisma` now
  expects `certifiedById`, so the *new* client throws
  `The column OrgMembershipProcess.certifiedById does not exist` on every read and
  write of the model. Verified — all four probes throw.

So deletion trades a loud, one-release prod outage for a silent, permanent dev
outage with a green deploy. Editing the file in place is worse: `MIGRATION_COALESCE_FLOW.md`
and rule 6 both note the ledger checksum is a sha256 of `migration.sql`, and editing
a migration already recorded as applied breaks it.

The remedy is a compensating migration,
`20260808120100_org_membership_process_restore_certified_by_column`, a single
`ALTER TABLE ... RENAME COLUMN` back. `20260808120000` is left byte-identical
(`git diff origin/main` on that directory is empty).

Its timestamp sorts it **immediately after** the forward rename rather than at the
end of the chain, per @thpr's review. `migrate deploy` runs the chain sequentially
and unwrapped, and prod's v1.1.1 stops at `20260724120000`, so all four migrations
are pending together there: at the original `20260809120000` the column would have
sat on its new name across `20260808130000_drop_fee_feepayment` **and**
`20260809090000_audit_log_table_timestamp_index` — a non-concurrent `CREATE INDEX`
on `AuditLog` whose duration scales with the table — with v1.1.1 still serving.
That shortened the outage to the index build rather than closing it. Adjacent, the
window is two back-to-back metadata-only `ALTER`s. Out-of-order insertion is safe:
`migrate deploy` applies whatever is pending and no environment has the old name in
its ledger (the migration is unreleased and unmerged), and nothing in the tree
references it.

Behaviour per environment:

- **prod / any fresh DB** (neither applied): both run, net effect zero, column ends
  as `certifiedById`.
- **dev** (forward already applied): the compensating one is the only pending
  migration; verified it applies alone and cleanly.
- **CI drift check**: `prisma migrate diff --from-config-datasource --to-schema
  prisma/schema.prisma --exit-code` after deploying the full chain reports
  "No difference detected".

A rename-forward/rename-back pair in the history is the cost. It is transient — the
next coalesce (`MIGRATION_COALESCE_FLOW.md`) regenerates the baseline from
`schema.prisma`, where the pair collapses to a column named `certifiedById`.

Single-statement migration, so no `BEGIN`/`COMMIT` wrapper (rule 5 applies to
multi-statement files).

## Verification

- `npx prisma validate` — valid
- `npm run lint` — clean
- `npx tsc --noEmit --pretty false` — only the two pre-existing
  `@aws-sdk/client-lambda` errors in `s-read` (environmental, absent dependency)
- `npm test` — 2656 passed, 0 failed; the same two `s-read` suites fail to *load*
  for the same missing module
- `npx prisma generate` leaves `src/security/generated/classifications.ts`
  byte-identical (`@map` changes the column, not the logical field name or its
  `@sensitivity` tier), so no security-boundary file is touched:
  `git diff --name-only origin/main...HEAD -- checkin-app/src/security/` is empty
- No raw SQL depends on the column name — the three `$queryRaw` statements against
  `OrgMembershipProcess` select `id` only; `scripts/` and `prisma/seed.ts` never
  name it

## What I could not verify

- **The real dev database was not inspected.** It is VPC-only. That dev has the
  migration applied is inferred from a successful **Deploy dev** run on a commit
  descended from #1586, plus the workflow's documented "migrate to completion, then
  deploy" shape — not from reading dev's `_prisma_migrations`. If it somehow did not
  apply, the compensating migration would fail there with `column "manualPaymentById"
  does not exist`; worth a glance at the dev migrate-task logs before merge.
- **Prod was assumed not to have it.** #1586 has not been released; prod's last
  release is v1.1.1, whose chain stops at `20260724120000`.
- **The ~83 call-site count is #1586's, not re-counted here.** The failure does not
  depend on it — a bare `findMany` with zero call sites still throws.
- **`#1583`'s issue body still names only the two `BoardSettings` columns.** I added
  `manualPaymentById` to the `UNFINISHED.md` entry that points at it; the issue itself
  needs the third column added by hand (I did not have issue-write scope).
- **The integration and flow suites were not run** — they need a seeded DB and a live
  dev server respectively. The unit suite and the drift check both passed against a
  real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier

