### PR TITLE
perf(audit-log): dedup the filter dropdowns in SQL, not in the client

### DIFF
--- a/checkin-app/src/app/api/system-status/audit-log/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/system-status/audit-log/__tests__/route.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Guard: the three filter-dropdown reads must dedup in SQL, not in the client.
+ * Prisma's `distinct` is a client-side filter — it emits a bare SELECT with no
+ * DISTINCT and no LIMIT, so every AuditLog row the org has ever written crosses
+ * the wire on every load of this page. `groupBy` emits SQL GROUP BY (verified
+ * against Postgres 15; numbers in the PR body). This pins the call shape, which
+ * is the only thing observable without a live database.
+ *
+ * withAuth is mocked to a passthrough — the auth gate is not what's under test.
+ */
+jest.mock('@/lib/auth', () => ({
+    withAuth: (_opts: unknown, handler: (req: Request, auth: unknown) => unknown) =>
+        (req: Request, auth: unknown) => handler(req, auth),
+}));
+
+import { GET } from '../route';
+import prisma from '@/lib/prisma';
+
+const groupBy = () => prisma.auditLog.groupBy as unknown as jest.Mock;
+const findMany = () => prisma.auditLog.findMany as unknown as jest.Mock;
+
+beforeEach(() => {
+    prisma.auditLog.count = jest.fn().mockResolvedValue(0);
+    prisma.auditLog.findMany = jest.fn().mockResolvedValue([]);
+    prisma.auditLog.groupBy = jest.fn().mockImplementation(({ by }: { by: string[] }) => {
+        if (by[0] === 'tableName') return Promise.resolve([{ tableName: 'Visit' }]);
+        if (by[0] === 'actorId') return Promise.resolve([{ actorId: 7 }]);
+        return Promise.resolve([{ actorSystem: 'cron:nightly' }]);
+    });
+    prisma.person.findMany = jest.fn().mockResolvedValue([{ id: 7, name: 'Ada' }]);
+});
+
+const call = () =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (GET as any)(new Request('http://localhost/api/system-status/audit-log'), {
+        type: 'session',
+        user: { isSysadmin: true, isBoardMember: false },
+    });
+
+describe('GET /api/system-status/audit-log — dropdown reads dedup in SQL', () => {
+    it('reads each dropdown column with groupBy', async () => {
+        await call();
+        const columns = groupBy().mock.calls.map((c) => c[0].by).flat().sort();
+        expect(columns).toEqual(['actorId', 'actorSystem', 'tableName']);
+    });
+
+    it('never asks Prisma to dedup client-side', async () => {
+        await call();
+        for (const [args] of findMany().mock.calls) {
+            expect(args).not.toHaveProperty('distinct');
+        }
+    });
+
+    it('still serves the dropdown values it grouped', async () => {
+        const body = await (await call()).json();
+        expect(body.tables).toEqual(['Visit']);
+        expect(body.actors).toEqual([{ id: 7, name: 'Ada' }]);
+        expect(body.systemActors).toEqual(['cron:nightly']);
+    });
+});

--- a/checkin-app/src/app/api/system-status/audit-log/route.ts
+++ b/checkin-app/src/app/api/system-status/audit-log/route.ts
@@ -67,19 +67,20 @@ export const GET = withAuth(
                     take: PAGE_SIZE,
                 }),
                 // Distinct entity types / actors for the filter dropdowns (unfiltered, stable).
