### PR TITLE
fix(kiosk): point the client at paths and a branch the server actually serves

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -5,7 +5,7 @@ A thin Python client for Raspberry Pi that runs at the facility entrance. It act
 ## What it does
 
 1. **Transparent signing proxy** — serves on `localhost:8083`, proxies all requests to the backend with Ed25519 signature headers injected automatically
-2. **Kiosk display wrapper** — serves an HTML wrapper at `/` that iframes `/kioskdisplay` from the backend, with a flash banner overlay for scan feedback
+2. **Kiosk display wrapper** — serves an HTML wrapper at `/` that iframes `kiosk_path` (default `/attendance/current?mode=kiosk`) from the backend, with a flash banner overlay for scan feedback
 3. **Listens for badge scans** — reads USB barcode/QR scanner input, sends signed POST to `/api/scan`
 4. **Scan feedback** — displays check-in/check-out confirmation banners via a polling mechanism
 
@@ -102,7 +102,7 @@ When `usb_device` is empty in `config.json`, the client reads participant IDs fr
 | `private_key_path` | Path to the Ed25519 private key file |
 | `usb_device` | Device name or path (e.g. `Newtologic` or `/dev/input/event0`), empty for stdin |
 | `listen_port` | Local HTTP server port (default `8083`) |
-| `kiosk_path` | Backend path for the kiosk display and initial data fetch (default `/kioskdisplay?mode=kiosk`) |
+| `kiosk_path` | Backend path for the kiosk display and initial data fetch (default `/attendance/current?mode=kiosk`) |
 
 ## Architecture
 
@@ -112,8 +112,8 @@ When `usb_device` is empty in `config.json`, the client reads participant IDs fr
 │  localhost:8083     │  ──────────────→   │  (Next.js)   │
 │                     │                    │              │
 │  GET /              │  serves wrapper    │              │
-│  GET /kioskdisplay  │  ← proxied ──────  │ /kioskdisplay│
-│  GET /poll          │  scan feedback     │              │
+│  GET kiosk_path     │  ← proxied ──────  │ kiosk_path   │
+│  GET /events        │  scan feedback SSE │              │
 │  POST /api/scan     │  ← from scanner   │ /api/scan    │
 │  * (all other)      │  ← proxied ──────  │              │
 │                     │                    │              │

--- a/client/client.py
+++ b/client/client.py
@@ -4,7 +4,7 @@ CheckMeIn Kiosk Client
 
 A thin client for Raspberry Pi that:
   1. Serves a transparent reverse proxy on localhost:8083
