### PR TITLE
fix(trusted-adult): don't tell a family a renewed adult is de-authorized

### DIFF
--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -721,4 +721,39 @@ describe('runExpirySweep edge cases', () => {
         expect(sendEmail).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining('Renewed Grandma'), expect.anything());
         expect(sendEmail).toHaveBeenCalledTimes(1);
     });
+
+    // Pins "one notice per ADULT, not one per row" — a property of statement ORDER: each
+    // row's flip commits before the next row's authorization check reads, so only the last
+    // row to lapse finds no approval and mails. Batch the flips into one upfront
+    // transaction and every row sees zero approvals: one email per row again. The
+    // `expired` assertion pins the other half — `continue` stays AFTER `expired++`, so
+    // per-review bookkeeping is byte-identical to the pre-fix behaviour.
+    it('two lapsed reviews on ONE adult expire both rows but send exactly one de-authorization email', async () => {
+        const now = new Date();
+        const ta = await prisma.trustedAdult.create({
+            data: { householdId, trustedAdultName: `Twice Lapsed ${SWEEP_TAG}`, trustedAdultEmail: 'twice@example.com', familyContext: 'ctx', disclosedById: leadId },
+        });
+        // A year-old original and the renewal that replaced it, both now past reviewBy.
+        const older = await prisma.trustedAdultReview.create({
+            data: { householdId, trustedAdultId: ta.id, kind: 'INITIAL', status: 'APPROVED', reviewBy: new Date(now.getTime() - 400 * DAY) },
+        });
+        const newer = await prisma.trustedAdultReview.create({
+            data: { householdId, trustedAdultId: ta.id, kind: 'RENEWAL', status: 'APPROVED', reviewBy: new Date(now.getTime() - 1 * DAY) },
+        });
+
+        const run = await runExpirySweep(now);
+
+        // Per-review bookkeeping unchanged: both rows counted, both flipped.
+        expect(run.expired).toBe(2);
+        expect((await prisma.trustedAdultReview.findUnique({ where: { id: older.id } }))!.status).toBe('EXPIRED');
+        expect((await prisma.trustedAdultReview.findUnique({ where: { id: newer.id } }))!.status).toBe('EXPIRED');
+        // The adult really is de-authorized now, so the notice is owed — exactly once.
+        expect(await prisma.trustedAdult.count({ where: { id: ta.id, reviews: { some: { status: 'APPROVED' } } } })).toBe(0);
+        expect(sendEmail).toHaveBeenCalledTimes(1);
+        expect(sendEmail).toHaveBeenCalledWith(
+            `sweeplead-${SWEEP_TAG}@ex.com`,
+            `Trusted adult approval expired: Twice Lapsed ${SWEEP_TAG}`,
+            expect.stringContaining('no longer authorized at the front desk'),
+        );
+    });
 });

--- a/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
+++ b/checkin-app/src/app/__tests__/trustedAdultService.integration.test.ts
@@ -675,4 +675,50 @@ describe('runExpirySweep edge cases', () => {
             expect(after!.expiryWarningSentAt).toBeNull(); // expired, never warned
         }
     });
