### PR TITLE
fix: two oversight surfaces that stay green while broken (cron health, trends hours)

### DIFF
--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -1262,9 +1262,14 @@ model CronRunLog {
   startedAt  DateTime
   /// @sensitivity:internal
   finishedAt DateTime @default(now())
+  /// Whether the run COMPLETED — not whether it was clean. A sweep that isolates
+  /// per-row failures still completed, so it lands here as true with `error` set.
+  /// Drives "is this job still running" (lib/cronRuns.ts lastSuccessByJob).
   /// @sensitivity:internal
   success    Boolean
-  /// Message from the throw that failed the run; null on success.
+  /// Why the run was not clean — the throw's message, the HTTP status, or the count
+  /// of rows the sweep could not process. Null means the run did all of its work.
+  /// Drives "is this job still working", independently of `success`.
   /// @sensitivity:internal
   error      String?
 

--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -213,8 +213,10 @@ describe('Cron Nightly API Integration Tests', () => {
                 // Both visits are still open — nothing was swept.
                 expect(await prisma.visit.count({ where: { id: { in: [one.id, two.id] }, departedAt: null } })).toBe(2);
 
+                // The run COMPLETED (so the job never reads as "stopped") but was not
+                // clean — both facts recorded, on the two separate ledger columns.
                 const ledger = await prisma.cronRunLog.findFirst({ where: { job: 'nightly' }, orderBy: { id: 'desc' } });
-                expect(ledger?.success).toBe(false);
+                expect(ledger?.success).toBe(true);
                 expect(ledger?.error).toBe('2 item(s) failed');
             } finally {
                 mockBadVisitIds.clear();

--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -187,6 +187,40 @@ describe('Cron Nightly API Integration Tests', () => {
         const systemNotifyCount = () =>
             prisma.auditLog.count({ where: { tableName: 'SYSTEM_NOTIFY' } });
 
+        // The System Status pill is the only in-app signal that the sweeps still
+        // work, and it reads the CronRunLog. A night that checked NOBODY out must
+        // not land there as a fresh success.
+        it('records the run as a failure when every checkout fails', async () => {
+            await closeAllOpenVisits();
+            await prisma.auditLog.deleteMany();
+
+            const arrivedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+            const one = await prisma.visit.create({ data: { personId: normalUserId, arrivedAt } });
+            const two = await prisma.visit.create({ data: { personId: keyholderId, arrivedAt } });
+
+            mockBadVisitIds.clear();
+            mockBadVisitIds.add(one.id);
+            mockBadVisitIds.add(two.id);
+
+            try {
+                const res = await GET(cronReq());
+                expect(res.status).toBe(200);
+
+                const data = await res.json();
+                expect(data.facilityClose.checkedOutCount).toBe(0);
+                expect(data.failed).toBe(2);
+
+                // Both visits are still open — nothing was swept.
+                expect(await prisma.visit.count({ where: { id: { in: [one.id, two.id] }, departedAt: null } })).toBe(2);
+
+                const ledger = await prisma.cronRunLog.findFirst({ where: { job: 'nightly' }, orderBy: { id: 'desc' } });
+                expect(ledger?.success).toBe(false);
+                expect(ledger?.error).toBe('2 item(s) failed');
+            } finally {
+                mockBadVisitIds.clear();
+            }
+        });
+
         it('keeps checking out good visits when ONE visit fails, still notifies the board, and returns 200', async () => {
             await closeAllOpenVisits();
             await prisma.auditLog.deleteMany();
@@ -220,8 +254,10 @@ describe('Cron Nightly API Integration Tests', () => {
                 const data = await res.json();
                 expect(data.success).toBe(true);
 
-                // 2 good visits checked out; the bad one is NOT counted as success.
+                // 2 good visits checked out; the bad one is NOT counted as success,
+                // and the run reports it so the ledger can mark the sweep unhealthy.
                 expect(data.facilityClose.checkedOutCount).toBe(2);
+                expect(data.failed).toBe(1);
 
                 // Board still notified even though the isKeyholder's checkout failed
                 // (notification derives from the abandoned-visit list, not results).

--- a/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronNightlyAPI.integration.test.ts
@@ -189,8 +189,9 @@ describe('Cron Nightly API Integration Tests', () => {
 
         // The System Status pill is the only in-app signal that the sweeps still
         // work, and it reads the CronRunLog. A night that checked NOBODY out must
-        // not land there as a fresh success.
-        it('records the run as a failure when every checkout fails', async () => {
+        // not land there as a clean success — nor as "job stopped running", which is
+        // a different failure the board would chase into the scheduler.
+        it('records the run as unclean, not as stopped, when every checkout fails', async () => {
             await closeAllOpenVisits();
             await prisma.auditLog.deleteMany();
 

--- a/checkin-app/src/app/__tests__/cronScholarshipGraceExpiry.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronScholarshipGraceExpiry.integration.test.ts
@@ -159,10 +159,12 @@ describe('Cron Scholarship-Grace-Expiry API Integration Tests', () => {
                 expect(data.processed).toBe(2);
                 expect(data.released).toBe(1);
                 // Isolating the row keeps the sweep going; it does not make the run
-                // healthy, so the count is reported and the ledger records a failure.
+                // healthy. The run completed, so `success` stays true — the ledger
+                // records the failure on `error` instead, which is what the panel reads.
                 expect(data.failed).toBe(1);
                 const ledger = await prisma.cronRunLog.findFirst({ where: { job: 'scholarship-grace-expiry' }, orderBy: { id: 'desc' } });
-                expect(ledger?.success).toBe(false);
+                expect(ledger?.success).toBe(true);
+                expect(ledger?.error).toBe('1 item(s) failed');
 
                 // Inside the window: untouched.
                 const inside = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId: ids.inside } } });

--- a/checkin-app/src/app/__tests__/cronScholarshipGraceExpiry.integration.test.ts
+++ b/checkin-app/src/app/__tests__/cronScholarshipGraceExpiry.integration.test.ts
@@ -158,6 +158,11 @@ describe('Cron Scholarship-Grace-Expiry API Integration Tests', () => {
                 // "gone" throws on delete() and is isolated, not counted as released.
                 expect(data.processed).toBe(2);
                 expect(data.released).toBe(1);
+                // Isolating the row keeps the sweep going; it does not make the run
+                // healthy, so the count is reported and the ledger records a failure.
+                expect(data.failed).toBe(1);
+                const ledger = await prisma.cronRunLog.findFirst({ where: { job: 'scholarship-grace-expiry' }, orderBy: { id: 'desc' } });
+                expect(ledger?.success).toBe(false);
 
                 // Inside the window: untouched.
                 const inside = await prisma.programParticipant.findUnique({ where: { programId_personId: { programId, personId: ids.inside } } });

--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -9,8 +9,8 @@
  * path: bucketing visits by period, the volunteer/participant split (by program
  * enrollment — ProgramParticipant, NOT age), structured (event-associated) vs
  * unstructured hours, the `arrivedVia=LEAD_MARKED` exclusion (synthetic "marked
- * present" visits, plus its pre-split `SYSTEM` spelling), the `programId`
- * filter, and the invalid-period 400.
+ * present" visits, plus its pre-split `SYSTEM` spelling) and the untagged-arrival
+ * case it must not swallow, the `programId` filter, and the invalid-period 400.
  */
 
 import { GET } from '@/app/api/facility/trends/route';
@@ -33,7 +33,9 @@ describe('Facility trends API', () => {
     let youthId: number; // youth by DOB, not enrolled -> volunteer (proves age doesn't drive it)
     let programId: number;
     let otherProgramId: number;
+    let untaggedProgramId: number;
     let eventId: number;
+    let untaggedEventId: number;
     const visitIds: number[] = [];
 
     // Every seeded arrival hangs off one anchor, a few minutes apart and at least an hour
@@ -122,14 +124,32 @@ describe('Facility trends API', () => {
         const open = await prisma.visit.create({
             data: { personId: youthId, arrivedAt: arrival(0), arrivedVia: 'WEB' },
         });
-        visitIds.push(structured.id, youthStructured.id, unstructured.id, synthetic.id, legacySynthetic.id, open.id);
+        // A program of its own, so the untagged-arrival assertions can scope by
+        // programId and be exact instead of leaning on the shared month bucket.
+        const untaggedProgram = await prisma.program.create({ data: { name: `Untagged ${TAG}` } });
+        untaggedProgramId = untaggedProgram.id;
+        const untaggedEvent = await prisma.event.create({
+            data: { programId: untaggedProgramId, name: `Untagged event ${TAG}`, startAt: arrival(2), endAt: departure(2, 3) },
+        });
+        untaggedEventId = untaggedEvent.id;
+        // Arrival with no source recorded: an ordinary visit, 2h, counted.
+        const untagged = await prisma.visit.create({
+            data: { personId: volunteerId, arrivedAt: arrival(2), departedAt: departure(2, 2), arrivedVia: null, associatedEventId: untaggedEventId },
+        });
+        // Staff-asserted arrival in the same program, 3h, still excluded.
+        const untaggedProgramSynthetic = await prisma.visit.create({
+            data: { personId: youthId, arrivedAt: arrival(2), departedAt: departure(2, 3), arrivedVia: 'LEAD_MARKED', associatedEventId: untaggedEventId },
+        });
+
+        visitIds.push(structured.id, youthStructured.id, unstructured.id, synthetic.id, legacySynthetic.id, open.id,
+            untagged.id, untaggedProgramSynthetic.id);
     });
 
     afterAll(async () => {
         await prisma.visit.deleteMany({ where: { id: { in: visitIds } } });
         await prisma.programParticipant.deleteMany({ where: { programId } });
-        await prisma.event.deleteMany({ where: { id: eventId } });
-        await prisma.program.deleteMany({ where: { id: { in: [programId, otherProgramId] } } });
+        await prisma.event.deleteMany({ where: { id: { in: [eventId, untaggedEventId] } } });
+        await prisma.program.deleteMany({ where: { id: { in: [programId, otherProgramId, untaggedProgramId] } } });
         await prisma.person.deleteMany({ where: { id: { in: [adminId, volunteerId, enrolledAdultId, youthId] } } });
         await prisma.household.deleteMany({ where: { id: householdId } });
     });
@@ -179,6 +199,22 @@ describe('Facility trends API', () => {
         // Non-enrolled YOUTH counts as a volunteer — age (<18) does not make them a participant.
         expect(data.totals.uniqueVolunteers).toBe(1);
         expect(data.totals.totalVolunteerHours).toBe(2);
+    });
+
+    // The source filter is written as a NOT IN, and in SQL a NULL never satisfies
+    // one — so an arrival with no source recorded drops out of the chart entirely
+    // unless it is admitted explicitly.
+    it('counts an untagged arrival and still drops the staff-marked one', async () => {
+        const res = await callAs({ id: adminId, isSysadmin: true }, `?period=month&programId=${untaggedProgramId}`);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+
+        // The 2h untagged visit, and only it — the 3h LEAD_MARKED visit in the same
+        // program is excluded, so its person never appears either.
+        expect(data.totals.uniqueVolunteers).toBe(1);
+        expect(data.totals.totalVolunteerHours).toBe(2);
+        expect(data.totals.uniqueParticipants).toBe(0);
+        expect(data.totals.structuredHours).toBe(2);
     });
 
     it('scopes to a single program via programId', async () => {

--- a/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/navTodoCountsAPI.integration.test.ts
@@ -15,7 +15,7 @@
 import { GET } from '@/app/api/nav/todo-counts/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
-import { CRON_STALE_AFTER_MS } from '@/lib/cronRuns';
+import { CRON_STALE_AFTER_MS, getCronJobStatuses } from '@/lib/cronRuns';
 
 jest.mock('next-auth/next', () => ({
     getServerSession: jest.fn(),
@@ -295,15 +295,16 @@ describe('Nav todo-counts API', () => {
     });
 
     // Nothing in this repo schedules the crons, so a sweep that stops firing is
-    // invisible until the ledger goes cold. That staleness has to reach the board's
-    // red System Status pill — and only the board's.
-    describe('stale cron jobs', () => {
+    // invisible until the ledger goes cold. That has to reach the board's red System
+    // Status pill — and only the board's — as does a sweep that runs but cannot
+    // finish its work.
+    describe('unhealthy cron jobs', () => {
         const JOB = `nav-badge-${TAG}`;
 
-        const staleCount = async (user: object) => {
+        const unhealthyCount = async (user: object) => {
             const res = await callAs(user);
             const data = await res.json();
-            return data.configHealth?.staleCronJobs as number | undefined;
+            return data.configHealth?.unhealthyCronJobs as number | undefined;
         };
 
         // Functions, not constants: the ids are assigned in beforeAll, which runs
@@ -316,26 +317,42 @@ describe('Nav todo-counts API', () => {
         });
 
         it('a recent success does not count', async () => {
-            const before = (await staleCount(board()))!;
+            const before = (await unhealthyCount(board()))!;
             await prisma.cronRunLog.create({
                 data: { job: JOB, startedAt: new Date(), finishedAt: new Date(), success: true },
             });
 
-            expect(await staleCount(board())).toBe(before);
+            expect(await unhealthyCount(board())).toBe(before);
+        });
+
+        // The freeze this split exists to prevent: one poison row must not make a job
+        // that ran last night read as stopped, and must not go unreported either.
+        it('a completed-but-unclean run raises the count without ever going stale', async () => {
+            const before = (await unhealthyCount(board()))!;
+            await prisma.cronRunLog.create({
+                data: { job: JOB, startedAt: new Date(), finishedAt: new Date(), success: true, error: '1 item(s) failed' },
+            });
+
+            expect(await unhealthyCount(board())).toBe(before + 1);
+
+            // ...and the panel shows it as run-recently, not as stopped.
+            const status = (await getCronJobStatuses()).find((j) => j.job === JOB);
+            expect(status?.stale).toBe(false);
+            expect(status?.lastError).toBe('1 item(s) failed');
         });
 
         it('a job whose last success is older than the threshold raises the count', async () => {
-            const before = (await staleCount(board()))!;
+            const before = (await unhealthyCount(board()))!;
             const long = new Date(Date.now() - (CRON_STALE_AFTER_MS + 60 * 60 * 1000));
             await prisma.cronRunLog.create({
                 data: { job: JOB, startedAt: long, finishedAt: long, success: true },
             });
 
-            expect(await staleCount(board())).toBe(before + 1);
+            expect(await unhealthyCount(board())).toBe(before + 1);
         });
 
         it('failed runs do not refresh a stale job — only a success clears it', async () => {
-            const before = (await staleCount(board()))!;
+            const before = (await unhealthyCount(board()))!;
             const long = new Date(Date.now() - (CRON_STALE_AFTER_MS + 60 * 60 * 1000));
             await prisma.cronRunLog.createMany({
                 data: [
@@ -344,7 +361,7 @@ describe('Nav todo-counts API', () => {
                 ],
             });
 
-            expect(await staleCount(board())).toBe(before + 1);
+            expect(await unhealthyCount(board())).toBe(before + 1);
         });
 
         it('a non-board, non-admin caller gets no count at all', async () => {
@@ -356,7 +373,7 @@ describe('Nav todo-counts API', () => {
             const res = await callAs(nonAdmin());
             const data = await res.json();
             expect(data.configHealth).toBeUndefined();
-            expect(await staleCount(board())).toBeGreaterThanOrEqual(1);
+            expect(await unhealthyCount(board())).toBeGreaterThanOrEqual(1);
         });
     });
 });

--- a/checkin-app/src/app/api/cron/nightly/route.ts
+++ b/checkin-app/src/app/api/cron/nightly/route.ts
@@ -26,6 +26,7 @@ export const GET = withCron(async () => {
         });
 
         let checkedOutCount = 0;
+        let failed = 0;
         let boardNotified = false;
 
         if (abandonedVisits.length > 0) {
@@ -40,6 +41,7 @@ export const GET = withCron(async () => {
                 if (result.status === "fulfilled") {
                     checkedOutCount += 1;
                 } else {
+                    failed += 1;
                     const visit = abandonedVisits[i];
                     logger.error(`Failed to check out visit ${visit.id} (person ${visit.person.email}):`, result.reason);
                 }
@@ -117,6 +119,9 @@ export const GET = withCron(async () => {
 
         return NextResponse.json({
             success: true,
+            // Checkouts this run swallowed. withCron reads it and records the run
+            // unhealthy when non-zero — a swept-nothing sweep is not a green sweep.
+            failed,
             facilityClose: {
                 checkedOutCount,
                 boardNotified

--- a/checkin-app/src/app/api/cron/nightly/route.ts
+++ b/checkin-app/src/app/api/cron/nightly/route.ts
@@ -120,7 +120,8 @@ export const GET = withCron(async () => {
         return NextResponse.json({
             success: true,
             // Checkouts this run swallowed. withCron reads it and records the run
-            // unhealthy when non-zero — a swept-nothing sweep is not a green sweep.
+            // as completed-but-unclean when non-zero — a swept-nothing sweep is not
+            // a green sweep, and is also not a sweep that failed to run.
             failed,
             facilityClose: {
                 checkedOutCount,

--- a/checkin-app/src/app/api/cron/scholarship-grace-expiry/route.ts
+++ b/checkin-app/src/app/api/cron/scholarship-grace-expiry/route.ts
@@ -42,6 +42,7 @@ export const GET = withCron(async () => {
     });
 
     let released = 0;
+    let failed = 0;
     for (const record of expired) {
         try {
             const { released: didRelease } = await withdrawAndReleaseHold(record.programId, record.personId, record.program);
@@ -63,9 +64,12 @@ export const GET = withCron(async () => {
             logger.info(`[CRON] Auto-withdrew ${record.person.name} from ${record.program.name} — scholarship denial grace period (${graceDays}d) expired.`);
         } catch (err) {
             // Isolate one bad row from the rest of the sweep.
+            failed++;
             logger.error(`[CRON] Failed to process grace-expiry for participant ${record.personId} in program ${record.programId}:`, err);
         }
     }
 
-    return NextResponse.json({ success: true, enabled: true, processed: expired.length, released });
+    // `failed` is the run-health signal withCron reads: isolating a bad row keeps
+    // the sweep going, it does not make the run a success.
+    return NextResponse.json({ success: true, enabled: true, processed: expired.length, released, failed });
 });

--- a/checkin-app/src/app/api/cron/scholarship-grace-expiry/route.ts
+++ b/checkin-app/src/app/api/cron/scholarship-grace-expiry/route.ts
@@ -70,6 +70,7 @@ export const GET = withCron(async () => {
     }
 
     // `failed` is the run-health signal withCron reads: isolating a bad row keeps
-    // the sweep going, it does not make the run a success.
+    // the sweep going and the run still counts as having RUN, but it is not clean,
+    // so withCron records it with an error rather than silently green.
     return NextResponse.json({ success: true, enabled: true, processed: expired.length, released, failed });
 });

--- a/checkin-app/src/app/api/facility/trends/route.ts
+++ b/checkin-app/src/app/api/facility/trends/route.ts
@@ -70,14 +70,17 @@ export const GET = withAuth(
                 arrivedAt: { gte: since },
                 departedAt: { not: null },
                 deletedAt: null,
-                // Exclude synthetic "marked present" visits (events attendance route): their
-                // arrivedAt/departedAt is the event window, not a measured duration.
-                // arrivedVia=LEAD_MARKED is the marker — real visits use SCANNER/WEB on
-                // arrival. Legacy SYSTEM is listed too: the previous release can still write
-                // it through a rolling deploy's drain window, and it meant the same thing on
-                // this field. The departure-side split (FACILITY_CLOSE / AUTO_CLOSE) does not
-                // reach here — this keys on arrival only.
-                arrivedVia: { notIn: ["LEAD_MARKED", "SYSTEM"] },
+                // Drop staff-asserted arrivals (LEAD_MARKED, and its legacy spelling
+                // SYSTEM): those times are an event window, not a measured duration.
+                // An untagged (null) arrival is an ordinary visit and counts — it needs
+                // the explicit OR, because NULL never satisfies a SQL NOT IN.
+                // ponytail: this only reaches rows that already carry LEAD_MARKED. The
+                // events roster mark stamps WEB, so its visits are still counted as
+                // measured hours until that writer stamps LEAD_MARKED.
+                OR: [
+                    { arrivedVia: null },
+                    { arrivedVia: { notIn: ["LEAD_MARKED", "SYSTEM"] } },
+                ],
             };
 
             if (programId) {

--- a/checkin-app/src/app/api/nav/todo-counts/route.ts
+++ b/checkin-app/src/app/api/nav/todo-counts/route.ts
@@ -7,7 +7,7 @@ import { canReviewBackgroundChecks, reviewQueueCounts } from "@/lib/membership/r
 import { getLeadConflicts } from "@/lib/attendanceConflicts";
 import { pickAddress, validateAddress } from "@/lib/address";
 import { openConfigIssues } from "@/lib/configHealth";
-import { countStaleCronJobs } from "@/lib/cronRuns";
+import { countUnhealthyCronJobs } from "@/lib/cronRuns";
 import { PROGRAM_CHECKOUT_BROKEN_WHERE } from "@/lib/programCheckout";
 import { apiError } from "@/lib/api-response";
 import { BROKEN_HOUSEHOLD_WHERE, UNCLAIMED_OR_BROKEN_HOUSEHOLD_WHERE } from "@/lib/household/filters";
@@ -83,10 +83,12 @@ export type TodoCounts = {
     // Status nav badge; the full detail lives at /api/system-status/config-health.
     // `openIssues` = failing system-config checks (e.g. Zoho e-sign unconfigured) —
     // synchronous env presence checks, see lib/configHealth.ts.
-    // `staleCronJobs` = cron sweeps with no successful run inside CRON_STALE_AFTER_MS.
-    // Computed here rather than in getConfigHealth() because it needs a DB read and
-    // that function is deliberately synchronous. See lib/cronRuns.ts.
-    configHealth?: { openIssues: number; staleCronJobs: number };
+    // `unhealthyCronJobs` = cron sweeps that have stopped running (no completed run
+    // inside CRON_STALE_AFTER_MS) OR whose latest run could not process every row.
+    // Both mean "go look at Scheduled Jobs"; the panel says which. Computed here
+    // rather than in getConfigHealth() because it needs a DB read and that function
+    // is deliberately synchronous. See lib/cronRuns.ts.
+    configHealth?: { openIssues: number; unhealthyCronJobs: number };
     // Background-check reviewer surface (reviewers + board, per-viewer). `canActOn`
     // = applications this reviewer may attest now (green). `approvedAwaitingSecond`
     // = ones they approved that still need a second reviewer (gray).
@@ -370,7 +372,7 @@ export const GET = withAuth({}, async (_req, auth) => {
 
     // ---- Admin surface (board's own queue) — only for board/isSysadmin ----
     if (user.isSysadmin || user.isBoardMember) {
-        const [membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, programsMisconfig, openPaymentExceptions, boardSettings, staleCronJobs] = await Promise.all([
+        const [membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, programsMisconfig, openPaymentExceptions, boardSettings, unhealthyCronJobs] = await Promise.all([
             prisma.orgMembershipProcess.count({
                 where: { status: { in: BOARD_ACTIONABLE_MEMBERSHIP } },
             }),
@@ -426,10 +428,10 @@ export const GET = withAuth({}, async (_req, auth) => {
                 where: { id: 1 },
                 select: { orgMembershipVariantId: true, volunteerDiscountCode: true, bgRecheckMonths: true, orgMembershipYearBoundary: true },
             }),
-            // Cron sweeps with no successful run in the last CRON_STALE_AFTER_MS. The
+            // Cron sweeps that stopped running, plus ones running but failing rows. The
             // schedule lives in a separate infra repo, so this is the app's only way to
-            // notice its own nightly sweep stopped firing. See lib/cronRuns.ts.
-            countStaleCronJobs(),
+            // notice its own nightly sweep stopped working. See lib/cronRuns.ts.
+            countUnhealthyCronJobs(),
         ]);
         const settingsMisconfig =
             (boardSettings?.orgMembershipVariantId ? 0 : 1) +
@@ -438,9 +440,9 @@ export const GET = withAuth({}, async (_req, auth) => {
             (boardSettings?.orgMembershipYearBoundary ? 0 : 1);
         result.admin = { membership, applicationsTotal, paymentPlanPending, membershipPaymentPlanPending, trustedAdults, householdsMissingContact, unclaimedHouseholds, brokenHouseholds, brokenEmails, settingsMisconfig, programsMisconfig, openPaymentExceptions };
         // Infra health: env-var/deploy gaps (synchronous presence checks) plus cron
-        // sweeps that have stopped running. Same admin+board gate as the rest of this
-        // block — both fold into the single red System Status pill.
-        result.configHealth = { openIssues: openConfigIssues(), staleCronJobs };
+        // sweeps that stopped running or stopped working. Same admin+board gate as the
+        // rest of this block — both fold into the single red System Status pill.
+        result.configHealth = { openIssues: openConfigIssues(), unhealthyCronJobs };
     }
 
     // ---- Reviewer surface (per-viewer background-check queue) ----

--- a/checkin-app/src/components/__tests__/navBadges.test.ts
+++ b/checkin-app/src/components/__tests__/navBadges.test.ts
@@ -302,28 +302,28 @@ describe('finance-ops nav ↔ tab agreement', () => {
 describe('system-status infra-health badge', () => {
   it('no badge when the payload has no configHealth (non-admin) or zero issues', () => {
     expect(navBadgeFor('/system-status', base)).toEqual([]);
-    expect(navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 0, staleCronJobs: 0 } })).toEqual([]);
+    expect(navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 0, unhealthyCronJobs: 0 } })).toEqual([]);
   });
 
   it('red alert badge counting open config issues', () => {
-    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 2, staleCronJobs: 0 } });
+    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 2, unhealthyCronJobs: 0 } });
     expect(badges).toEqual([{ count: 2, color: 'red', label: '2 config issues' }]);
   });
 
   it('singularizes the label at one issue', () => {
-    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 1, staleCronJobs: 0 } });
+    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 1, unhealthyCronJobs: 0 } });
     expect(badges[0].label).toBe('1 config issue');
   });
 
   it('a stale cron job alone raises the red pill', () => {
-    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 0, staleCronJobs: 1 } });
-    expect(badges).toEqual([{ count: 1, color: 'red', label: '1 cron job not running' }]);
+    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 0, unhealthyCronJobs: 1 } });
+    expect(badges).toEqual([{ count: 1, color: 'red', label: '1 cron job unhealthy' }]);
   });
 
   // One pill, not two: both halves are "infra broken" on the same page.
   it('folds stale cron jobs into the same count as config issues', () => {
-    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 2, staleCronJobs: 3 } });
-    expect(badges).toEqual([{ count: 5, color: 'red', label: '2 config issues, 3 cron jobs not running' }]);
+    const badges = navBadgeFor('/system-status', { ...base, configHealth: { openIssues: 2, unhealthyCronJobs: 3 } });
+    expect(badges).toEqual([{ count: 5, color: 'red', label: '2 config issues, 3 cron jobs unhealthy' }]);
   });
 });
 

--- a/checkin-app/src/components/admin/SystemHealthPanels.tsx
+++ b/checkin-app/src/components/admin/SystemHealthPanels.tsx
@@ -151,8 +151,9 @@ function timeAgo(iso: string): string {
  * Last successful run of each cron sweep, from GET /api/system-status/config-health
  * (admins + board only). Nothing in this repo schedules the crons — the schedule and
  * the caller live in a separate infra repo — so this panel is the app's only view of
- * whether its own nightly sweeps are still firing. A job past the staleness window is
- * red here and adds to the red System Status nav pill. See lib/cronRuns.ts.
+ * whether its own nightly sweeps are still firing. Two separate failures show here and
+ * both add to the red System Status nav pill: a job past the staleness window (stopped
+ * running) and a job whose latest run could not finish its work. See lib/cronRuns.ts.
  */
 export function CronRunsBox() {
   const [jobs, setJobs] = useState<CronJob[] | null>(null);
@@ -165,17 +166,20 @@ export function CronRunsBox() {
       .catch(() => setFailed(true));
   }, []);
 
-  const staleCount = jobs?.filter((j) => j.stale).length ?? 0;
+  // Mirrors countUnhealthyCronJobs so the panel badge and the nav pill agree: a job
+  // that ran last night but failed rows is not stale, and still needs attention.
+  const alertCount = jobs?.filter((j) => j.stale || j.lastError).length ?? 0;
 
   return (
     <Card withBorder radius="md" padding="lg">
       <Group gap="sm" mb="xs">
         <Title order={4}>Scheduled Jobs</Title>
-        {staleCount > 0 && <Badge color="red" circle title={`${staleCount} job(s) not running`} />}
+        {alertCount > 0 && <Badge color="red" circle title={`${alertCount} job(s) need attention`} />}
       </Group>
       <Text size="sm" c="dimmed" mb="md">
-        Last successful run of each nightly sweep. A job listed in red has not succeeded in
-        over 48 hours — treat it as stopped and check the scheduler.
+        Last completed run of each nightly sweep. A red timestamp means the job has not run
+        in over 48 hours — treat it as stopped and check the scheduler. A red line beneath a
+        green timestamp means the job ran, but could not finish its work.
       </Text>
 
       {failed ? (
@@ -195,7 +199,7 @@ export function CronRunsBox() {
                 </Text>
               </Group>
               {j.lastError && (
-                <Text size="xs" c="red">Failing since: {j.lastError}</Text>
+                <Text size="xs" c="red">Last run: {j.lastError}</Text>
               )}
             </List.Item>
           ))}

--- a/checkin-app/src/components/admin/__tests__/SystemHealthPanels.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/SystemHealthPanels.test.tsx
@@ -1,6 +1,6 @@
 import { screen, fireEvent } from "@testing-library/react";
 import { renderWithProviders, mockFetchJson, resetRtl } from "@/test-helpers/rtl";
-import { SystemVersionBox, BadgeScanChart, SReadDiagnosticsBox } from "../SystemHealthPanels";
+import { SystemVersionBox, BadgeScanChart, SReadDiagnosticsBox, CronRunsBox } from "../SystemHealthPanels";
 
 beforeEach(() => resetRtl());
 
@@ -79,5 +79,45 @@ describe("SReadDiagnosticsBox", () => {
     renderWithProviders(<SReadDiagnosticsBox />);
     fireEvent.click(screen.getByRole("button", { name: /Run diagnostics/ }));
     expect(await screen.findByText(/Diagnostics failed to run/)).toBeInTheDocument();
+  });
+});
+
+/**
+ * The panel is the detail view behind the red System Status pill, and it derives its
+ * own badge count client-side — so it can drift from countUnhealthyCronJobs and leave
+ * the pill saying 2 while the panel it links to shows nothing. It also has to keep
+ * the two failures visually distinct: "stopped running" is a scheduler problem,
+ * "ran but could not finish" is not.
+ */
+describe("CronRunsBox", () => {
+  const twoJobs = (now: number) => ({
+    "/api/system-status/config-health": {
+      cronJobs: [
+        // Stale: no completed run in over 48h.
+        { job: "post-event", lastSuccessAt: new Date(now - 72 * 3600_000).toISOString(), stale: true },
+        // Ran two hours ago, but could not process every row.
+        { job: "nightly", lastSuccessAt: new Date(now - 2 * 3600_000).toISOString(), stale: false, lastError: "3 item(s) failed" },
+      ],
+    },
+  });
+
+  it("counts a job that ran-but-failed toward the badge, not just the stale one", async () => {
+    mockFetchJson(twoJobs(Date.now()));
+    renderWithProviders(<CronRunsBox />);
+
+    // 2, not 1 — mirrors countUnhealthyCronJobs, which feeds the nav pill.
+    expect(await screen.findByTitle("2 job(s) need attention")).toBeInTheDocument();
+  });
+
+  it("shows the failing job as recently-run rather than as stopped", async () => {
+    mockFetchJson(twoJobs(Date.now()));
+    renderWithProviders(<CronRunsBox />);
+
+    // The error is named, so the row is actionable...
+    expect(await screen.findByText(/3 item\(s\) failed/)).toBeInTheDocument();
+    // ...but its timestamp is fresh, which is the whole point of the split: this job
+    // did run last night, and must not read as "not running".
+    expect(screen.getByText(/2 hours ago/)).toBeInTheDocument();
+    expect(screen.getByText(/3 days ago/)).toBeInTheDocument();
   });
 });

--- a/checkin-app/src/components/navBadges.ts
+++ b/checkin-app/src/components/navBadges.ts
@@ -181,7 +181,7 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
     case '/system-status': {
       // Red alert: things broken about the deployment itself — failing system-config
       // checks (env-var/deploy gaps, e.g. Zoho e-sign unconfigured) plus cron sweeps
-      // with no successful run inside the staleness window. Distinct from the
+      // that stopped running OR stopped working. Distinct from the
       // green/gray queue badges — this is "infra broken," not "you have a task."
       // Admins + board only (the counts are absent from the payload for everyone else).
       //
@@ -191,12 +191,14 @@ export function navBadgeFor(href: string, counts: TodoCounts | null): NavBadge[]
       // label keeps them itemized so the pill is still specific. See lib/configHealth.ts
       // and lib/cronRuns.ts.
       const config = counts.configHealth?.openIssues ?? 0;
-      const stale = counts.configHealth?.staleCronJobs ?? 0;
-      const n = config + stale;
+      // "unhealthy", not "not running": the count also covers a sweep that runs every
+      // night and cannot finish its work. Which one it is, is a panel-level detail.
+      const cron = counts.configHealth?.unhealthyCronJobs ?? 0;
+      const n = config + cron;
       if (n === 0) return [];
       const parts = [
         ...(config > 0 ? [`${config} config ${config === 1 ? 'issue' : 'issues'}`] : []),
-        ...(stale > 0 ? [`${stale} cron job${plural(stale, '', 's')} not running`] : []),
+        ...(cron > 0 ? [`${cron} cron job${plural(cron, '', 's')} unhealthy`] : []),
       ];
       return [{ count: n, color: 'red', label: parts.join(', ') }];
     }

--- a/checkin-app/src/lib/__tests__/cronAuth.test.ts
+++ b/checkin-app/src/lib/__tests__/cronAuth.test.ts
@@ -116,6 +116,27 @@ describe('withCron run ledger', () => {
         expect(create.mock.calls[0][0].data).toMatchObject({ job: 'reconcile-shopify', success: false, error: 'HTTP 503' });
     });
 
+    // A sweep that isolates per-row failures answers 200 with counts, so the status
+    // cannot see them. Without reading the count, a night that checked nobody out
+    // lands in the ledger as a fresh success and the System Status pill stays green.
+    it('records a run that reports failed rows as a failure, not a success', async () => {
+        const body = { success: true, failed: 4, facilityClose: { checkedOutCount: 0 } };
+        const handler = jest.fn().mockResolvedValue(NextResponse.json(body));
+        const res = await withCron(handler)(authed('http://localhost/api/cron/nightly'));
+
+        // The route's own envelope still reaches the caller untouched.
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual(body);
+        expect(create.mock.calls[0][0].data).toMatchObject({ job: 'nightly', success: false, error: '4 item(s) failed' });
+    });
+
+    it('records a success when the body reports zero failed rows', async () => {
+        const handler = jest.fn().mockResolvedValue(NextResponse.json({ success: true, failed: 0, released: 2 }));
+        await withCron(handler)(authed('http://localhost/api/cron/scholarship-grace-expiry'));
+
+        expect(create.mock.calls[0][0].data).toMatchObject({ success: true, error: null });
+    });
+
     it('records a failure and still returns the 500 when the handler throws', async () => {
         // Suppressed locally, NOT via jest.setup.js's global allowlist: a global entry
         // for the wrapper's own logs would silence them in every other cron test too.

--- a/checkin-app/src/lib/__tests__/cronAuth.test.ts
+++ b/checkin-app/src/lib/__tests__/cronAuth.test.ts
@@ -118,8 +118,12 @@ describe('withCron run ledger', () => {
 
     // A sweep that isolates per-row failures answers 200 with counts, so the status
     // cannot see them. Without reading the count, a night that checked nobody out
-    // lands in the ledger as a fresh success and the System Status pill stays green.
-    it('records a run that reports failed rows as a failure, not a success', async () => {
+    // lands in the ledger as a clean success and the System Status pill stays green.
+    //
+    // Recorded as BOTH: the run completed (success), and it was not clean (error).
+    // Writing success: false instead would freeze lastSuccessAt on the first
+    // permanently-failing row and the badge would call the job "not running".
+    it('records a partial sweep as a run that completed AND names what failed', async () => {
         const body = { success: true, failed: 4, facilityClose: { checkedOutCount: 0 } };
         const handler = jest.fn().mockResolvedValue(NextResponse.json(body));
         const res = await withCron(handler)(authed('http://localhost/api/cron/nightly'));
@@ -127,10 +131,19 @@ describe('withCron run ledger', () => {
         // The route's own envelope still reaches the caller untouched.
         expect(res.status).toBe(200);
         expect(await res.json()).toEqual(body);
-        expect(create.mock.calls[0][0].data).toMatchObject({ job: 'nightly', success: false, error: '4 item(s) failed' });
+        expect(create.mock.calls[0][0].data).toMatchObject({ job: 'nightly', success: true, error: '4 item(s) failed' });
     });
 
-    it('records a success when the body reports zero failed rows', async () => {
+    // The other half of the split: a run that never completed records no success, so
+    // staleness still fires on a job that genuinely stopped.
+    it('records a handler error envelope as a run that did NOT complete', async () => {
+        const handler = jest.fn().mockResolvedValue(NextResponse.json({ error: 'nope' }, { status: 503 }));
+        await withCron(handler)(authed('http://localhost/api/cron/nightly'));
+
+        expect(create.mock.calls[0][0].data).toMatchObject({ success: false, error: 'HTTP 503' });
+    });
+
+    it('records a clean success when the body reports zero failed rows', async () => {
         const handler = jest.fn().mockResolvedValue(NextResponse.json({ success: true, failed: 0, released: 2 }));
         await withCron(handler)(authed('http://localhost/api/cron/scholarship-grace-expiry'));
 

--- a/checkin-app/src/lib/__tests__/cronRuns.test.ts
+++ b/checkin-app/src/lib/__tests__/cronRuns.test.ts
@@ -2,27 +2,33 @@
  * @jest-environment node
  */
 /**
- * Staleness derivation for the cron run ledger. The DB half is a single groupBy,
- * stubbed here; what's worth testing is the rule applied to its rows — one coarse
- * window for every job, and a job that has NEVER run is not reported as stale
- * (the app can't know whether infra schedules it at all).
+ * Health derivation for the cron run ledger. The DB half is two stubbed reads; what
+ * is worth testing is the rule applied to their rows — one coarse staleness window
+ * for every job, a job that has NEVER run is not reported as stale (the app can't
+ * know whether infra schedules it at all), and above all that "did it run" and "did
+ * it work" stay independent of each other.
  */
 import prisma from '@/lib/prisma';
-import { CRON_STALE_AFTER_MS, cronJobName, countStaleCronJobs, getCronJobStatuses } from '@/lib/cronRuns';
+import { CRON_STALE_AFTER_MS, cronJobName, countUnhealthyCronJobs, getCronJobStatuses } from '@/lib/cronRuns';
 
 const NOW = new Date('2026-08-06T12:00:00.000Z');
 const ago = (ms: number) => new Date(NOW.getTime() - ms);
 const HOUR = 60 * 60 * 1000;
 
-/** Stub the two reads: the success aggregate, and the latest-failure-per-job scan. */
+/**
+ * Stub the two reads: the last-completed-run aggregate, and the latest-run-per-job
+ * scan the error is taken from. `latest` defaults to a clean run for every job.
+ */
 function stubGroupBy(
     rows: { job: string; finishedAt: Date | null }[],
-    failures: { job: string; finishedAt: Date; error: string | null }[] = [],
+    latest?: { job: string; success: boolean; error: string | null }[],
 ) {
     prisma.cronRunLog.groupBy = jest.fn().mockResolvedValue(
         rows.map((r) => ({ job: r.job, _max: { finishedAt: r.finishedAt } })),
     );
-    prisma.cronRunLog.findMany = jest.fn().mockResolvedValue(failures);
+    prisma.cronRunLog.findMany = jest.fn().mockResolvedValue(
+        latest ?? rows.map((r) => ({ job: r.job, success: true, error: null })),
+    );
 }
 
 describe('cronJobName', () => {
@@ -60,7 +66,7 @@ describe('getCronJobStatuses', () => {
         stubGroupBy([]);
 
         expect(await getCronJobStatuses(NOW)).toEqual([]);
-        expect(await countStaleCronJobs(NOW)).toBe(0);
+        expect(await countUnhealthyCronJobs(NOW)).toBe(0);
     });
 
     it('puts the stalest job first and counts only the stale ones', async () => {
@@ -74,13 +80,13 @@ describe('getCronJobStatuses', () => {
 
         expect(statuses.map((s) => s.job)).toEqual(['reconcile-shopify', 'nightly', 'post-event']);
         expect(statuses.filter((s) => s.stale).map((s) => s.job)).toEqual(['reconcile-shopify', 'nightly']);
-        expect(await countStaleCronJobs(NOW)).toBe(2);
+        expect(await countUnhealthyCronJobs(NOW)).toBe(2);
     });
 
-    it('reports the error of a job that has failed since its last success', async () => {
+    it('reports the error of a job whose latest run failed outright', async () => {
         stubGroupBy(
             [{ job: 'nightly', finishedAt: ago(3 * 24 * HOUR) }],
-            [{ job: 'nightly', finishedAt: ago(2 * HOUR), error: 'connection refused' }],
+            [{ job: 'nightly', success: false, error: 'connection refused' }],
         );
 
         expect(await getCronJobStatuses(NOW)).toEqual([
@@ -89,13 +95,67 @@ describe('getCronJobStatuses', () => {
     });
 
     it('drops a failure the job has since recovered from', async () => {
-        stubGroupBy(
-            [{ job: 'nightly', finishedAt: ago(2 * HOUR) }],
-            [{ job: 'nightly', finishedAt: ago(3 * 24 * HOUR), error: 'connection refused' }],
-        );
+        // Latest run is clean, so the older failure is history rather than status.
+        stubGroupBy([{ job: 'nightly', finishedAt: ago(2 * HOUR) }]);
 
         const [status] = await getCronJobStatuses(NOW);
         expect(status.lastError).toBeUndefined();
         expect(status.stale).toBe(false);
+    });
+
+    it('names a failure even when the ledger row recorded no message', async () => {
+        // Guard: `error` is nullable, and a row that failed with nothing written must
+        // still render a red line rather than silently reading as clean.
+        stubGroupBy(
+            [{ job: 'nightly', finishedAt: ago(3 * 24 * HOUR) }],
+            [{ job: 'nightly', success: false, error: null }],
+        );
+
+        expect((await getCronJobStatuses(NOW))[0].lastError).toBe('unknown error');
+    });
+});
+
+/**
+ * The two signals are independent. A sweep that runs every night but cannot process
+ * one poison row is NOT the same as a sweep that stopped running, and the ledger has
+ * to say so: judging both off `success` alone freezes `lastSuccessAt` on the first
+ * permanently-failing row, and the badge then calls a job that ran last night "not
+ * running" for as long as the row stays broken.
+ */
+describe('a run that completed but could not do all of its work', () => {
+    const partial = () =>
+        stubGroupBy(
+            [{ job: 'nightly', finishedAt: ago(2 * HOUR) }],
+            [{ job: 'nightly', success: true, error: '1 item(s) failed' }],
+        );
+
+    it('is not stale — it ran, so lastSuccessAt keeps moving', async () => {
+        partial();
+
+        const [status] = await getCronJobStatuses(NOW);
+        expect(status.stale).toBe(false);
+        expect(status.lastSuccessAt).toEqual(ago(2 * HOUR));
+    });
+
+    it('still surfaces the error, so the panel does not read as healthy', async () => {
+        partial();
+
+        expect((await getCronJobStatuses(NOW))[0].lastError).toBe('1 item(s) failed');
+    });
+
+    it('counts toward the nav badge even though nothing is stale', async () => {
+        // Without this the pill goes green on a nightly sweep that fails every row.
+        partial();
+
+        expect(await countUnhealthyCronJobs(NOW)).toBe(1);
+    });
+
+    it('is counted once when the job is BOTH stale and failing', async () => {
+        stubGroupBy(
+            [{ job: 'nightly', finishedAt: ago(CRON_STALE_AFTER_MS + HOUR) }],
+            [{ job: 'nightly', success: false, error: 'connection refused' }],
+        );
+
+        expect(await countUnhealthyCronJobs(NOW)).toBe(1);
     });
 });

--- a/checkin-app/src/lib/cronAuth.ts
+++ b/checkin-app/src/lib/cronAuth.ts
@@ -69,10 +69,19 @@ async function reportedFailures(res: NextResponse): Promise<number> {
  * swallows its own failures. Only AUTHORIZED runs are recorded; a 401 never
  * happened as far as the ledger is concerned.
  *
- * Success is the response STATUS **and** the handler's own `failed` count, not
- * merely "the handler didn't throw" — a route that returns an error envelope, or
- * that isolates per-row failures behind a 200, has not had a healthy run, and the
- * ledger must not claim otherwise.
+ * TWO signals are recorded, not one, because "did it run" and "did it work" are
+ * different questions:
+ *   - `success` — the run COMPLETED. False only when the handler threw or returned
+ *     its own error envelope; "the handler didn't throw" is not enough.
+ *   - `error` — the run was not clean. Set from the handler's own top-level `failed`
+ *     count, so a sweep that isolates per-row failures behind a 200 still reports
+ *     them.
+ *
+ * A partial sweep therefore records `success: true` WITH an error. Collapsing the
+ * two would break one reader or the other: judged as a failure, one permanently
+ * poisoned row freezes `lastSuccessAt` and the nav badge calls a job that ran last
+ * night "not running", forever; judged as a success, a sweep that failed every row
+ * stays green. See {@link CronJobStatus} for how each half is consumed.
  */
 export function withCron(
     handler: (req: Request) => Promise<NextResponse>,
@@ -86,9 +95,9 @@ export function withCron(
 
         try {
             const res = await handler(req);
-            const failed = res.status < 400 ? await reportedFailures(res) : 0;
-            const healthy = res.status < 400 && failed === 0;
-            await recordCronRun(job, startedAt, healthy, healthy ? undefined : failed > 0 ? `${failed} item(s) failed` : `HTTP ${res.status}`);
+            const ran = res.status < 400;
+            const failed = ran ? await reportedFailures(res) : 0;
+            await recordCronRun(job, startedAt, ran, failed > 0 ? `${failed} item(s) failed` : ran ? undefined : `HTTP ${res.status}`);
             return res;
         } catch (error) {
             logger.error("Cron handler error:", error);

--- a/checkin-app/src/lib/cronAuth.ts
+++ b/checkin-app/src/lib/cronAuth.ts
@@ -35,6 +35,22 @@ export function requireCronSecret(req: Request): NextResponse | null {
 }
 
 /**
+ * Rows the handler could not process, read from its own response body.
+ *
+ * A sweep that isolates per-row failures still answers 200 with counts, so the
+ * status alone cannot see them; a top-level `failed` is how such a route reports
+ * partial or total inner failure. Absent or non-numeric means "nothing to report".
+ */
+async function reportedFailures(res: NextResponse): Promise<number> {
+    try {
+        const body = await res.clone().json() as { failed?: unknown };
+        return typeof body?.failed === "number" && body.failed > 0 ? body.failed : 0;
+    } catch {
+        return 0;
+    }
+}
+
+/**
  * Higher-order wrapper for the cron routes — mirrors {@link withAuth} but for the
  * session-less cron family. Gates on {@link requireCronSecret} (so the handler
  * never runs unauthorized), then runs the handler inside a top-level catch that
@@ -53,9 +69,10 @@ export function requireCronSecret(req: Request): NextResponse | null {
  * swallows its own failures. Only AUTHORIZED runs are recorded; a 401 never
  * happened as far as the ledger is concerned.
  *
- * Success is the response STATUS, not merely "the handler didn't throw" — a route
- * that returns its own error envelope has not had a healthy run, and the ledger
- * must not claim otherwise just because nothing was thrown.
+ * Success is the response STATUS **and** the handler's own `failed` count, not
+ * merely "the handler didn't throw" — a route that returns an error envelope, or
+ * that isolates per-row failures behind a 200, has not had a healthy run, and the
+ * ledger must not claim otherwise.
  */
 export function withCron(
     handler: (req: Request) => Promise<NextResponse>,
@@ -69,7 +86,9 @@ export function withCron(
 
         try {
             const res = await handler(req);
-            await recordCronRun(job, startedAt, res.status < 400, res.status < 400 ? undefined : `HTTP ${res.status}`);
+            const failed = res.status < 400 ? await reportedFailures(res) : 0;
+            const healthy = res.status < 400 && failed === 0;
+            await recordCronRun(job, startedAt, healthy, healthy ? undefined : failed > 0 ? `${failed} item(s) failed` : `HTTP ${res.status}`);
             return res;
         } catch (error) {
             logger.error("Cron handler error:", error);

--- a/checkin-app/src/lib/cronRuns.ts
+++ b/checkin-app/src/lib/cronRuns.ts
@@ -15,9 +15,14 @@ import prisma from "./prisma";
 export const CRON_STALE_AFTER_MS = 48 * 60 * 60 * 1000;
 
 /**
- * Last successful run of one cron job, and whether that is too long ago.
- * `lastError` is set only when the job has failed SINCE its last success — i.e. when it
- * is still broken. A failure the job later recovered from is history, not a status.
+ * Two independent signals per job, because "did it run" and "did it work" are
+ * different questions and one boolean cannot answer both:
+ *   - `lastSuccessAt`/`stale` — did the sweep RUN. Only a run that never completed
+ *     (a throw, or the route's own error envelope) holds this back.
+ *   - `lastError` — was the latest run CLEAN. Set from that run's error, so a sweep
+ *     that ran last night and failed 4 rows reads as fresh-but-unhealthy rather
+ *     than as stopped. A failure the job has since recovered from is history, not
+ *     a status: the next clean run clears it.
  */
 export type CronJobStatus = { job: string; lastSuccessAt: Date; stale: boolean; lastError?: string };
 
@@ -29,6 +34,10 @@ export function cronJobName(url: string): string {
 
 /**
  * Records one completed cron run, then purges rows older than 90 days.
+ *
+ * `success` means the run COMPLETED, not that it was clean — pass an `error`
+ * alongside `success: true` for a sweep that finished but could not process every
+ * row. See {@link CronJobStatus}.
  *
  * Never throws and never rethrows: recording that a job ran must not change
  * whether the job ran or what it returned. A failed write degrades the System
@@ -58,7 +67,8 @@ export async function recordCronRun(job: string, startedAt: Date, success: boole
 }
 
 /**
- * Most recent successful run per job.
+ * Most recent COMPLETED run per job — the "did it run" half. A partial sweep counts:
+ * it ran, so it must not read as stopped. Whether it was clean is {@link lastRunByJob}.
  *
  * Only jobs with a recorded success appear. A route that has never run is not
  * reported as stale, because the app has no way to know whether infra schedules
@@ -80,50 +90,57 @@ async function lastSuccessByJob(): Promise<Map<string, Date>> {
 }
 
 /**
- * Every job that has ever succeeded, most-stale first so the problems are at the
- * top of the panel. Carries the failure message when the job has thrown since its
- * last success — a red row that names what broke is actionable; one that only says
- * "stopped" sends the reader to CloudWatch.
+ * Latest run per job whatever its outcome — the "did it work" half. Read for its
+ * `error`, which a partial sweep sets while still recording a completed run.
+ *
+ * `distinct` after an ordered scan rather than a correlated subquery: the table is
+ * ~one row per job per day under a 90-day TTL, so there is nothing worth optimising.
+ */
+async function lastRunByJob() {
+    const rows = await prisma.cronRunLog.findMany({
+        orderBy: [{ job: "asc" }, { finishedAt: "desc" }],
+        distinct: ["job"],
+        select: { job: true, success: true, error: true },
+    });
+    return new Map(rows.map((r) => [r.job, r]));
+}
+
+/**
+ * Every job that has ever completed a run, most-stale first so the problems are at
+ * the top of the panel. Carries the latest run's error — a red row that names what
+ * broke is actionable; one that only says "stopped" sends the reader to CloudWatch.
+ *
+ * The two halves are read independently on purpose: a sweep that ran last night and
+ * failed 4 of 200 rows gets a fresh `lastSuccessAt` AND a `lastError`. Judging both
+ * off one flag is what let "9 of 10 rows processed" render as "job not running".
  */
 export async function getCronJobStatuses(now: Date = new Date()): Promise<CronJobStatus[]> {
-    const [successes, failures] = await Promise.all([
-        lastSuccessByJob(),
-        // Latest failure per job. `distinct` after an ordered scan rather than a
-        // correlated subquery: the table is ~one row per job per day under a 90-day
-        // TTL, so there is nothing here worth optimising.
-        prisma.cronRunLog.findMany({
-            where: { success: false },
-            orderBy: [{ job: "asc" }, { finishedAt: "desc" }],
-            distinct: ["job"],
-            select: { job: true, finishedAt: true, error: true },
-        }),
-    ]);
-
-    const latestFailure = new Map(failures.map((f) => [f.job, f]));
+    const [successes, latestRuns] = await Promise.all([lastSuccessByJob(), lastRunByJob()]);
 
     return [...successes.entries()]
         .map(([job, lastSuccessAt]) => {
-            const failure = latestFailure.get(job);
+            // Only the LATEST run's error is a status; the next clean run clears it.
+            const latest = latestRuns.get(job);
+            const unclean = latest && (latest.error !== null || !latest.success);
             return {
                 job,
                 lastSuccessAt,
                 stale: now.getTime() - lastSuccessAt.getTime() > CRON_STALE_AFTER_MS,
-                // A failure the job has since recovered from is history, not status.
-                ...(failure && failure.finishedAt > lastSuccessAt ? { lastError: failure.error ?? "unknown error" } : {}),
+                ...(unclean ? { lastError: latest.error ?? "unknown error" } : {}),
             };
         })
         .sort((a, b) => a.lastSuccessAt.getTime() - b.lastSuccessAt.getTime());
 }
 
 /**
- * Count of jobs past {@link CRON_STALE_AFTER_MS} — the nav-badge number. Reads only
- * the success aggregate: this runs on the hot nav-poll path, where the panel's
- * failure detail would be dead weight.
+ * Count of jobs needing attention — the nav-badge number. BOTH halves: a job that
+ * stopped running, and a job that runs nightly but cannot finish its work. Counting
+ * only staleness is what let a sweep fail every row forever behind a green pill.
+ *
+ * ponytail: shares getCronJobStatuses' two reads rather than keeping a leaner
+ * aggregate for the nav-poll path — the panel's "failure detail" IS half the badge
+ * now, so a second query shape would only be the same reads spelled twice.
  */
-export async function countStaleCronJobs(now: Date = new Date()): Promise<number> {
-    let stale = 0;
-    for (const lastSuccessAt of (await lastSuccessByJob()).values()) {
-        if (now.getTime() - lastSuccessAt.getTime() > CRON_STALE_AFTER_MS) stale += 1;
-    }
-    return stale;
+export async function countUnhealthyCronJobs(now: Date = new Date()): Promise<number> {
+    return (await getCronJobStatuses(now)).filter((j) => j.stale || j.lastError).length;
 }

--- a/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
+++ b/checkin-app/src/lib/finance/__tests__/reconcile.integration.test.ts
@@ -149,6 +149,25 @@ describe("forward recovery", () => {
         expect(await prisma.paymentException.count({ where: { processId } })).toBe(0);
     });
 
+    // An order whose pass throws is isolated (the sweep goes on) but counted: the
+    // cron ledger reads `failed`, so a pass that recovered nothing is not a green run.
+    it("counts an order whose forward pass throws", async () => {
+        const email = `boom-${TAG}@ex.com`;
+        await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: true });
+        ordersChangedSince.mockResolvedValue([order({ legacyId: `${TAG}-boom`, customerEmail: email })]);
+        orderLineVariantIds.mockRejectedValue(new Error("mirror read failed"));
+
+        const logged = jest.spyOn(console, "error").mockImplementation(() => {});
+        try {
+            const r = await runReconcile();
+            expect(r.ordersScanned).toBe(1);
+            expect(r.failed).toBe(1);
+            expect(logged).toHaveBeenCalled();
+        } finally {
+            logged.mockRestore();
+        }
+    });
+
     it("holds at PENDING_BG_CLEARANCE when bg not cleared", async () => {
         const email = `hold-${TAG}@ex.com`;
         const { processId } = await makeApplicant({ email, status: "PENDING_PAYMENT", bgCleared: false });

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -512,6 +512,10 @@ export interface ReconcileResult {
     configured: boolean;
     ordersScanned: number;
     reversalsRaised: number;
+    /** Orders whose forward pass threw. The cron route surfaces it as the run's
+     *  health signal (lib/cronAuth.ts) — isolating a bad order keeps the sweep
+     *  going, it does not make the run a success. */
+    failed: number;
 }
 
 /**
@@ -520,7 +524,7 @@ export interface ReconcileResult {
  * so the next run only re-scans changed orders.
  */
 export async function runReconcile(): Promise<ReconcileResult> {
-    if (!mirror.isConfigured()) return { configured: false, ordersScanned: 0, reversalsRaised: 0 };
+    if (!mirror.isConfigured()) return { configured: false, ordersScanned: 0, reversalsRaised: 0, failed: 0 };
 
     const settings = await prisma.boardSettings.findUnique({ where: { id: 1 }, select: { shopifyReconcileCursorAt: true } });
     const cursor = settings?.shopifyReconcileCursorAt ?? null;
@@ -532,12 +536,14 @@ export async function runReconcile(): Promise<ReconcileResult> {
     // orders in this batch still get processed (idempotent, so re-scanning them
     // tomorrow is harmless); only the watermark holds back until the bad order heals.
     let cursorFrozen = false;
+    let failed = 0;
     for (const order of orders) {
         try {
             const claimed = await reconcileForwardMembership(order);
             if (!claimed) await reconcileForwardProgram(order);
         } catch (e) {
             logger.error(`[reconcile] forward pass failed for order ${order.legacyId ?? order.orderGid}:`, e);
+            failed++;
             cursorFrozen = true;
             // The watermark may ALREADY sit at this order's updatedAt — an earlier
             // order in the batch with the same timestamp succeeded and advanced it.
@@ -558,5 +564,5 @@ export async function runReconcile(): Promise<ReconcileResult> {
         await prisma.boardSettings.update({ where: { id: 1 }, data: { shopifyReconcileCursorAt: newCursor } });
     }
 
-    return { configured: true, ordersScanned: orders.length, reversalsRaised };
+    return { configured: true, ordersScanned: orders.length, reversalsRaised, failed };
 }

--- a/checkin-app/src/lib/finance/reconcile.ts
+++ b/checkin-app/src/lib/finance/reconcile.ts
@@ -514,7 +514,8 @@ export interface ReconcileResult {
     reversalsRaised: number;
     /** Orders whose forward pass threw. The cron route surfaces it as the run's
      *  health signal (lib/cronAuth.ts) — isolating a bad order keeps the sweep
-     *  going, it does not make the run a success. */
+     *  going and the run still counts as having RUN, but it is not clean. Do not
+     *  reuse this key for anything else: withCron reads `failed` by name. */
     failed: number;
 }
 


### PR DESCRIPTION
Two monitoring surfaces that stayed reassuring while the thing they watch was broken.

## Defect 1 — cron health stayed green through a total failure

**Reproduction.** `cron/nightly` wraps each abandoned-visit checkout in
`Promise.allSettled`, logs every rejection, and returns
`{ success: true, facilityClose: { checkedOutCount: 0 } }` with status 200 — even
when every single checkout rejected. `withCron` judged the run by
`res.status < 400` alone, so `recordCronRun(job, startedAt, true)` wrote a fresh
success into `CronRunLog`, `getCronJobStatuses` reported the job healthy with a
new `lastSuccessAt` and no `lastError`, and the board's red System Status pill —
the app's only signal that the sweeps still run — stayed green. Covered by the
new integration test: two open visits, both checkouts forced to reject, sweep
closes nobody, ledger row `success: true` with no error on `main`.

**What I chose and why.** The response body already carried counts, so the honest
signal was half-written. A route now reports the rows it could not process as a
top-level `failed`, and `withCron` reads that count off the response body.

The ledger records **two** things, not one, because "did it run" and "did it work"
are different questions:

| column | means | drives |
|---|---|---|
| `success` | the run COMPLETED | `lastSuccessAt`, `stale`, "this job stopped running" |
| `error` | the run was not clean | `lastError`, the red line in the panel |

A partial sweep therefore records **`success: true` WITH an error**. No migration:
`CronRunLog` already had both columns, so the distinction was expressible in the
schema as it stands — only the two `///` doc comments needed to say so.

The response the caller receives is untouched — a partial sweep still answers 200
and still did its partial work, and infra's retry semantics do not change; only
the health verdict does.

Alternatives rejected: returning 5xx on inner failure (turns a partial sweep into
a retry/alarm storm and hides the counts), and a per-route ledger call (every new
cron route would have to remember it — the same reason `withCron` owns the
recording today).

**Every route under `api/cron/` was checked**, not just the one reported:

| route | swallows rows? | change |
|---|---|---|
| `nightly` | `Promise.allSettled` | reports `failed` |
| `scholarship-grace-expiry` | per-row `try/catch` | reports `failed` |
| `reconcile-shopify` | per-order `try/catch` in `runReconcile` | `ReconcileResult.failed`, spread into the body |
| `lifecycle-reconcile` | per-row `try/catch` | none — see below |
| `pending-participants`, `post-event`, `membership-renewals`, `person-bg-annual`, `trusted-adult-expiry` | no | none needed: a throw propagates to `withCron`, which already records a failure |

`lifecycle-reconcile` isolates rows too, but a failed I1 heal leaves the row
off-diagram, so the scan that follows re-finds it and reports it to the
sysadmin/board channel as a violation. It is not a blind spot, so it is left
alone rather than grown a second signal.

### Review round 2 — why the two signals are split rather than collapsed

The first version of this PR recorded a partial sweep as `success: false`. That
was wrong in the other direction, and @thpr caught it: `lastSuccessByJob()`
aggregates only `success: true`, so a single **permanently**-failing row — a visit
whose `processVisitCheckout` always throws, or reconcile's cursor-frozen order,
which is *by design* re-scanned every run until it heals — would freeze
`lastSuccessAt` forever. After 48h the job reads as stale, the panel row goes red,
and `countStaleCronJobs`' badge says **"N job(s) not running"** about a job that
ran last night and swept everything else. One silent failure traded for another.

A job that ran, completed, and processed 9 of 10 rows is not a job that did not
run, so it does not get to say so. Both readers were changed to keep the two
apart:

- **`getCronJobStatuses`** takes `lastError` from the **latest run**, instead of
  the latest row with `success: false`. An error on a completed run now surfaces.
  This also *deleted* the "failed since last success" timestamp comparison — it is
  implied once the row being read is the latest one.
- **`countStaleCronJobs` → `countUnhealthyCronJobs`**, counting stale **OR**
  erroring. This half is not optional: without it a nightly sweep that fails every
  row runs forever behind a green pill, which is precisely defect 1 above. The
  payload field (`configHealth.staleCronJobs` → `unhealthyCronJobs`) and the badge
  label follow — "unhealthy" is true of both states, where "not running" was false
  for one of them. Which one it is stays a panel-level detail, one click away.

The Scheduled Jobs panel now distinguishes them visually: a **red timestamp** means
the job stopped running (check the scheduler); a **red line under a green
timestamp** means it ran but could not finish its work.

## Defect 2 — the trends exclusion matches no live writer

**Reproduction.** A program lead marks twenty participants Present for a
three-hour session. `GET /api/facility/trends` excludes
`arrivedVia notIn [LEAD_MARKED, SYSTEM]` to keep synthetic staff marks out of
measured hours, but the roster mark writes `arrivedVia: "WEB"`
(`events/[id]/route.ts:349`), so all sixty placeholder hours land in the
Participation Trends chart as measured facility time. Verified on
`origin/main` @ `fbc59f7` (2026-08-09): `git grep LEAD_MARKED` finds no writer
anywhere in `src/` — only the schema, the two `20260803000*` migrations, the
trends filter, `visit/significance.ts`, the source-icon map, and tests. The
exclusion reaches only rows the `20260803000100` backfill rewrote. The comment
above it asserted the opposite ("real visits use SCANNER/WEB on this field"),
which is exactly what makes it invisible: `WEB` is what the roster mark writes.

**Cross-file dependency I could not fix.** The writer lives in
`events/[id]/route.ts`, which this change does not own and which open PR #1558 is
also editing. It is a follow-up, written out in full below.

No reader-side substitute is honest. Roster-marked visits are indistinguishable
from a member's own self-report by source (`WEB`/`WEB`), by `associatedEventId`
(`attendance/manual` and `/api/scan` both set it), and by times (a lead can type
any). The only durable discriminator is the `newData.type =
"lead_attendance_correction"` audit row, and joining the hours report to
`AuditLog` JSON is precisely the "sum visits plus overlays" the design rejected —
plus it would still miss the adopt-an-existing-visit branch, and would be dead
weight the day the writer is fixed. So the comment now states the ceiling in
present tense rather than asserting a filter that does not fire.

**What I did fix on the reader side.** The same clause silently dropped every
visit whose arrival source was never recorded: `arrivedVia` is nullable, and in
SQL a NULL never satisfies a `NOT IN`. Verified empirically against Postgres 15
through the generated client — Prisma emits
`"arrivedVia" NOT IN (…)` for `notIn` (and `NOT "arrivedVia" IN (…)` for
`NOT: { in }`), and both drop NULL rows. So untagged legacy visits vanish from
the board's hours chart entirely, under-reporting facility time with no
indication. The filter now admits NULL explicitly, which matches how
`visit/significance.ts` already reads an untagged source ("untagged legacy value
≈ self-reported" — real, trusted least). The new test also asserts the
`LEAD_MARKED` exclusion still fires, so the fix does not widen the hole it sits
next to.

---

# Required follow-up — filed as #1619

The writer-side fix is [#1619](https://github.com/innovationtreehouse/checkin/issues/1619),
filed by @thpr from the text that used to be reproduced here. It carries the part that
matters: the `⚠️ This is NOT the one-line change it looks like` section, the create/adopt
rule (leave `arrivedVia` alone on the update branch, so an adopted walk-in keeps its real
measured source), the five acceptance criteria, the #1558 coordination note, and the open
question about already-written `WEB` rows.

Only the NULL under-count is fixed in this PR. The `WEB` over-count is #1619.

---

## Tests fail without the fixes

Each was run against `origin/main`'s source with the new tests in place
(`git checkout origin/main -- <source files>`), then against this branch:

| test | on `origin/main` | on this branch |
|---|---|---|
| `cronAuth.test.ts` › records a partial sweep as a run that completed AND names what failed | **fail** — ledger row has no error | pass |
| `cronNightlyAPI` › records the run as unclean, not as stopped, when every checkout fails | **fail** — `data.failed` `undefined`, ledger error null | pass |
| `cronNightlyAPI` › keeps checking out good visits when ONE visit fails | **fail** — `data.failed` `undefined` | pass |
| `cronScholarshipGraceExpiry` › isolates a per-row failure | **fail** — `data.failed` `undefined`, ledger error null | pass |
| `reconcile.integration` › counts an order whose forward pass throws | **fail** — `r.failed` `undefined` | pass |
| `facilityTrendsAPI` › counts an untagged arrival and still drops the staff-marked one | **fail** — `uniqueVolunteers` 0, hours 0 | pass |

The three guards for the round-2 split were verified red the same way, by mutating
the logic back and confirming each one bites:

| mutation | test that fails |
|---|---|
| `withCron` records `success: healthy` again (one flag) | `cronAuth` › records a partial sweep as a run that completed AND names what failed |
| `getCronJobStatuses` reads `lastError` only from `!success` rows | `cronRuns` › still surfaces the error, so the panel does not read as healthy |
| `countUnhealthyCronJobs` filters on `stale` only | `cronRuns` › counts toward the nav badge even though nothing is stale |
| the panel's own badge count filters on `stale` only | `SystemHealthPanels` › counts a job that ran-but-failed toward the badge |

`CronRunsBox` had no test at all before this. It derives its badge count client-side,
so it can drift from `countUnhealthyCronJobs` and leave the nav pill saying 2 while
the panel it links to shows nothing — now guarded, along with the two-state render.

Companion assertions that pass on both are boundary guards for the new branches,
not regression tests: `records a clean success when the body reports zero failed
rows` (the `> 0` boundary), `names a failure even when the ledger row recorded no
message` (`error` is nullable), and `is counted once when the job is BOTH stale and
failing` (no double-count in the badge).

## Verification

- **CI: 9/9 checks green** on `aba5650`, including the user-journey flow tests.
- `npm run lint` — clean.
- `npx tsc --noEmit --pretty false` — clean.
- Unit: `npm run test:ci` — **276 suites, 2701 tests, all passing**.
- Integration: full `npm run test:integration` against a throwaway Docker
  Postgres 15 — **136 suites, 1444 tests, all passing**.
- Schema drift: CI's exact check reproduced locally —
  `prisma migrate deploy` onto a clean DB, then
  `prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code`
  → *"No difference detected"*, exit 0. The `///` comment edit emits no SQL.
- `git diff --name-only origin/main...HEAD -- checkin-app/src/security/` is empty.
  The `schema.prisma` edit is `///` doc comments only: it emits no SQL (no migration
  in this repo's history contains a `COMMENT ON`), and `prisma generate` reproduced
  `src/security/generated/classifications.ts` byte-identical, since neither
  `@sensitivity:` annotation changed.

**Not verified:** whether any NULL `arrivedVia`
rows exist in the production DB; the squashed baseline
makes the field nullable with no backfill, and no current writer omits it, so the
affected rows are legacy ones. The follow-up writer fix above is unverified by
construction — it lives in a file this PR does not touch.