-  2. Wraps the Next.js frontend in an iframe at GET / pointing to /kioskdisplay
+  2. Wraps the Next.js frontend in an iframe at GET / pointing to kiosk_path
   3. Injects Ed25519 signature headers automatically into proxied API requests
   4. Listens for USB barcode/QR scanner input
 """
@@ -34,6 +34,10 @@ log = logging.getLogger("kiosk")
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
+# The backend page serving the kiosk display; `mode=kiosk` selects its kiosk
+# layout. Overridable per-Pi via config.json.
+DEFAULT_KIOSK_PATH = "/attendance/current?mode=kiosk"
+
 def load_config(path="config.json"):
     if not os.path.exists(path):
         log.error(f"Config file not found: {path}")
@@ -115,7 +119,9 @@ class BackendClient:
             return {"error": str(e)}, 0
 
     def get_server_version(self):
-        path = "/api/kiosk/version"
+        # Public, DB-free route returning {"version": <git sha>}; it ignores the
+        # signature headers below, which are sent anyway for uniformity.
+        path = "/api/system-status/kiosk-version"
         headers = self._headers("GET", path)
         try:
             r = self.session.get(
@@ -161,7 +167,7 @@ class AttendanceState:
 class KioskHandler(BaseHTTPRequestHandler):
     state = None
     backend = None
-    kiosk_path = "/kioskdisplay?mode=kiosk"
+    kiosk_path = DEFAULT_KIOSK_PATH
     disable_blackout = False
 
     def do_GET(self):
@@ -624,10 +630,10 @@ def version_poller(backend, state, interval=60):
         
         # 2. Check Client Version Update
         try:
-            subprocess.run(["git", "fetch", "origin", "master"], capture_output=True, timeout=15)
-            
+            subprocess.run(["git", "fetch", "origin", "main"], capture_output=True, timeout=15)
+
             local_head = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-            remote_head = subprocess.check_output(["git", "rev-parse", "origin/master"], text=True).strip()
+            remote_head = subprocess.check_output(["git", "rev-parse", "origin/main"], text=True).strip()
             
             if local_head and remote_head and local_head != remote_head:
                 log.info(f"Client version update available ({local_head} -> {remote_head}). Restarting client.")
@@ -641,7 +647,7 @@ def main():
     key_path = config.get("private_key_path", "./client.key")
     usb_device = config.get("usb_device", "")
     port = int(config.get("listen_port", 8080))
-    kiosk_path = config.get("kiosk_path", "/kioskdisplay?mode=kiosk")
+    kiosk_path = config.get("kiosk_path", DEFAULT_KIOSK_PATH)
     attendance_path = config.get("attendance_path", "")
     disable_blackout = config.get("disable_blackout", True)
 

--- a/client/config.example.json
+++ b/client/config.example.json
@@ -3,6 +3,6 @@
   "private_key_path": "./client.key",
   "usb_device": "Newtologic",
   "listen_port": 8083,
-  "kiosk_path": "/kioskdisplay?mode=kiosk",
+  "kiosk_path": "/attendance/current?mode=kiosk",
   "attendance_path": "/api/attendance"
 }

--- a/client/test_client.py
+++ b/client/test_client.py
@@ -1,6 +1,8 @@
 import inspect
+import json
+import os
 import unittest
-from client import BackendClient, main
+from client import BackendClient, DEFAULT_KIOSK_PATH, main
 
 class TestBackendClient(unittest.TestCase):
     def test_required_methods_exist(self):
@@ -19,6 +21,15 @@ class TestProxyBindsLocalhostOnly(unittest.TestCase):
         src = inspect.getsource(main)
         self.assertIn('"127.0.0.1"', src, "proxy must bind 127.0.0.1")
         self.assertNotIn("0.0.0.0", src, "proxy must not bind 0.0.0.0 (LAN-exposed kiosk-signature oracle)")
+
+class TestExampleConfigMatchesDefaults(unittest.TestCase):
+    def test_example_kiosk_path_matches_client_default(self):
+        """A fresh Pi copies config.example.json, so its kiosk_path must not
+        drift from the in-code default. Does not prove the backend serves it."""
+        example = os.path.join(os.path.dirname(__file__), "config.example.json")
+        with open(example) as f:
+            cfg = json.load(f)
+        self.assertEqual(cfg["kiosk_path"], DEFAULT_KIOSK_PATH)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Three paths the kiosk client depends on do not exist on the server. Each one
fails silently, which is why the kiosk degrades without saying why.

This is **Phase 0** of `docs/designs/KIOSK_RESILIENCE.md` §3.3, which §4 says to
"ship first, alone." It is paths and config only.

## The three dead paths, and the evidence

**1. `version_poller` polled a branch that does not exist.** `client/client.py`
ran `git fetch origin master` and `git rev-parse origin/master`. The repo's
default branch is `main`. Run against a clone of this repo:

```
$ git rev-parse origin/master
fatal: ambiguous argument 'origin/master': unknown revision or path not in the working tree.
$ git rev-parse origin/main
fbc59f7436062ab4bb4a765e3ffc2cfa713122e9
```

`check_output` raises on that non-zero exit, the surrounding `except Exception`
turns it into one `Error checking client version` log line, and the `os._exit(0)`
that lets `kiosk.sh`'s loop pull a new client has therefore never fired. Pis have
only ever updated when someone restarted them by hand. Both the fetch and the
rev-parse now name `origin/main`.

**2. `get_server_version` called a route that does not exist.** It requested
`/api/kiosk/version`. There is no such route on `main` — the only files matching
are `api/kioskdisplay/certifications/route.ts` and
`api/system-status/kiosk-version/route.ts`. Curled against this branch running
locally:

```
/api/kiosk/version                404
/api/system-status/kiosk-version  200   {"version":"fbc59f7436062ab4bb4a765e3ffc2cfa713122e9"}
```

I confirmed the replacement is public and DB-free as the design claims, rather
than assuming it: the route is a bare `export async function GET()` with no auth
wrapper and no Prisma import, `middleware.ts`'s matcher exempts `/api` entirely,
and it appears nowhere in `src/security/registry.ts`. I also confirmed the
response shape rather than assuming it — the route returns
`NextResponse.json({ version: cachedVersion })`, and the client parses
`data.get("version")`. They match.

Second-order effect worth naming: `version_poller` seeds `initial_server_version`
from this call and skips the comparison entirely when it stays `None`. Because
the old path 404s, the "server redeployed, reload the display" path was dead as
well, not just slow.

**3. `kiosk_path` defaulted to a page that does not exist.** `client.py` (two
places) and `config.example.json` all shipped `/kioskdisplay?mode=kiosk`. Against
a local instance of this branch:

```
/kioskdisplay?mode=kiosk        404
/attendance/current?mode=kiosk  200
```

This is the exact request #1547 asked someone to make, and it returns the 404
that issue predicted. I checked the four places a rewrite could reconcile the two
and found none: no `page.tsx` under `src/app/kioskdisplay/`, no `rewrites` or
`redirects` in `next.config.ts`, nothing in `deploy/Caddyfile`, and `middleware.ts`
only redirects — it never rewrites a 404 into a page. `/attendance/current` is
the page that implements the contract: it reads `mode=kiosk` to select its kiosk
layout and reads the `sig`/`ts`/`nonce` params the client sends.

The default lived in three copies, which is how it drifted. It is now one
constant (`DEFAULT_KIOSK_PATH`) plus the shipped example, with a test asserting
the two agree.

## The open question — please read before assuming this fixes the building

**I cannot tell from here whether the kiosk is now fixed, and I am not claiming
it is.** #1547 raises a question that needs a human at a Pi. Both cases are live:

- **If deployed Pis carry a `config.json` that overrides `kiosk_path`** with a
  working path, then nothing was broken in the field, the checked-in default was
  merely stale, and fix 3 only affects the next Pi imaged from
  `config.example.json`. Fixes 1 and 2 still bite in this case — they are in
  `client.py`, which no `config.json` can override.
- **If deployed Pis use the default**, the kiosk has been iframing a 404 behind
  the client's own flash-banner overlay. The scan banner is drawn by the client,
  not the page, so **scanning would look like it works while the roster behind it
  shows nothing** — and nobody in the building has had a live view of who is
  present.

**What a human must check on a Pi**, in order:

1. `cat ~/checkin/client/config.json` — is there a `kiosk_path` key, and what is
   its value? Its absence means the stale default was in use.
2. `curl -s -o /dev/null -w '%{http_code}\n' 'https://<host>/kioskdisplay?mode=kiosk'`
   against the real deployment. A 404 confirms the second case.
3. If a Pi has a `config.json` with the old `/kioskdisplay` value, **this PR does
   not fix that Pi** — the file must be edited on the device, because
   `config.json` wins over the default.

## Fourth-dead-path sweep

The design was written 2026-07-22, so I re-checked every server path and git ref
in `client/` rather than trusting its list of three. **There is no fourth.** The
remaining referenced paths all resolve: `/api/scan` (`client.py`, `badge.py`) and
`/api/attendance` (`config.example.json`) both exist; `/events` is served by the
client itself. `kiosk.sh` and `migrate.sh` already used `main`, so the stale
branch was confined to `version_poller`.

One stale doc line came along: the README architecture diagram advertised
`GET /poll` for scan feedback, but the client serves `/events` (SSE) and has no
`/poll` handler. Same defect class, one line, fixed in passing.

## Explicitly not in this PR

No offline queue, no health state machine, no schema change, no heartbeat — those
are Phases 1-3, and §4 gates two of them on audit findings (B2, B6, B9) that are
still open. The idle-stop behavior of the kiosk poll is a known Phase 2
prerequisite and is deliberately untouched.

## Verification

Run and passing: `python3 -m py_compile client/client.py`, `jq . client/config.example.json`,
and `python3 -m unittest discover` in `client/` (7 tests, including the new one).
I confirmed the new test fails on drift by reverting `config.example.json` to the
old value and watching it go red. CI's "Kiosk client tests (Python)" job runs the
same command and is triggered by changes under `client/`.

The four HTTP results above come from `next dev` run off this branch on a fresh
worktree. **What that does not cover:** it is a local dev server, not the
production deployment, and I did not run an end-to-end kiosk test — no scanner,
no Pi, no Chromium, no signed request through the proxy. The 404/200 routing
results do not depend on the database, but nothing here proves a real badge scan
now updates a real display. That still needs someone at the building.

Fixes #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