+
+    // Regression: renewing early leaves the adult with TWO APPROVED reviews (renew never
+    // retires the prior one). When the OLD row lapses the sweep must still expire it, but
+    // the family is NOT de-authorized — /operational lists a TA while ANY review is
+    // APPROVED. Asserts both directions so the fix can't be "stop emailing".
+    it('a renewed adult whose old review lapses gets no de-authorization email; a genuinely lapsed one still does', async () => {
+        const now = new Date();
+        const past = new Date(now.getTime() - 1 * DAY);
+        const future = new Date(now.getTime() + 300 * DAY);
+
+        // Adult A: original approval lapsing now, plus a board-approved renewal still live.
+        const renewedTa = await prisma.trustedAdult.create({
+            data: { householdId, trustedAdultName: `Renewed Grandma ${SWEEP_TAG}`, trustedAdultEmail: 'gran@example.com', familyContext: 'ctx', disclosedById: leadId },
+        });
+        const staleRow = await prisma.trustedAdultReview.create({
+            data: { householdId, trustedAdultId: renewedTa.id, kind: 'INITIAL', status: 'APPROVED', reviewBy: past },
+        });
+        const renewalRow = await prisma.trustedAdultReview.create({
+            data: { householdId, trustedAdultId: renewedTa.id, kind: 'RENEWAL', status: 'APPROVED', reviewBy: future },
+        });
+
+        // Adult B: one approval, lapsed, nothing behind it — genuinely de-authorized.
+        const lapsedRow = await seedReview('APPROVED', past);
+
+        const run = await runExpirySweep(now);
+
+        // Both stale rows flip: expiry is per-review bookkeeping and is unchanged.
+        expect(run.expired).toBe(2);
+        expect((await prisma.trustedAdultReview.findUnique({ where: { id: staleRow.id } }))!.status).toBe('EXPIRED');
+        expect((await prisma.trustedAdultReview.findUnique({ where: { id: lapsedRow.id } }))!.status).toBe('EXPIRED');
+        // The renewal is untouched, so /operational's `some: APPROVED` rule still lists adult A.
+        expect((await prisma.trustedAdultReview.findUnique({ where: { id: renewalRow.id } }))!.status).toBe('APPROVED');
+        expect(await prisma.trustedAdult.count({ where: { id: renewedTa.id, reviews: { some: { status: 'APPROVED' } } } })).toBe(1);
+        // ...and adult B really is off the list.
+        expect(await prisma.trustedAdult.count({ where: { id: lapsedRow.trustedAdultId, reviews: { some: { status: 'APPROVED' } } } })).toBe(0);
+
+        // Direction 1: the genuinely lapsed adult's family is still told.
+        expect(sendEmail).toHaveBeenCalledWith(
+            `sweeplead-${SWEEP_TAG}@ex.com`,
+            `Trusted adult approval expired: Sweep ${SWEEP_TAG}`,
+            expect.stringContaining('no longer authorized at the front desk'),
+        );
+        // Direction 2: the renewed adult's family is NOT told they lost someone they still have.
+        expect(sendEmail).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining('Renewed Grandma'), expect.anything());
+        expect(sendEmail).toHaveBeenCalledTimes(1);
+    });
 });

--- a/checkin-app/src/app/api/trusted-adults/operational/route.ts
+++ b/checkin-app/src/app/api/trusted-adults/operational/route.ts
@@ -1,6 +1,8 @@
 import prisma from "@/lib/prisma";
 import { handler, unauthorized } from "@/security/handler";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import { AUTHORIZED_REVIEW } from "@/lib/trusted-adult/filters";
+import type { Prisma } from "@/generated/prisma/client";
 
 export const dynamic = "force-dynamic";
 
