### PR TITLE
fix(security): serve manual-attendance corrections through handler()

### DIFF
--- a/checkin-app/scripts/migrated-routes.txt
+++ b/checkin-app/scripts/migrated-routes.txt
@@ -7,3 +7,5 @@
 GET /api/profile
 GET /api/programs/[id]
 GET /api/safety/board-contacts
+PATCH /api/attendance/manual/[id]
+DELETE /api/attendance/manual/[id]

--- a/checkin-app/src/app/api/attendance/manual/[id]/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/attendance/manual/[id]/__tests__/route.test.ts
@@ -265,6 +265,11 @@ describe("household-lead correction of a member's visit", () => {
         (visitSubject as jest.Mock).mockImplementation(leadScope);
         visitFindUnique.mockResolvedValue(memberVisit);
         tx.visit.findFirst.mockResolvedValue({ id: 42 });
+        // The row written back is the MEMBER's. Leaving the default (personId =
+        // OWN_ID) let their_own resolve on it, which masks what led_households
+        // does or doesn't grant — the whole point of this block.
+        tx.visit.update.mockImplementation(async (args: { data: Record<string, unknown> }) => ({ ...memberVisit, ...args.data }));
+        (processVisitCheckout as jest.Mock).mockResolvedValue([{ ...memberVisit }]);
     });
 
     it("edits a member's visit, locking and matching on the MEMBER, auditing the actor", async () => {
@@ -320,6 +325,23 @@ describe("household-lead correction of a member's visit", () => {
         for (const internal of ["deletedAt", "deletedById", "forceCloseWarnedAt"]) {
             expect(visit).not.toHaveProperty(internal);
         }
+    });
+
+    // The other edge: led_households is gated on the roster, not on "is a lead".
+    // visitSubject (DB leadship) and ledHouseholdMemberIds (session householdLead
+    // + householdId) are different sources and can disagree on a stale session —
+    // when they do, the grant must not resolve and the times must not ship.
+    it("strips the times when the roster does not contain the visit's person", async () => {
+        mockSession.mockResolvedValue({ user: { id: OWN_ID, householdLead: true, householdId: HOUSEHOLD_ID } });
+        personFindMany.mockResolvedValue([{ id: OWN_ID }]); // MEMBER_ID absent
+
+        const res = await PATCH(req("PATCH", { arrivedAt: "2026-07-20T14:05:00Z" }), ctx as never);
+        expect(res.status).toBe(200);
+        const { visit } = await res.json();
+
+        expect(visit).not.toHaveProperty("arrivedAt");
+        expect(visit).not.toHaveProperty("departedAt");
+        expect(visit.personId).toBe(MEMBER_ID); // public tier still rides through
     });
 
     it("404s a visit belonging to someone outside the lead's household", async () => {

--- a/checkin-app/src/app/api/attendance/manual/[id]/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/attendance/manual/[id]/__tests__/route.test.ts
@@ -9,6 +9,11 @@
  * emails the board, a delete never removes the row, closing an open visit
  * routes through processVisitCheckout, and every lock/where keys on the visit's
  * PERSON (not the actor) so a lead's write serializes against the member's kiosk.
+ *
+ * Both verbs go through @/security/handler, so the registered policy is what
+ * shapes the response: PATCH returns the `visit` envelope stripped to the
+ * registry's their_own/led_households:personal grant, DELETE ships no model
+ * data at all.
  */
 
 import type { NextRequest } from "next/server";
@@ -40,6 +45,9 @@ jest.mock("@/lib/prisma", () => ({
     default: {
         visit: { findUnique: jest.fn(), update: jest.fn() },
         auditLog: { create: jest.fn() },
+        // buildCallerContext reads the led-household roster (the route's only
+        // ctxNeeds prefetch) to resolve led_households.
+        person: { findMany: jest.fn() },
         $transaction: jest.fn(async (cb: (t: unknown) => unknown) => cb(tx)),
     },
 }));
@@ -47,13 +55,17 @@ jest.mock("@/lib/prisma", () => ({
 const mockSession = getServerSession as jest.Mock;
 const visitFindUnique = prisma.visit.findUnique as jest.Mock;
 const auditCreate = prisma.auditLog.create as jest.Mock;
+const personFindMany = prisma.person.findMany as jest.Mock;
 
 const OWN_ID = 7;
 const MEMBER_ID = 8; // a household member the actor leads
+const HOUSEHOLD_ID = 2;
+// Every column a real `visit.update` returns, tombstone fields included — the
+// stripper only drops fields the row actually carries.
 const baseVisit = {
     id: 42, personId: OWN_ID, deletedAt: null, deletedById: null, associatedEventId: null,
     arrivedAt: new Date("2026-07-20T14:00:00Z"), departedAt: new Date("2026-07-20T16:00:00Z"),
-    arrivedVia: "WEB", departedVia: "WEB",
+    arrivedVia: "WEB", departedVia: "WEB", forceCloseWarnedAt: null,
 };
 
 function req(method: string, body?: unknown): NextRequest {
@@ -75,6 +87,7 @@ beforeEach(() => {
     tx.visit.updateMany.mockResolvedValue({ count: 1 });
     (processVisitCheckout as jest.Mock).mockResolvedValue([{ ...baseVisit }]);
     auditCreate.mockResolvedValue({});
+    personFindMany.mockResolvedValue([]); // not a household lead unless a test says so
 });
 
 describe("PATCH /api/attendance/manual/[id]", () => {
@@ -120,7 +133,6 @@ describe("PATCH /api/attendance/manual/[id]", () => {
         const res = await PATCH(req("PATCH", { arrivedAt: "2026-07-20T14:05:00Z" }), ctx as never);
 
         expect(res.status).toBe(200);
-        expect(await res.json()).toMatchObject({ flagged: false });
         expect(tx.visit.update).toHaveBeenCalledWith(expect.objectContaining({
             data: { arrivedAt: new Date("2026-07-20T14:05:00Z"), arrivedVia: "WEB" },
         }));
@@ -139,7 +151,6 @@ describe("PATCH /api/attendance/manual/[id]", () => {
         const res = await PATCH(req("PATCH", { arrivedAt: "2026-07-20T12:00:00Z" }), ctx as never);
 
         expect(res.status).toBe(200);
-        expect(await res.json()).toMatchObject({ flagged: true });
         expect(emailBoardMembers).toHaveBeenCalledTimes(1);
     });
 
@@ -209,7 +220,8 @@ describe("DELETE /api/attendance/manual/[id]", () => {
         const res = await DELETE(req("DELETE"), ctx as never);
 
         expect(res.status).toBe(200);
-        expect(await res.json()).toEqual({ success: true, flagged: true });
+        // No bag: a tombstone ships no model data (registry `envelope: null`).
+        expect(await res.json()).toEqual({});
         // Ownership + liveness are re-asserted inside the lock, not just before it.
         expect(tx.visit.updateMany).toHaveBeenCalledWith({
             where: { id: 42, personId: OWN_ID, deletedAt: null },
@@ -273,7 +285,7 @@ describe("household-lead correction of a member's visit", () => {
         // 50 min on a WEB (weight 1) arrival: 50 alone is under the 90 threshold,
         // 100 by proxy is over it.
         const res = await PATCH(req("PATCH", { arrivedAt: "2026-07-20T14:50:00Z" }), ctx as never);
-        expect(await res.json()).toMatchObject({ flagged: true });
+        expect(res.status).toBe(200);
         expect((emailBoardMembers as jest.Mock).mock.calls[0][0]).toContain("household-edit");
     });
 
@@ -288,6 +300,26 @@ describe("household-lead correction of a member's visit", () => {
         expect(auditCreate.mock.calls[0][0].data).toMatchObject({
             actorId: OWN_ID, secondaryAffectedEntity: MEMBER_ID,
         });
+    });
+
+    // THE regression pin for the registry↔route seam. Both edges matter: the
+    // times must SURVIVE (led_households:personal is granted and resolving) and
+    // the 'internal' tombstone columns must be GONE. On legacy withAuth the raw
+    // `visit.update` row shipped whole and deletedAt/deletedById/
+    // forceCloseWarnedAt reached the browser.
+    it("strips the internal tombstone columns while keeping the times the lead may see", async () => {
+        mockSession.mockResolvedValue({ user: { id: OWN_ID, householdLead: true, householdId: HOUSEHOLD_ID } });
+        personFindMany.mockResolvedValue([{ id: OWN_ID }, { id: MEMBER_ID }]);
+
+        const res = await PATCH(req("PATCH", { arrivedAt: "2026-07-20T14:05:00Z" }), ctx as never);
+        expect(res.status).toBe(200);
+        const { visit } = await res.json();
+
+        expect(visit.arrivedAt).toBe("2026-07-20T14:05:00.000Z");
+        expect(visit.departedAt).toBe(baseVisit.departedAt.toISOString());
+        for (const internal of ["deletedAt", "deletedById", "forceCloseWarnedAt"]) {
+            expect(visit).not.toHaveProperty(internal);
+        }
     });
 
     it("404s a visit belonging to someone outside the lead's household", async () => {

--- a/checkin-app/src/app/api/attendance/manual/[id]/route.ts
+++ b/checkin-app/src/app/api/attendance/manual/[id]/route.ts
@@ -1,5 +1,4 @@
-import { withAuth } from "@/lib/auth";
-import { NextResponse } from "next/server";
+import { handler, ApiResponseError, badRequest, notFound, unauthorized } from "@/security/handler";
 import prisma from "@/lib/prisma";
 import type { Prisma } from "@/generated/prisma/client";
 import { parseVisitTime, departureAfterArrival, withinMaxDuration } from "@/lib/visitTimes";
@@ -9,7 +8,6 @@ import { visitSubject } from "@/lib/visit/scope";
 import { emailBoardMembers } from "@/lib/emailRecipients";
 import { escapeHtml } from "@/lib/email-templates/base";
 import { logBackendError } from "@/lib/logger";
-import { apiError } from "@/lib/api-response";
 import { formatDateTime } from "@/lib/time";
 import { resolveDisplayTimezone } from "@/lib/appSettings";
 
@@ -47,20 +45,20 @@ function flagBoard(kind: "edit" | "delete", visitId: number, actorName: string, 
     );
 }
 
-export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return apiError("Unauthorized", 401);
+export const PATCH = handler<{ id: string }>('PATCH /api/attendance/manual/[id]', async ({ req, auth, params }) => {
+    if (auth.type !== 'session') throw unauthorized();
     try {
         const userId = auth.user.id;
-        const visitId = Number((await ctx.params).id);
-        if (!Number.isInteger(visitId)) return apiError("Invalid visit id", 400);
+        const visitId = Number(params.id);
+        if (!Number.isInteger(visitId)) throw badRequest("Invalid visit id");
 
         const body = await req.json().catch(() => null);
-        if (!body || typeof body !== "object") return apiError("Invalid JSON", 400);
+        if (!body || typeof body !== "object") throw badRequest("Invalid JSON");
         const { arrivedAt, departedAt } = body;
-        if (!arrivedAt && !departedAt) return apiError("Nothing to change.", 400);
+        if (!arrivedAt && !departedAt) throw badRequest("Nothing to change.");
 
         const visit = await loadEditableVisit(visitId, userId);
-        if (!visit) return apiError("Visit not found.", 404);
+        if (!visit) throw notFound("Visit not found.");
         const byProxy = visit.personId !== userId;
 
         const now = new Date();
@@ -69,25 +67,25 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
 
         if (arrivedAt) {
             const r = parseVisitTime(arrivedAt, "arrival", now);
-            if (!r.ok) return apiError(r.error, 400);
+            if (!r.ok) throw badRequest(r.error);
             nextArrived = r.value;
         }
         if (departedAt) {
             const r = parseVisitTime(departedAt, "departure", now);
-            if (!r.ok) return apiError(r.error, 400);
+            if (!r.ok) throw badRequest(r.error);
             nextDeparted = r.value;
         }
 
         // A closed visit stays closed (same rule as the staff route): editing
         // must never turn a historical record back into "in the building".
         if (visit.departedAt && !nextDeparted) {
-            return apiError("Departure time is required to close this visit.", 400);
+            throw badRequest("Departure time is required to close this visit.");
         }
         if (nextDeparted && !departureAfterArrival(nextArrived, nextDeparted)) {
-            return apiError("Departure time must be after arrival time", 400);
+            throw badRequest("Departure time must be after arrival time");
         }
         if (nextDeparted && !withinMaxDuration(nextArrived, nextDeparted)) {
-            return apiError("A visit cannot be longer than 24 hours.", 400);
+            throw badRequest("A visit cannot be longer than 24 hours.");
         }
 
         const significance = editSignificance(visit, { arrivedAt: nextArrived, departedAt: nextDeparted }, { byProxy });
@@ -121,7 +119,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
                 },
             });
         });
-        if (!updated) return apiError("Visit not found.", 404);
+        if (!updated) throw notFound("Visit not found.");
 
         // The checkout chunks a program-enrolled stay into per-event rows,
         // replacing the original: the audit row and the response must name a row
@@ -129,7 +127,7 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
         let surviving = updated;
         if (closingOpenVisit) {
             const chunks = await processVisitCheckout(visitId, nextDeparted!, undefined, "WEB");
-            if (chunks.length === 0) return apiError("Visit not found.", 404);
+            if (chunks.length === 0) throw notFound("Visit not found.");
             surviving = chunks[chunks.length - 1];
         }
 
@@ -152,22 +150,27 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
                 `${formatDateTime(visit.arrivedAt, { timeZone })} → ${formatDateTime(nextArrived, { timeZone })}`);
         }
 
-        return NextResponse.json({ visit: surviving, flagged: significance.flagged });
+        // The bag, not a hand-built body: stripBag keeps arrivedAt/departedAt for
+        // the two subjects the registry grants (their_own / led_households) and
+        // drops the 'internal' tombstone columns the raw row carries.
+        return { Visit: surviving };
     } catch (error: unknown) {
-        await logBackendError(error, "PATCH /api/attendance/manual/[id]");
-        return apiError("Internal Server Error", 500);
+        // handler() maps ApiResponseError to its declared status; anything else
+        // is a real fault, and keeps the DB error log withAuth used to give it.
+        if (!(error instanceof ApiResponseError)) await logBackendError(error, "PATCH /api/attendance/manual/[id]");
+        throw error;
     }
 });
 
-export const DELETE = withAuth({}, async (req, auth, ctx: { params: Promise<{ id: string }> }) => {
-    if (auth.type !== 'session') return apiError("Unauthorized", 401);
+export const DELETE = handler<{ id: string }>('DELETE /api/attendance/manual/[id]', async ({ auth, params }) => {
+    if (auth.type !== 'session') throw unauthorized();
     try {
         const userId = auth.user.id;
-        const visitId = Number((await ctx.params).id);
-        if (!Number.isInteger(visitId)) return apiError("Invalid visit id", 400);
+        const visitId = Number(params.id);
+        if (!Number.isInteger(visitId)) throw badRequest("Invalid visit id");
 
         const visit = await loadEditableVisit(visitId, userId);
-        if (!visit) return apiError("Visit not found.", 404);
+        if (!visit) throw notFound("Visit not found.");
         const byProxy = visit.personId !== userId;
 
         const significance = deleteSignificance(visit, { byProxy });
@@ -183,7 +186,7 @@ export const DELETE = withAuth({}, async (req, auth, ctx: { params: Promise<{ id
                 data: { deletedAt: new Date(), deletedById: userId },
             });
         });
-        if (tombstoned.count === 0) return apiError("Visit not found.", 404);
+        if (tombstoned.count === 0) throw notFound("Visit not found.");
 
         await prisma.auditLog.create({
             data: {
@@ -202,9 +205,12 @@ export const DELETE = withAuth({}, async (req, auth, ctx: { params: Promise<{ id
         flagBoard("delete", visitId, auth.user.name ?? `person #${userId}`, byProxy, significance.score,
             `Visit ${formatDateTime(visit.arrivedAt, { timeZone })} – ${visit.departedAt ? formatDateTime(visit.departedAt, { timeZone }) : "(open)"} tombstoned.`);
 
-        return NextResponse.json({ success: true, flagged: true });
+        // Empty bag — a tombstone ships no model data, so the registry declares
+        // `envelope: null` and the 200 body is `{}` (stripBag drops any
+        // non-model key, so the old { success, flagged } has no legal home).
+        return {};
     } catch (error: unknown) {
-        await logBackendError(error, "DELETE /api/attendance/manual/[id]");
-        return apiError("Internal Server Error", 500);
+        if (!(error instanceof ApiResponseError)) await logBackendError(error, "DELETE /api/attendance/manual/[id]");
+        throw error;
     }
 });


### PR DESCRIPTION
## The defect

`PATCH` and `DELETE /api/attendance/manual/[id]` are both registered in `src/security/registry.ts` with `their_own:personal` + `led_households:personal`, but the route was implemented with legacy `withAuth`. `handler()` — and therefore `stripBag()` — never ran, so the declared policy was **inert**: the registry described a boundary nothing enforced.

Re-verified against `origin/main` (`fbc59f743`) with `git show origin/main:<path>`, not a working-tree grep.

### The leak, observed directly

A household lead PATCHes a member's visit. Same mocked request, run against each version of `route.ts`:

```jsonc
// origin/main (legacy withAuth) — 200
{ "visit": { "id": 42, "personId": 8,
             "deletedAt": null, "deletedById": null, "forceCloseWarnedAt": null,
             "associatedEventId": null, "arrivedAt": "2026-07-20T14:05:00.000Z",
             "departedAt": "2026-07-20T16:00:00.000Z",
             "arrivedVia": "WEB", "departedVia": "WEB" },
  "flagged": false }

// this branch (handler) — 200
{ "visit": { "id": 42, "personId": 8,
             "arrivedAt": "2026-07-20T14:05:00.000Z",
             "departedAt": "2026-07-20T16:00:00.000Z",
             "arrivedVia": "WEB", "departedVia": "WEB",
             "associatedEventId": null } }
```

All three `internal` columns — `deletedAt`, `deletedById`, `forceCloseWarnedAt` — were on the wire, against a registry comment that says *"'internal' tombstone fields stay stripped"*.

## The fix

Both verbs converted to `handler()` returning a `ModelBag`, matching the already-converted routes (`api/profile`, `api/facility/corrections`, `api/membership-audit/person-agreement`, `api/trusted-adults/mine`): `apiError(...)` returns become `throw badRequest/notFound/unauthorized(...)`, and the response is the bag rather than a hand-built body.

**No boundary file is touched.** `src/security/**` is untouched — the registry entries already exist and already say the right thing; the route simply never asked. `security-boundary-isolation.yml` sees `BOUNDARY_TOUCHED=0` and short-circuits. The changed files are the route, its test, and `scripts/migrated-routes.txt`.

### Are the registry tokens right for this endpoint?

**PATCH — yes.** Checked against the bindings, not the prose. The response is one `Visit` row; the caller is either the row's owner (`their_own`: `Visit.personId === selfId`) or the lead of that member's household (`led_households`: `Visit.personId ∈ ledHouseholdMemberIds`) — both bound on `Visit` in `scopeBindings.ts`, so neither grant silently resolves to nothing. `arrivedAt`/`departedAt` are `personal`, so `their_own:personal` + `led_households:personal` is exactly what keeps the times visible to those two subjects and nobody else; `member`/`public` cover `id`/`personId`/`arrivedVia`/`departedVia`/`associatedEventId`; the three tombstone columns are `internal` and granted to no one here. `scopeValidators.test.ts` already asserts the seam for `PATCH`.

**DELETE — not wrong, but vacuous, and its comment is now stale.** The tombstone response carries no model data, so the tokens are inert by construction. Two follow-ups, both needing a `registry.ts` edit that must ship alone, so **deliberately not done here**:

1. The entry's comment says *"the response is `{ success, flagged }`, no model data"*. That shape is not expressible through `handler()` — `stripBag` drops any top-level bag key that is not a model name (the same constraint the `GET /api/facility/corrections` entry already documents for pagination). The body is now `{}`.
2. `led_households` in the `orderedView` makes `deriveCtxNeeds` set `ledHouseholdMembers: true`, so every delete pays a `prisma.person.findMany` roster query for a response that ships nothing.

## Response-shape changes

| verb | before | after |
|---|---|---|
| `PATCH` | `{ visit: <raw row incl. deletedAt, deletedById, forceCloseWarnedAt>, flagged }` | `{ visit: <stripped to the granted view> }` |
| `DELETE` | `{ success: true, flagged: true }` | `{}` |

`flagged` and `success` are dropped because a non-model scalar has no legal home in a bag. **Nothing consumes them**: both callers (`src/app/attendance/my-visits/page.tsx:56`, `src/app/attendance/household/page.tsx:56`) read only `res.ok` and `data.error`, then reload. The board flag is unaffected — it is an email plus `auditLog.newData.significance`, both still written.

Error bodies are unchanged (`handler()` maps `ApiResponseError` through the same `apiError` helper), and the `logBackendError` call the legacy wrapper gave these routes is preserved by re-throwing non-`ApiResponseError`s after logging.

## The regression check

Two tests in `src/app/api/attendance/manual/[id]/__tests__/route.test.ts`, both edges of the same grant:

1. **"strips the internal tombstone columns while keeping the times the lead may see"** — a lead PATCHes a member's visit; the times must survive (`led_households:personal` resolves) *and* all three `internal` columns must be gone.
2. **"strips the times when the roster does not contain the visit's person"** — same lead session, `ledHouseholdMemberIds` without the member; the times must strip. `visitSubject` (DB leadship) and `ledHouseholdMemberIds` (session `householdLead` + `householdId`) are different sources and can disagree on a stale session; when they do, the grant must not resolve.

Test 2 caught test 1 passing for the wrong reason: the household-lead block inherited the global `tx.visit.update` mock, whose row carries `personId = OWN_ID`, so the times were surviving via `their_own`, not `led_households`. Fixed by pointing that block's `update`/`processVisitCheckout` mocks at the MEMBER's row, so test 1 now genuinely depends on the grant it names. `baseVisit` also gained `forceCloseWarnedAt: null` so the fixture carries every column a real `visit.update` returns.

### Before — `origin/main`'s `route.ts` restored, both tests in place

```
✕ strips the internal tombstone columns while keeping the times the lead may see (4 ms)
✕ strips the times when the roster does not contain the visit's person (2 ms)

  Expected path: not "deletedAt"
  Received value: null

  Expected path: not "arrivedAt"
  Received value: "2026-07-20T14:05:00.000Z"

Tests: 2 failed, 19 skipped, 21 total
```

Test 1 gets *past* its `arrivedAt`/`departedAt` assertions before failing — the failure is precisely the leak, not an incidental shape difference.

### After — this branch

```
PASS src/app/api/attendance/manual/[id]/__tests__/route.test.ts
Tests: 21 passed, 21 total
```

## Verification

- `npx tsc --noEmit --pretty false` — only the 2 known-environmental `@aws-sdk/client-lambda` errors.
- `npm run test:ci` — **2658 passed**, 0 test failures; the only 2 suite failures are the known `s-read` load errors (`Cannot find module '@aws-sdk/client-lambda'`).
- `npm run test:integration` against a throwaway Docker Postgres — **136 suites / 1440 tests green**, including `visitTombstoneCheckin.integration.test.ts` (imports `DELETE`), `tests/security/policy.contract.integration.test.ts` and `registryAuthz.integration.test.ts`.
- `npm run check-route-coverage` — **0 errors**. Both verbs dropped off the `[unmigrated]` list; the only remaining `attendance/manual` mention is the sibling `POST /api/attendance/manual`, out of scope and correctly still in `legacy-authz-routes.txt`.
- `npx eslint` on both changed source files — clean.

## Out of scope, but found while working

`POST /api/facility/visits/insert` has the same defect class: registered in the registry, implemented with `withAuth`, returns `NextResponse.json({ visit })`. Its declared view grants `everyones:internal`, so the tombstone columns it ships are *declared* rather than leaked — the registry comment says as much — but `stripBag` still never runs, so the entry is inert and any future tightening of the `Visit` tiers would not reach it. Separate PR.

## Not verified

Not exercised against a running app — no browser check of the two correction pages. The claim that neither page reads `flagged`/`success` comes from reading both call sites, not from running them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