-                prisma.auditLog.findMany({
-                    distinct: ['tableName'],
-                    select: { tableName: true },
+                // groupBy, not findMany+distinct: Prisma's `distinct` dedups in the client,
+                // so it drags every AuditLog row across the wire. groupBy emits SQL GROUP BY.
+                // ponytail: still an index-only scan of the whole column; a loose index scan
+                // (recursive CTE) is the next rung if the dropdowns ever get slow.
+                prisma.auditLog.groupBy({
+                    by: ['tableName'],
                     orderBy: { tableName: 'asc' },
                 }),
-                prisma.auditLog.findMany({
-                    distinct: ['actorId'],
-                    select: { actorId: true },
+                prisma.auditLog.groupBy({
+                    by: ['actorId'],
                     where: { actorId: { gt: 0 } },
                 }),
-                prisma.auditLog.findMany({
-                    distinct: ['actorSystem'],
-                    select: { actorSystem: true },
+                prisma.auditLog.groupBy({
+                    by: ['actorSystem'],
                     where: { actorSystem: { not: null } },
                     orderBy: { actorSystem: 'asc' },
                 }),


### PR DESCRIPTION
Prisma's `distinct` is a **client-side** filter, not a SQL `DISTINCT`. The three filter-dropdown reads in this route therefore emitted a bare `SELECT` with no `DISTINCT` and no `LIMIT` — every `AuditLog` row the org has ever written crossed the wire and was deduped in Node, on every load of the Audit Log tab. `AuditLog` is the highest-volume table in the app (a row per visit write, per membership transition, per role change).

`groupBy` emits a real SQL `GROUP BY`. Same values out, parameterized by Prisma, no raw SQL on an authenticated admin surface.

## Scope: three queries, not two

The report named the two actor dropdowns. Reproducing it showed the `tableName` dropdown two lines above has the identical defect — same Prisma behaviour, same `Promise.all`. Fixing two of three would have left the root cause in place on a sibling call, so all three moved.

## Reproduced first (Postgres 15, `log_statement=all`, 50,000 seeded `AuditLog` rows)

Emitted SQL, captured off the app's own generated client (Prisma 7.8.0):

```
-- before
SELECT "AuditLog"."id", "AuditLog"."actorId"     FROM "AuditLog" WHERE "actorId" > $1 OFFSET $2
SELECT "AuditLog"."id", "AuditLog"."actorSystem" FROM "AuditLog" WHERE "actorSystem" IS NOT NULL ORDER BY "actorSystem" ASC OFFSET $1
SELECT "AuditLog"."id", "AuditLog"."tableName"   FROM "AuditLog" WHERE 1=1 ORDER BY "tableName" ASC OFFSET $1

-- after
SELECT "AuditLog"."actorId"     FROM "AuditLog" WHERE "actorId" > $1 GROUP BY "actorId" OFFSET $2
SELECT "AuditLog"."actorSystem" FROM "AuditLog" WHERE "actorSystem" IS NOT NULL GROUP BY "actorSystem" ORDER BY "actorSystem" ASC OFFSET $1
SELECT "AuditLog"."tableName"   FROM "AuditLog" GROUP BY "tableName" ORDER BY "tableName" ASC OFFSET $1
```

Note the `id` column disappearing too — Prisma has to select it to dedup client-side.

## Measured (same 50k rows: 12 distinct actors, 4 distinct system paths, 3 distinct tables; `EXPLAIN (ANALYZE, BUFFERS)` after `VACUUM ANALYZE`)

| dropdown | rows to client | shared buffers | plan |
|---|---|---|---|
| `actorId` before | 50,000 | 556 | Seq Scan |
| `actorId` after | **12** | **50** | Index Only Scan `AuditLog_actorId_idx`, Heap Fetches: 0 |
| `actorSystem` before | 28,571 | 2,249 | Index Scan (heap) |
| `actorSystem` after | **4** | **26** | Index Only Scan `AuditLog_actorSystem_idx` |
| `tableName` before | 50,000 | 2,078 | Index Scan (heap) |
| `tableName` after | **3** | **559** | Seq Scan + HashAggregate |

Rows over the wire drop 128,571 → 19. Buffers drop 4,883 → 635 (7.7x). All three scale with table size in prod, so the row-transfer saving grows linearly with the audit history.

## No new index

Checked, as asked, whether `20260809090000_audit_log_table_timestamp_index` helps: it does **not** serve the two actor queries — its leading column is `tableName`. Those two are already served by the pre-existing `@@index([actorId])` and `@@index([actorSystem])`, which is exactly what turns them into index-only scans above. The `tableName` query can use `AuditLog_tableName_timestamp_idx` but the planner prefers a seq scan + HashAggregate at this row count. **No index added; no migration in this PR.**

## The check — labelled a guard

`checkin-app/src/app/api/system-status/audit-log/__tests__/route.test.ts` pins the **call shape** (dropdown columns read via `groupBy`; no `auditLog.findMany` call carries `distinct`). It is a **guard**, not a SQL pin: the app's shared Prisma client is constructed without query-event logging, so the emitted SQL is not observable from a unit test, and the response body is byte-identical before and after — nothing in the HTTP contract can go red. The SQL itself is pinned empirically above, not in CI.

Red → green against `origin/main`'s source (restored `route.ts` from `git show origin/main:…`, same test file):

```
# origin/main route.ts
Tests: 3 failed, 3 total
  ✕ reads each dropdown column with groupBy      → Received: []
  ✕ never asks Prisma to dedup client-side       → Received value: ["tableName"]
  ✕ still serves the dropdown values it grouped  → Received: []

# this branch
Tests: 5 passed, 5 total   (incl. the existing page suite)
```

No wall-clock timing test — it would be flaky in CI and would prove nothing.

## Verification

- `npx tsc --noEmit --pretty false` → only the 2 known-environmental `@aws-sdk/client-lambda` errors.
- `npx eslint checkin-app/src/app/api/system-status/audit-log/` → clean.
- `git diff --name-only origin/main...HEAD -- checkin-app/src/security/` → empty. Diff touches only `checkin-app/src/app/api/system-status/audit-log/`.

## Known ceiling (left deliberately, marked in-code)

`GROUP BY` still walks the whole column, just as an index-only scan that ships 19 rows instead of 128,571. A loose index scan (recursive CTE) would make it O(distinct × log n), at the cost of three blocks of hand-written recursive SQL. Not worth it at current volumes — flagged in a `ponytail:` comment with the upgrade path.

## Not verified

The numbers come from a synthetic 50k-row probe DB with a deliberately small distinct cardinality, not from prod data. The *shape* of the win (client dedup → SQL dedup) is exact; the multipliers will differ in prod, and will grow as `AuditLog` does.