@@ -16,9 +18,7 @@ export const GET = handler("GET /api/trusted-adults/operational", async ({ auth 
     const u = auth.user;
     const privileged = u.isSysadmin || u.isBoardMember || u.isKeyholder;
 
-    const where: { reviews: { some: { status: "APPROVED" } }; householdId?: { in: number[] } } = {
-        reviews: { some: { status: "APPROVED" } },
-    };
+    const where: Prisma.TrustedAdultWhereInput = { reviews: { some: AUTHORIZED_REVIEW } };
 
     if (!privileged) {
         // Program leads: households of children enrolled in programs they lead or core-vol.
@@ -48,7 +48,7 @@ export const GET = handler("GET /api/trusted-adults/operational", async ({ auth 
             trustedAdultEmail: true,
             household: { select: { id: true, name: true } },
             reviews: {
-                where: { status: "APPROVED" },
+                where: AUTHORIZED_REVIEW,
                 orderBy: { id: "desc" },
                 take: 1,
                 select: { id: true, householdId: true, status: true, sharedNote: true, reviewBy: true },

--- a/checkin-app/src/lib/trusted-adult/filters.ts
+++ b/checkin-app/src/lib/trusted-adult/filters.ts
@@ -1,0 +1,9 @@
+import type { Prisma } from "@/generated/prisma/client";
+
+/**
+ * The ONE definition of "authorized at the front desk right now": the adult has at
+ * least one APPROVED review. Renewal leaves the prior approval APPROVED, so a
+ * TrustedAdult routinely carries several — authorization is a property of the ADULT,
+ * not of a single review. /operational, the deny notice, and the expiry sweep all read it.
+ */
+export const AUTHORIZED_REVIEW: Prisma.TrustedAdultReviewWhereInput = { status: "APPROVED" };

--- a/checkin-app/src/lib/trusted-adult/service.ts
+++ b/checkin-app/src/lib/trusted-adult/service.ts
@@ -3,6 +3,7 @@ import { personActor, systemActor, type AuditActor } from "@/lib/auditActor";
 import { escapeHtml } from "@/lib/email-templates/base";
 import { emailBoardMembers, emailHouseholdLeads } from "@/lib/emailRecipients";
 import { isTrustedAdultConflict } from "@/lib/trusted-adult/conflict";
+import { AUTHORIZED_REVIEW } from "@/lib/trusted-adult/filters";
 import { config } from "@/lib/config";
 import { validateContact } from "@/lib/trusted-adult/contact";
 import type { TxClient } from "@/lib/db-client";
@@ -401,7 +402,7 @@ export async function decideReview(reviewId: number, boardMemberId: number, inpu
         // one live would keep the adult on the pickup list after a full rejection.
         if (input.decision === "DENY" && input.revokePriorApprovals) {
             const live = await tx.trustedAdultReview.findMany({
-                where: { trustedAdultId: review.trustedAdultId, status: "APPROVED" },
+                where: { trustedAdultId: review.trustedAdultId, ...AUTHORIZED_REVIEW },
                 orderBy: { id: "desc" },
             });
             if (live.length) {
@@ -434,7 +435,7 @@ export async function decideReview(reviewId: number, boardMemberId: number, inpu
         } else {
             // Mirror /operational's rule: a surviving APPROVED review = still authorized.
             const live = await prisma.trustedAdultReview.findFirst({
-                where: { trustedAdultId: head.trustedAdultId, status: "APPROVED" },
+                where: { trustedAdultId: head.trustedAdultId, ...AUTHORIZED_REVIEW },
                 orderBy: { reviewBy: "desc" },
             });
             if (live) {
@@ -562,7 +563,16 @@ export async function runExpirySweep(now: Date) {
         expired++;
         // Notify only after the flip commits: the status change is the authoritative act,
         // the email a courtesy on top, so a slow or failing provider can't hold the tx.
-        // The flip is its own dedup — an EXPIRED row is no longer selected by this query.
+        // The flip is its own dedup — an EXPIRED row is no longer selected by this query —
+        // and it also excludes this row from the authorization check below.
+        const stillAuthorized = await prisma.trustedAdultReview.findFirst({
+            where: { trustedAdultId: r.trustedAdultId, ...AUTHORIZED_REVIEW },
+            select: { id: true },
+        });
+        // One lapsed review is not a lapsed adult: a renewal approved before this row's
+        // date still authorizes them, and /operational still lists them. Only the review
+        // that leaves the adult with no approval at all earns the de-authorization notice.
+        if (stillAuthorized) continue;
         const name = r.trustedAdult.trustedAdultName?.trim() || "your trusted adult";
         await notifyHouseholdFamily(
             r.householdId,


### PR DESCRIPTION
## The bug

`runExpirySweep` sent the "no longer authorized at the front desk" email **per lapsed REVIEW**, but `/api/trusted-adults/operational` lists a trusted adult while **ANY** of its reviews is `APPROVED`. Those two rules disagreed, so the ordinary renew-early flow mailed a false de-authorization notice.

The path, all on `origin/main`:

1. A trusted adult's INITIAL review is APPROVED with `reviewBy = T`.
2. At `T-30d` the sweep warns the family "expiring soon".
3. The family renews. `renewTrustedAdult` only refuses when the *latest* review is `PENDING_BOARD_REVIEW`/`PENDING_SUBJECT_ACTION`, so this is allowed.
4. The board approves the RENEWAL. `decideReview`'s APPROVE branch stamps a fresh `reviewBy` on the new row and never touches prior approvals — the adult now carries **two** APPROVED reviews.
5. At `T` the sweep's lapsed query matches the **old** review and emails the family that the adult is no longer authorized — while `/operational` still lists them, correctly, because the renewal is live.

The family is told they lost someone the front desk will still release their kids to.

## The fix

The root cause is two definitions of "authorized". `/operational` had it inline (`reviews: { some: { status: "APPROVED" } }`), `decideReview`'s deny branch had a second hand-rolled copy (with a `// Mirror /operational's rule` comment — already a warning sign), and the sweep had no notion of it at all.

Extracted `AUTHORIZED_REVIEW` into `src/lib/trusted-adult/filters.ts`, following the existing `LIVE_PERSON` precedent in `src/lib/person/filters.ts`. All three sites now read it:

- `/api/trusted-adults/operational` — the authority, unchanged in behaviour.
- `decideReview` — both the deny notice and Deny & Revoke.
- `runExpirySweep` — **the behaviour change**: after the flip to `EXPIRED` commits, re-ask whether the adult still has any APPROVED review. Only the review that leaves them with *no* approval at all earns the de-authorization notice.

The check runs after the flip, so the row being expired is already excluded, and the `continue` sits after `expired++` — the returned `expired` count and the per-review `EXPIRED` bookkeeping are unchanged. If several reviews for one adult lapse in the same sweep, the family gets exactly one notice, not one per row.

## Red / green

Two checks in `trustedAdultService.integration.test.ts`, both proved red by checking out `origin/main`'s `service.ts` underneath them.

**1. `a renewed adult whose old review lapses gets no de-authorization email; a genuinely lapsed one still does`**

Seeds two adults in one sweep — one renewed (stale INITIAL + live RENEWAL), one genuinely lapsed — and asserts both directions, so the fix cannot be "stop emailing".

RED on `origin/main`:
```
  expect(jest.fn()).not.toHaveBeenCalledWith(...expected)
  Expected: not Anything, StringContaining "Renewed Grandma", Anything
  Received
    1: "sweeplead-...@ex.com", "Trusted adult approval expired: Renewed Grandma ...",
       "<p>The board's approval of Renewed Grandma ... has expired. They are no longer
        authorized at the front desk. ...</p>"
  Number of calls: 2
```
Two emails on main — the genuinely lapsed family *and* the renewed one. On this branch, one: only the genuinely lapsed family.

**2. `two lapsed reviews on ONE adult expire both rows but send exactly one de-authorization email`** (added for review feedback)

"One notice per ADULT, not one per row" is a property of statement **order**: each row's flip commits before the next row's authorization check reads, so only the last row to lapse finds no approval and mails. Batch the flips into a single upfront transaction — a plausible perf refactor of a nightly sweep — and every row sees zero approvals, so the family gets one email per lapsed row again. Nothing pinned that, and the first test seeds two *different* adults so it doesn't cover it.

This one seeds **one** adult with **two** lapsed APPROVED reviews. The `expired === 2` assertion pins the other half of the contract — `continue` stays after `expired++`, so the returned count and the per-review `EXPIRED` flips stay identical to main.

RED on `origin/main`:
```
  expect(jest.fn()).toHaveBeenCalledTimes(expected)
  Expected number of calls: 1
  Received number of calls: 2
```
(`run.expired === 2` and both rows `EXPIRED` pass on *both* sides — that is the point: only the email count moves.)

GREEN on this branch: `Tests: 30 passed, 30 total`.

## Other verification

- `npm run test:integration -- --testPathPatterns trustedAdultService` — 30 passed.
- `npm test -- --testPathPatterns "trusted|pickup|todo-counts"` — 6 suites, 32 tests passed.
- `npx tsc --noEmit` — exit 0, zero output.
- `npx eslint` on the changed files — clean.
- Drift-guard suites pass.
- `git diff --name-only origin/main...HEAD -- checkin-app/src/security/` is empty.

## Known gap: "expiring" is still per-REVIEW on two other surfaces

This PR fixes the *de-authorization* notice, which asks **"is this adult authorized?"** — the question `AUTHORIZED_REVIEW` answers. Two neighbours ask a *different* question, **"is this adult's authorization running out?"**, and both still answer it one row at a time:

- **The sweep's warning email** (`service.ts`, the `expiring` query). Renew more than 30 days out, get board approval, and the stale row still mails "A trusted adult approval is expiring soon".
- **`/api/nav/todo-counts`** (`route.ts:202-208`, `:237-238`) — thpr's review finding, confirmed. The same stale row pushes one "Renew an expiring trusted adult" todo *per row*, so a family that renewed early and was approved is told to go renew someone they already renewed, while `/operational` correctly still lists that adult.

**`AUTHORIZED_REVIEW` does not fix either, and I checked rather than assumed.** todo-counts' filter is `status: { in: APPROVED_STATUSES }` where `APPROVED_STATUSES = ["APPROVED"]` (`route.ts:43`) — already byte-for-byte `AUTHORIZED_REVIEW`. Substituting it changes no behaviour at all; it would only *look* like a fix while the family keeps getting nagged.

What both surfaces actually need is the other predicate: exclude self, compare `reviewBy` across the adult's APPROVED rows — "is any approval outliving this one?". Folding that in here would have added back the second definition of "authorized" this PR exists to delete, and would have fixed one of the two surfaces while leaving its identical twin broken.

Secondary, same call site: todo-counts' `reviewBy: { not: null, lte: warnThreshold }` has no `gt: now` (the sweep's `expiring` query does), so a row that lapsed before the nightly sweep ran is still labelled "expiring". Adding `gt: now` does **not** fix the renewal nag — the stale row's `reviewBy` is in the future for the whole 30-day warn window.

**Follow-up:** one shared "expiring adult" predicate, applied to the warning email and todo-counts together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
