### PR TITLE
fix(membership): close three lifecycle gaps — merge carryover, individual agreement, legacy restore

### DIFF
--- a/checkin-app/src/app/__tests__/lifecycleReconcile.integration.test.ts
+++ b/checkin-app/src/app/__tests__/lifecycleReconcile.integration.test.ts
@@ -134,6 +134,20 @@ describe('lifecycle reconciler — invariant-driven sweep over a real DB', () =>
         expect(after.paidAt).not.toBeNull();
     });
 
+    it('a settled PERSON_AGREEMENT is not a violation — the signature alone completes it', async () => {
+        // markContractSigned flips an individual agreement straight to ACTIVE with no
+        // bgClearedAt: it has no membership, no payment and no background-check gate.
+        // Judging it by the membership convergence reports every adult child who signs.
+        const proc = await prisma.orgMembershipProcess.create({
+            data: { kind: 'PERSON_AGREEMENT', status: 'ACTIVE', subjectPersonId: selfId, contractSignedAt: new Date() },
+        });
+        processIds.push(proc.id);
+
+        const { violations } = await scanLifecycleViolations();
+
+        expect(violations.filter((v) => v.key === `process ${proc.id}`)).toEqual([]);
+    });
+
     it('clean: a row that validates clean produces no violation', async () => {
         await prisma.programParticipant.create({
             data: { programId, personId: selfId, status: 'ACTIVE', inventoryHeldAt: null },

--- a/checkin-app/src/app/__tests__/membershipArchiveAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/membershipArchiveAPI.integration.test.ts
@@ -225,6 +225,25 @@ describe('Membership application archive API', () => {
         expect(audit?.newData).toMatchObject({ status: 'PENDING_PAYMENT', unarchived: true });
     });
 
+    it('round-trips a renewal archived from the legacy RENEWAL_PENDING_BG', async () => {
+        // archiveApplication gates on ACTIVE alone, so this status is archivable today —
+        // and migration 20260806160000 backfills it for rows archived before the column
+        // existed. A restore list narrower than the archive gate strands them in ARCHIVED.
+        const hh = await prisma.household.create({ data: { name: `LegacyRenewal ${TAG}` } });
+        const m = await prisma.orgMembership.create({ data: { householdId: hh.id, status: 'ACTIVE' } });
+        const p = await prisma.orgMembershipProcess.create({ data: { orgMembershipId: m.id, kind: 'RENEWAL', status: 'RENEWAL_PENDING_BG' } });
+        asBoard(boardId);
+
+        expect((await ARCHIVE(req({ processId: p.id }) as never)).status).toBe(200);
+        expect((await prisma.orgMembershipProcess.findUnique({ where: { id: p.id } }))?.archivedFromStatus).toBe('RENEWAL_PENDING_BG');
+
+        const res = await UNARCHIVE(unarchiveReq({ processId: p.id }) as never);
+        expect(res.status).toBe(200);
+
+        const after = await prisma.orgMembershipProcess.findUnique({ where: { id: p.id } });
+        expect({ status: after?.status, from: after?.archivedFromStatus }).toEqual({ status: 'RENEWAL_PENDING_BG', from: null });
+    });
+
     it('refuses to unarchive a non-archived process (409 wrong_phase)', async () => {
         const { processId } = await makeProcess('NotArchived', 'PENDING_PAYMENT');
         asBoard(boardId);

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -1173,6 +1173,23 @@ describe("Merge Participants API", () => {
             expect(await prisma.auditLog.count({ where: { tableName: "OrgMembershipProcess", affectedEntityId: process.id } })).toBe(0);
         });
 
+        it("activates a paid PENDING_BG_CLEARANCE household, without dating anyone's own check", async () => {
+            // The one state where the carried check is the SOLE block: dues are settled and
+            // the membership sits INACTIVE. A stamp that doesn't converge leaves it there.
+            const process = await makeApplication("PENDING_BG_CLEARANCE", { contractSignedAt: new Date(), bgConsentAt: new Date(), paidAt: new Date() });
+            const child = await prisma.person.create({ data: { name: "Adult Child", householdId, isHouseholdLead: false } });
+            extraPersonIds.push(child.id);
+
+            expect((await POST(mergeReq(pKeepId, pMergeId))).status).toBe(200);
+
+            const after = await reload(process.id);
+            expect({ status: after.status, cleared: after.bgClearedAt !== null }).toEqual({ status: "ACTIVE", cleared: true });
+            expect((await prisma.orgMembership.findUniqueOrThrow({ where: { id: membershipId } })).status).toBe("ACTIVE");
+            // The clearance carries zero attestations, so it names no subject and stamps
+            // no person. A household-wide stamp would date this child off a parent's check.
+            expect((await prisma.person.findUniqueOrThrow({ where: { id: child.id } })).lastBackgroundCheck).toBeNull();
+        });
+
         it("never touches a PERSON_BG re-pointed onto the survivor", async () => {
             // householdBgIsFresh asks about household LEADS. Answering it for an adult
             // child's own check would clear them because a parent's check is fresh.
@@ -1186,6 +1203,24 @@ describe("Merge Participants API", () => {
             const after = await reload(personBg.id);
             expect({ status: after.status, cleared: after.bgClearedAt, subject: after.subjectPersonId })
                 .toEqual({ status: "PENDING_BG_REVIEW", cleared: null, subject: pKeepId });
+        });
+
+        it("never touches a PERSON_AGREEMENT re-pointed onto the survivor", async () => {
+            // The other orgMembership-less kind, and the one that shares a status with an
+            // acting state. Every candidate query goes through orgMembership, which both
+            // PERSON kinds sit outside; widening that scope would sign an adult child's
+            // own agreement off a parent's background check.
+            const agreement = await prisma.orgMembershipProcess.create({
+                data: { kind: "PERSON_AGREEMENT", subjectPersonId: pMergeId, status: "PENDING_EXTERNAL_ACTION" },
+            });
+            createdProcessIds.push(agreement.id);
+            await makeApplication("PENDING_BG_CLEARANCE", { contractSignedAt: new Date(), bgConsentAt: new Date(), paidAt: new Date() });
+
+            expect((await POST(mergeReq(pKeepId, pMergeId))).status).toBe(200);
+
+            const after = await reload(agreement.id);
+            expect({ status: after.status, cleared: after.bgClearedAt, signed: after.contractSignedAt })
+                .toEqual({ status: "PENDING_EXTERNAL_ACTION", cleared: null, signed: null });
         });
 
         it("attributes the carryover to the merging board member, naming the record it came from", async () => {

--- a/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
+++ b/checkin-app/src/lib/lifecycle/__tests__/guardFromStateParity.test.ts
@@ -69,10 +69,11 @@ const GUARDS: GuardSite[] = [
     { file: 'app/api/finance-ops/membership-payment-plans/route.ts', machine: 'membership', from: 'PENDING_PAYMENT', edge: ['PENDING_PAYMENT', 'ACTIVE'], mode: 'spread' },
     { file: 'app/api/finance-ops/membership-payment-plans/refuse/route.ts', machine: 'membership', from: 'PENDING_PAYMENT', mode: 'spread' }, // deny: flag-only, no status edge
     // merge BG carryover — two flag-only stamps (advanceExternalIfComplete / activate own the
-    // edges those rows later take) and one real clearance on an already-declared edge.
+    // edges those rows later take) and two real clearances on already-declared edges.
     { file: 'lib/membership/mergeBgAdvance.ts', machine: 'membership', from: 'PENDING_EXTERNAL_ACTION', mode: 'spread' },
     { file: 'lib/membership/mergeBgAdvance.ts', machine: 'membership', from: 'PENDING_PAYMENT', mode: 'spread' },
     { file: 'lib/membership/mergeBgAdvance.ts', machine: 'membership', from: 'PENDING_BG_REVIEW', edge: ['PENDING_BG_REVIEW', 'PENDING_PAYMENT'], mode: 'spread' },
+    { file: 'lib/membership/mergeBgAdvance.ts', machine: 'membership', from: 'PENDING_BG_CLEARANCE', edge: ['PENDING_BG_CLEARANCE', 'ACTIVE'], mode: 'spread' },
 
     // ── left literal on purpose (documented) ──
     // personBgTriggers is an idempotency EXISTENCE set (∅→PENDING_BG_REVIEW is the edge;

--- a/checkin-app/src/lib/lifecycle/__tests__/stateSpaceSafety.test.ts
+++ b/checkin-app/src/lib/lifecycle/__tests__/stateSpaceSafety.test.ts
@@ -28,6 +28,7 @@ import {
     validate as validateMembership,
     TRANSITIONS as MEMBERSHIP_TRANSITIONS,
     ALL_STATUSES as MEMBERSHIP_ALL_STATUSES,
+    ALL_KINDS as MEMBERSHIP_ALL_KINDS,
     INITIAL_STATES as MEMBERSHIP_INITIAL_STATES,
     LEGACY_STATUSES as MEMBERSHIP_LEGACY_STATUSES,
     type ClassifyRow as MembershipRow,
@@ -85,27 +86,32 @@ describe('membership — exhaustive state space', () => {
     const legacy = new Set<string>(MEMBERSHIP_LEGACY_STATUSES);
     const realized = new Set<string>();
 
-    test('every (status × 4 flags) tuple is on-diagram-clean or off-diagram-flagged', () => {
+    // Kind is the second axis because the machine's ACTIVE edges are kind-specific:
+    // a PERSON_AGREEMENT settles on the signature and owes no clearance stamp.
+    test('every (status × kind × 4 flags) tuple is on-diagram-clean or off-diagram-flagged', () => {
         for (const status of MEMBERSHIP_ALL_STATUSES) {
-            for (const contractSignedAt of BOOLS) {
-                for (const bgConsentAt of BOOLS) {
-                    for (const bgClearedAt of BOOLS) {
-                        for (const paidAt of BOOLS) {
-                            const row: MembershipRow = {
-                                status,
-                                contractSignedAt,
-                                bgConsentAt,
-                                bgClearedAt,
-                                paidAt,
-                            };
-                            const name = classifyMembership(row);
-                            if (name !== null) {
-                                expect(validateMembership(row)).toBeNull();
-                                // reachable, or the dead-but-guarded legacy status
-                                expect(reachable.has(name) || legacy.has(name)).toBe(true);
-                                realized.add(name);
-                            } else {
-                                expect(validateMembership(row)).not.toBeNull();
+            for (const kind of MEMBERSHIP_ALL_KINDS) {
+                for (const contractSignedAt of BOOLS) {
+                    for (const bgConsentAt of BOOLS) {
+                        for (const bgClearedAt of BOOLS) {
+                            for (const paidAt of BOOLS) {
+                                const row: MembershipRow = {
+                                    status,
+                                    kind,
+                                    contractSignedAt,
+                                    bgConsentAt,
+                                    bgClearedAt,
+                                    paidAt,
+                                };
+                                const name = classifyMembership(row);
+                                if (name !== null) {
+                                    expect(validateMembership(row)).toBeNull();
+                                    // reachable, or the dead-but-guarded legacy status
+                                    expect(reachable.has(name) || legacy.has(name)).toBe(true);
+                                    realized.add(name);
+                                } else {
+                                    expect(validateMembership(row)).not.toBeNull();
+                                }
                             }
                         }
                     }

--- a/checkin-app/src/lib/lifecycleDrift.ts
+++ b/checkin-app/src/lib/lifecycleDrift.ts
@@ -66,10 +66,13 @@ export async function scanLifecycleViolations(): Promise<{
         }
     }
 
+    // Every kind is scanned; `kind` goes to `validate` because the machine's invariants
+    // are kind-specific, and deciding which rows to skip HERE would re-derive them.
     const processes = await prisma.orgMembershipProcess.findMany({
         select: {
             id: true,
             status: true,
+            kind: true,
             contractSignedAt: true,
             bgConsentAt: true,
             bgClearedAt: true,
@@ -79,6 +82,7 @@ export async function scanLifecycleViolations(): Promise<{
     for (const p of processes) {
         const bad = validateMembership({
             status: p.status,
+            kind: p.kind,
             contractSignedAt: p.contractSignedAt !== null,
             bgConsentAt: p.bgConsentAt !== null,
             bgClearedAt: p.bgClearedAt !== null,

--- a/checkin-app/src/lib/membership/__tests__/lifecycle.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/lifecycle.test.ts
@@ -144,9 +144,9 @@ describe('IN_FLIGHT lists', () => {
 
 // ── classify / validate ────────────────────────────────────────────────────────
 
-describe('classify', () => {
-    const flags = { contractSignedAt: false, bgConsentAt: false, bgClearedAt: false, paidAt: false };
+const flags = { kind: 'INITIAL', contractSignedAt: false, bgConsentAt: false, bgClearedAt: false, paidAt: false } as const;
 
+describe('classify', () => {
     test('names on-diagram rows by status', () => {
         expect(classify({ ...flags, status: 'PENDING_PAYMENT' })).toBe('PENDING_PAYMENT');
         expect(classify({ ...flags, status: 'ACTIVE', bgClearedAt: true })).toBe('ACTIVE');
@@ -157,10 +157,13 @@ describe('classify', () => {
         expect(classify({ ...flags, status: 'INTAKE', paidAt: true })).toBeNull(); // paid before external
         expect(classify({ ...flags, status: 'ACTIVE', bgClearedAt: false })).toBeNull(); // active must be cleared
     });
+
+    test('an ACTIVE PERSON_AGREEMENT is on-diagram without a clearance', () => {
+        expect(classify({ ...flags, kind: 'PERSON_AGREEMENT', status: 'ACTIVE' })).toBe('ACTIVE');
+    });
 });
 
 describe('validate', () => {
-    const flags = { contractSignedAt: false, bgConsentAt: false, bgClearedAt: false, paidAt: false };
     test('clean rows validate null', () => {
         expect(validate({ ...flags, status: 'ACTIVE', bgClearedAt: true })).toBeNull();
         expect(validate({ ...flags, status: 'INTAKE' })).toBeNull();
@@ -168,6 +171,15 @@ describe('validate', () => {
     test('flags the violated invariant', () => {
         expect(validate({ ...flags, status: 'INTAKE', paidAt: true })).toEqual({ invariant: 'intake-is-unpaid' });
         expect(validate({ ...flags, status: 'ACTIVE', bgClearedAt: false })).toEqual({ invariant: 'active-is-bg-cleared' });
+    });
+    test('active-is-bg-cleared is the MEMBERSHIP convergence, and holds for the other kinds', () => {
+        // The individual agreement completes on the signature alone (the machine's own
+        // PENDING_EXTERNAL_ACTION→ACTIVE edge, kind PERSON_AGREEMENT) — it has no
+        // payment and no check to converge, so no clearance stamp is owed.
+        expect(validate({ ...flags, kind: 'PERSON_AGREEMENT', status: 'ACTIVE' })).toBeNull();
+        // PERSON_BG does clear before it activates, so nothing is relaxed for it.
+        expect(validate({ ...flags, kind: 'PERSON_BG', status: 'ACTIVE' })).toEqual({ invariant: 'active-is-bg-cleared' });
+        expect(validate({ ...flags, kind: 'RENEWAL', status: 'ACTIVE' })).toEqual({ invariant: 'active-is-bg-cleared' });
     });
 });
 

--- a/checkin-app/src/lib/membership/__tests__/lifecycle.test.ts
+++ b/checkin-app/src/lib/membership/__tests__/lifecycle.test.ts
@@ -29,6 +29,9 @@ import {
     isLegalTransition,
     TRANSITIONS,
     ALL_STATUSES,
+    ALL_KINDS,
+    ARCHIVABLE_STATUSES,
+    RESTORABLE_STATUSES,
     INITIAL_STATES,
     type ProcessStatus,
 } from '@/lib/membership/lifecycle';
@@ -177,7 +180,8 @@ describe('validate', () => {
         // PENDING_EXTERNAL_ACTION→ACTIVE edge, kind PERSON_AGREEMENT) — it has no
         // payment and no check to converge, so no clearance stamp is owed.
         expect(validate({ ...flags, kind: 'PERSON_AGREEMENT', status: 'ACTIVE' })).toBeNull();
-        // PERSON_BG does clear before it activates, so nothing is relaxed for it.
+        // PERSON_BG does clear before it activates, so nothing is relaxed for it — it is
+        // NOT in SETTLES_ON_SIGNATURE, and this fails the moment someone puts it there.
         expect(validate({ ...flags, kind: 'PERSON_BG', status: 'ACTIVE' })).toEqual({ invariant: 'active-is-bg-cleared' });
         expect(validate({ ...flags, kind: 'RENEWAL', status: 'ACTIVE' })).toEqual({ invariant: 'active-is-bg-cleared' });
     });
@@ -216,9 +220,21 @@ describe('isLegalTransition covers §5', () => {
         for (const to of ['INTAKE', 'PENDING_EXTERNAL_ACTION', 'PENDING_BG_REVIEW', 'PENDING_PAYMENT', 'PENDING_BG_CLEARANCE', 'PENDING_RENEWAL', 'BLOCKED'] as ProcessStatus[]) {
             expect(isLegalTransition('ARCHIVED', to)).toBe(true);
         }
-        // Nothing is ever archived from these two, so neither is a restore target.
-        expect(isLegalTransition('ARCHIVED', 'RENEWAL_PENDING_BG')).toBe(false);
         expect(isLegalTransition('ARCHIVED', 'ARCHIVED')).toBe(false);
+    });
+
+    // GUARD (new): the restore set and the transition table are two lists, and the
+    // gap between them is deliberate. RENEWAL_PENDING_BG IS restorable at runtime —
+    // archive's gate is `status !== ACTIVE`, and migration 20260806160000 backfills
+    // that value — but declaring the edge would make an unreachable status reachable
+    // and delete the unreachable report machineSpecs.ts exists to surface. So the
+    // table stays silent and this records the divergence instead of denying it.
+    test('GUARD: the restore set is the archivable set plus the legacy status, and nothing else', () => {
+        expect([...RESTORABLE_STATUSES].sort()).toEqual(
+            [...ARCHIVABLE_STATUSES, ...LEGACY_STATUSES].sort(),
+        );
+        expect(RESTORABLE_STATUSES.has('RENEWAL_PENDING_BG')).toBe(true);
+        expect(isLegalTransition('ARCHIVED', 'RENEWAL_PENDING_BG')).toBe(false);
     });
 
     test('rejects undeclared edges', () => {
@@ -256,6 +272,6 @@ describe('enum parity with Prisma', () => {
         expect(() => assertEnumParity(ALL_STATUSES, OrgMembershipProcessStatus, 'OrgMembershipProcessStatus')).not.toThrow();
     });
     test('ProcessKind union matches OrgMembershipProcessKind keys', () => {
-        expect(() => assertEnumParity(['INITIAL', 'RENEWAL', 'PERSON_BG', 'PERSON_AGREEMENT'], OrgMembershipProcessKind, 'OrgMembershipProcessKind')).not.toThrow();
+        expect(() => assertEnumParity(ALL_KINDS, OrgMembershipProcessKind, 'OrgMembershipProcessKind')).not.toThrow();
     });
 });

--- a/checkin-app/src/lib/membership/archive.ts
+++ b/checkin-app/src/lib/membership/archive.ts
@@ -1,7 +1,7 @@
 import { Prisma, type OrgMembershipProcessStatus } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { ReviewError } from "@/lib/membership/review";
-import { ARCHIVABLE_STATUSES, fromWhere } from "@/lib/membership/lifecycle";
+import { ALL_STATUSES, fromWhere } from "@/lib/membership/lifecycle";
 import { personActor } from "@/lib/auditActor";
 
 /**
@@ -38,9 +38,16 @@ export async function archiveApplication(processId: number, actorId: number) {
     return { status: "ARCHIVED" as const };
 }
 
-/** Restore targets are exactly the statuses archive can come from — one list, so the
- *  two directions can never disagree (the ARCHIVED↔ edges in TRANSITIONS). */
-const RESTORABLE_STATUSES = new Set<OrgMembershipProcessStatus>(ARCHIVABLE_STATUSES);
+/**
+ * Restore targets are the statuses `archiveApplication` can actually capture, derived
+ * from its own gate above rather than from a second list. That gate is `status !== ACTIVE`
+ * (ARCHIVED returns early), so the set is every other status — one wider than
+ * ARCHIVABLE_STATUSES, which omits the legacy RENEWAL_PENDING_BG on the premise that
+ * nothing is ever archived from it. Migration 20260806160000 backfills that very value.
+ */
+const RESTORABLE_STATUSES = new Set<OrgMembershipProcessStatus>(
+    ALL_STATUSES.filter((s) => s !== "ACTIVE" && s !== "ARCHIVED"),
+);
 
 /**
  * Board recovery of a wrongly-archived application. The restore target is the

--- a/checkin-app/src/lib/membership/archive.ts
+++ b/checkin-app/src/lib/membership/archive.ts
@@ -1,7 +1,7 @@
-import { Prisma, type OrgMembershipProcessStatus } from "@/generated/prisma/client";
+import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { ReviewError } from "@/lib/membership/review";
-import { ALL_STATUSES, fromWhere } from "@/lib/membership/lifecycle";
+import { RESTORABLE_STATUSES, fromWhere } from "@/lib/membership/lifecycle";
 import { personActor } from "@/lib/auditActor";
 
 /**
@@ -37,17 +37,6 @@ export async function archiveApplication(processId: number, actorId: number) {
     ]);
     return { status: "ARCHIVED" as const };
 }
-
-/**
- * Restore targets are the statuses `archiveApplication` can actually capture, derived
- * from its own gate above rather than from a second list. That gate is `status !== ACTIVE`
- * (ARCHIVED returns early), so the set is every other status — one wider than
- * ARCHIVABLE_STATUSES, which omits the legacy RENEWAL_PENDING_BG on the premise that
- * nothing is ever archived from it. Migration 20260806160000 backfills that very value.
- */
-const RESTORABLE_STATUSES = new Set<OrgMembershipProcessStatus>(
-    ALL_STATUSES.filter((s) => s !== "ACTIVE" && s !== "ARCHIVED"),
-);
 
 /**
  * Board recovery of a wrongly-archived application. The restore target is the

--- a/checkin-app/src/lib/membership/lifecycle.ts
+++ b/checkin-app/src/lib/membership/lifecycle.ts
@@ -230,8 +230,16 @@ export function fromWhere(from: ProcessStatus): Where {
 
 // ── classify / validate ──────────────────────────────────────────────────────
 
-/** Row shape classify/validate read — all four flags as booleans, no Prisma. */
-export type ClassifyRow = { status: ProcessStatus } & ProcessFlags;
+/**
+ * Row shape classify/validate read — all four flags as booleans, no Prisma. `kind`
+ * is part of the row because the machine's own edges are kind-specific: a
+ * PERSON_AGREEMENT reaches ACTIVE on the signature alone, so "what is legal here"
+ * has no kind-free answer.
+ */
+export type ClassifyRow = { status: ProcessStatus; kind: ProcessKind } & ProcessFlags;
+
+/** Kinds whose ACTIVE is the two-track membership convergence, so a clearance is owed. */
+const CONVERGING_KINDS: readonly ProcessKind[] = ["INITIAL", "RENEWAL", "PERSON_BG"];
 
 /**
  * Name a row's lifecycle state, or null when it's off-diagram. Total over the
@@ -246,7 +254,8 @@ export function classify(row: ClassifyRow): ProcessStatus | null {
             return row.paidAt ? null : "INTAKE";
         case "ACTIVE":
             // Convergence stamps bgClearedAt before flipping ACTIVE (payment.ts / review.ts).
-            return row.bgClearedAt ? "ACTIVE" : null;
+            // A PERSON_AGREEMENT has no convergence to stamp — see CONVERGING_KINDS.
+            return row.bgClearedAt || !CONVERGING_KINDS.includes(row.kind) ? "ACTIVE" : null;
         case "PENDING_EXTERNAL_ACTION":
             return "PENDING_EXTERNAL_ACTION";
         case "PENDING_BG_REVIEW":
@@ -272,8 +281,10 @@ export function classify(row: ClassifyRow): ProcessStatus | null {
 export const INVARIANTS: readonly Invariant<ClassifyRow>[] = [
     // Payment is stamped no earlier than PENDING_PAYMENT; INTAKE is pre-external.
     { name: "intake-is-unpaid", holds: (r) => r.status !== "INTAKE" || !r.paidAt },
-    // ACTIVE is only reached through the two-track convergence, which stamps bgClearedAt.
-    { name: "active-is-bg-cleared", holds: (r) => r.status !== "ACTIVE" || r.bgClearedAt },
+    // ACTIVE is only reached through the two-track convergence, which stamps bgClearedAt —
+    // for the kinds that HAVE one. markContractSigned settles a PERSON_AGREEMENT outright
+    // (the kind-tagged PENDING_EXTERNAL_ACTION→ACTIVE edge below), owing no clearance.
+    { name: "active-is-bg-cleared", holds: (r) => r.status !== "ACTIVE" || !CONVERGING_KINDS.includes(r.kind) || r.bgClearedAt },
 ];
 
 export const validate = defineValidator(INVARIANTS);
@@ -285,10 +296,12 @@ export type OriginState = "∅";
 type TState = ProcessStatus | OriginState;
 
 /**
- * Every pre-terminal status the board can archive from — and, reversed, the only
- * statuses unarchive can restore to (§5 #13). ACTIVE is never archivable; the
- * legacy RENEWAL_PENDING_BG is unreachable, so nothing is ever archived from it
- * and it is not a restore target either.
+ * The archive edges this machine DECLARES (§5 #13). ACTIVE is never archivable.
+ * RENEWAL_PENDING_BG is out because it is unreachable, so the diagram would gain a
+ * dead pair of arrows and lose the unreachable report that surfaces it — but it is
+ * NOT the archive gate: `archiveApplication` refuses ACTIVE and nothing else, so a
+ * surviving legacy row IS archivable. archive.ts derives its restore set from that
+ * gate, not from this list.
  */
 export const ARCHIVABLE_STATUSES = [
     "INTAKE",
@@ -367,6 +380,9 @@ export function isLegalTransition(from: ProcessStatus, to: ProcessStatus, kind?:
 
 /** Entry states for reachability analysis (the ∅-edges' targets). */
 export const INITIAL_STATES: readonly ProcessStatus[] = ["INTAKE", "PENDING_RENEWAL", "PENDING_BG_REVIEW"];
+
+/** Every declared kind — the second axis of the exhaustive state-space test. */
+export const ALL_KINDS: readonly ProcessKind[] = ["INITIAL", "RENEWAL", "PERSON_BG", "PERSON_AGREEMENT"];
 
 /** Every declared status (for reachability's `unreachable` computation). */
 export const ALL_STATUSES: readonly ProcessStatus[] = [

--- a/checkin-app/src/lib/membership/lifecycle.ts
+++ b/checkin-app/src/lib/membership/lifecycle.ts
@@ -238,8 +238,9 @@ export function fromWhere(from: ProcessStatus): Where {
  */
 export type ClassifyRow = { status: ProcessStatus; kind: ProcessKind } & ProcessFlags;
 
-/** Kinds whose ACTIVE is the two-track membership convergence, so a clearance is owed. */
-const CONVERGING_KINDS: readonly ProcessKind[] = ["INITIAL", "RENEWAL", "PERSON_BG"];
+/** The one kind that reaches ACTIVE on a signature, owing no clearance stamp. An
+ *  exemption list, not an allowlist: a kind added later owes the stamp by default. */
+const SETTLES_ON_SIGNATURE: readonly ProcessKind[] = ["PERSON_AGREEMENT"];
 
 /**
  * Name a row's lifecycle state, or null when it's off-diagram. Total over the
@@ -254,8 +255,8 @@ export function classify(row: ClassifyRow): ProcessStatus | null {
             return row.paidAt ? null : "INTAKE";
         case "ACTIVE":
             // Convergence stamps bgClearedAt before flipping ACTIVE (payment.ts / review.ts).
-            // A PERSON_AGREEMENT has no convergence to stamp — see CONVERGING_KINDS.
-            return row.bgClearedAt || !CONVERGING_KINDS.includes(row.kind) ? "ACTIVE" : null;
+            // A PERSON_AGREEMENT has no convergence to stamp — see SETTLES_ON_SIGNATURE.
+            return row.bgClearedAt || SETTLES_ON_SIGNATURE.includes(row.kind) ? "ACTIVE" : null;
         case "PENDING_EXTERNAL_ACTION":
             return "PENDING_EXTERNAL_ACTION";
         case "PENDING_BG_REVIEW":
@@ -284,7 +285,7 @@ export const INVARIANTS: readonly Invariant<ClassifyRow>[] = [
     // ACTIVE is only reached through the two-track convergence, which stamps bgClearedAt —
     // for the kinds that HAVE one. markContractSigned settles a PERSON_AGREEMENT outright
     // (the kind-tagged PENDING_EXTERNAL_ACTION→ACTIVE edge below), owing no clearance.
-    { name: "active-is-bg-cleared", holds: (r) => r.status !== "ACTIVE" || !CONVERGING_KINDS.includes(r.kind) || r.bgClearedAt },
+    { name: "active-is-bg-cleared", holds: (r) => r.status !== "ACTIVE" || SETTLES_ON_SIGNATURE.includes(r.kind) || r.bgClearedAt },
 ];
 
 export const validate = defineValidator(INVARIANTS);
@@ -300,8 +301,8 @@ type TState = ProcessStatus | OriginState;
  * RENEWAL_PENDING_BG is out because it is unreachable, so the diagram would gain a
  * dead pair of arrows and lose the unreachable report that surfaces it — but it is
  * NOT the archive gate: `archiveApplication` refuses ACTIVE and nothing else, so a
- * surviving legacy row IS archivable. archive.ts derives its restore set from that
- * gate, not from this list.
+ * surviving legacy row IS archivable — that gate's set is RESTORABLE_STATUSES below,
+ * and the test pins the one status by which the two differ.
  */
 export const ARCHIVABLE_STATUSES = [
     "INTAKE",
@@ -397,3 +398,14 @@ export const ALL_STATUSES: readonly ProcessStatus[] = [
     "RENEWAL_PENDING_BG",
     "ARCHIVED",
 ];
+
+/**
+ * What `archiveApplication` can actually capture — its gate is `status !== ACTIVE`
+ * (ARCHIVED returns early) — and so the only targets `unarchiveApplication` restores
+ * to. Wider than ARCHIVABLE_STATUSES by the legacy RENEWAL_PENDING_BG, which
+ * TRANSITIONS omits on purpose; lifecycle.test.ts pins that gap so neither list moves
+ * unnoticed and the restore set is no longer a second, unlinked list.
+ */
+export const RESTORABLE_STATUSES: ReadonlySet<ProcessStatus> = new Set(
+    ALL_STATUSES.filter((s) => s !== "ACTIVE" && s !== "ARCHIVED"),
+);

--- a/checkin-app/src/lib/membership/mergeBgAdvance.ts
+++ b/checkin-app/src/lib/membership/mergeBgAdvance.ts
@@ -58,7 +58,7 @@ export async function advanceHouseholdBgAfterMerge(
 
         await stampPendingExternal(householdId, actorId, source);
         await stampParallelPayment(householdId, actorId, source);
-        await clearHeldReview(householdId, actorId, mergedPersonId);
+        for (const held of HELD_STATES) await clearHeldRow(householdId, actorId, mergedPersonId, held);
     } catch (error) {
         await logBackendError(error, "membership merge background-check advance", { householdId, mergedPersonId });
     }
@@ -138,14 +138,29 @@ async function stampParallelPayment(householdId: number, actorId: number, source
 }
 
 /**
- * Legacy household rows parked at PENDING_BG_REVIEW — no edge puts one there any
- * more, and nothing re-advances them. Stamping `bgClearedAt` alone would strand a
- * row: it drops out of the reviewer queue while nothing but `clearBackgroundCheck`
- * moves its status, leaving no exit but archival. So run the real clearance, which
- * stamps and converges in one write. Zero attestations, re-read under the lock.
+ * The states a stamp alone would strand, because nothing but `clearBackgroundCheck`
+ * moves them: legacy rows parked at PENDING_BG_REVIEW, and PENDING_BG_CLEARANCE — paid,
+ * membership INACTIVE, the carried check the only thing left. Each pairs its status with
+ * its own CAS clause so the guard↔TRANSITIONS parity test can see both from-states.
  */
-async function clearHeldReview(householdId: number, actorId: number, mergedPersonId: number): Promise<void> {
-    const from = fromWhere("PENDING_BG_REVIEW");
+const HELD_STATES = [
+    { status: "PENDING_BG_REVIEW", from: fromWhere("PENDING_BG_REVIEW") },
+    { status: "PENDING_BG_CLEARANCE", from: fromWhere("PENDING_BG_CLEARANCE") },
+] as const;
+
+/**
+ * Stamping `bgClearedAt` on a held row drops it out of the reviewer queue with no exit
+ * but archival. So run the real clearance, which stamps and converges in one write —
+ * to PENDING_PAYMENT if the dues are still owed, to ACTIVE if they are already paid.
+ * Zero attestations, re-read under the lock.
+ */
+async function clearHeldRow(
+    householdId: number,
+    actorId: number,
+    mergedPersonId: number,
+    held: (typeof HELD_STATES)[number],
+): Promise<void> {
+    const { status, from } = held;
     for (const process of await uncleared(householdId, from)) {
         const outcome = await prisma.$transaction(async (tx) => {
             // clearBackgroundCheck's contract; also serializes against a concurrent attest.
@@ -154,7 +169,7 @@ async function clearHeldReview(householdId: number, actorId: number, mergedPerso
                 where: { id: process.id },
                 select: { status: true, bgClearedAt: true, _count: { select: { attestations: true } } },
             });
-            if (!fresh || fresh.status !== "PENDING_BG_REVIEW" || fresh.bgClearedAt || fresh._count.attestations > 0) return null;
+            if (!fresh || fresh.status !== status || fresh.bgClearedAt || fresh._count.attestations > 0) return null;
             return clearBackgroundCheck(tx, process.id, actorId, undefined, {
                 via: "merge",
                 sourcePersonId: mergedPersonId,


### PR DESCRIPTION
Three independent defects in `lib/membership/**`, each re-verified against `origin/main` (`fbc59f74`) with `git show origin/main:<path>` before writing a line. All three were real. Built on #1595 and #1597 — neither is reverted.

---

## 1. Merge carryover skipped `PENDING_BG_CLEARANCE` (`mergeBgAdvance.ts`)

`advanceHouseholdBgAfterMerge` acted on `PENDING_EXTERNAL_ACTION`, `PENDING_PAYMENT` and `PENDING_BG_REVIEW`. A household that pays while its check is outstanding lands at `PENDING_BG_CLEARANCE` (`paidAt` set, `bgClearedAt` null, `orgMembership` INACTIVE). After a merge moved a still-valid `lastBackgroundCheck` onto the survivor, `householdBgFresh` returned true and all three stamp helpers ran — and the row matched none of their `fromWhere` clauses. The paid household stayed inactive with a valid check on file.

`MERGE_BG_CARRYOVER.md` (it lives at `docs/in-design/`, not `checkin-app/docs/designs/`) calls this out directly: its state matrix gives `PENDING_BG_CLEARANCE` **"stamp + `ACTIVE`" + flip `OrgMembership.status`, converging via the existing `clearBackgroundCheck` edge**, and its Reachability section says the parallel-track states are where essentially all the fix's value lives.

The fix follows the doc rather than inventing a path: `clearHeldReview` already did exactly this for `PENDING_BG_REVIEW`, so it is generalised over a two-entry `HELD_STATES` table. `clearBackgroundCheck` sees `paidAt` set and converges to `ACTIVE`, flips the membership, applies volunteer status and audits with #1597's provenance, in one write. `notifyClearanceOutcome` then fires `sendCongrats` + Trigger C post-transaction — the doc's recommendation. `sendCongrats` says "your membership is now active" and claims nothing about a review, so it does not reintroduce the #1597 problem; `notifyPaymentOpen` is unreachable from this state.

No new machine edge: `PENDING_BG_CLEARANCE → ACTIVE via clearBackgroundCheck` is already in `TRANSITIONS`, so `docs/generated/lifecycle/membership.md` needed no regeneration (`artifactsDrift` passes untouched).

### How the scoping hole was avoided

The prior spec's hole came from `householdBgIsFresh` filtering `isHouseholdLead: true` — a household-wide answer applied to a person-scoped row would clear an adult child's own check off a parent's date. Three things prevent it here, and none of them is new code:

- **The candidate query is unchanged.** Every acting state goes through `uncleared()`, whose `where` is `orgMembership: { householdId }`. `PERSON_BG` and `PERSON_AGREEMENT` both carry `orgMembershipId: null` (`personBgTriggers.ts:52`, `personAgreementTriggers.ts:128`), so they are excluded *structurally*, not by an added filter that could be dropped later. I widened the status set only, never the scope.
- **No person's date is written.** `clearBackgroundCheck` stamps `lastBackgroundCheck` for `subjectsWithTwoApprovals(attestations)`. The carryover runs only on rows with **zero** attestations (re-checked under `FOR UPDATE`), so that list is empty and no `person.updateMany` fires. The carried date is never overwritten with `now()`, and no household member is dated off a lead's check.
- **Both exclusions are now pinned by tests**, including a new `PERSON_AGREEMENT` case — the kind that shares `PENDING_EXTERNAL_ACTION` with an acting state and so is the one a scope widening would actually catch.

---

## 2. Settled `PERSON_AGREEMENT` violated `active-is-bg-cleared` (`lifecycle.ts`)

`markContractSigned` writes `{ contractSignedAt, status: 'ACTIVE', stageEnteredAt }` for `PERSON_AGREEMENT`, leaving `bgClearedAt` null. `scanLifecycleViolations` selects no kind and filters none, so the `lifecycle-reconcile` cron reported every adult child who signed to the sysadmin/board channel, permanently — noise on a channel whose value is that it is quiet.

**I scoped the invariant by kind rather than scoping the scanner, and rather than giving `PERSON_AGREEMENT` its own invariant set.** The reasoning, not the diff size:

- `docs/rules/membership.md` states two separate rules. Activation: *"payment and review run in parallel, and membership activates on whichever finishes last."* Individual agreement: *"An adult child of a household lead signs their own membership agreement"*, and *"It gates nothing."* `active-is-bg-cleared` is the **first** rule. It was written as if it were about rows; it is about memberships. Applying it to a row with no payment track and no check is a category error, not a missing exemption.
- **The machine already knew this.** `TRANSITIONS` carries a `kind`-tagged edge `PENDING_EXTERNAL_ACTION → ACTIVE, event: markContractSigned, kind: PERSON_AGREEMENT` (added in #1477). The transition table and the invariant list disagreed about the same machine. Putting `kind` on `ClassifyRow` makes them agree at the definition layer, which is where `lifecycle.ts`'s header says the one definition lives.
- **Scoping the scanner was the wrong layer.** `lifecycleDrift.ts` opens with *"This module NEVER re-derives an invariant."* A `kind: { in: [...] }` filter there is precisely a re-derivation — it encodes "which kinds owe a clearance" in the consumer, where the panel, the System Status route and the cron would each have to repeat it, and it would silently drop `intake-is-unpaid` coverage for those rows too.
- **A separate invariant set was an abstraction for one row shape.** The two kinds share `intake-is-unpaid`; only one clause differs. A second machine for one differing clause is more surface, not less.

`PERSON_BG` is *not* relaxed — `clearBackgroundCheck`'s `PERSON_BG` branch stamps `bgClearedAt` before flipping ACTIVE, so it genuinely owes the stamp. `SETTLES_ON_SIGNATURE` names the one kind that does not, and the test asserts `PERSON_BG` and `RENEWAL` still fail without it. **It is an exemption list, not an allowlist** (review, round 2): a fifth kind owes the stamp by default, and has to be exempted deliberately. Over the four declared kinds the two spellings are equivalent, which the exhaustive matrix below proves rather than asserts.

`classify` got the same clause: it and `validate` are the drift oracle for the same rows, and leaving `classify` returning `null` for a row `validate` calls clean would have been a new disagreement. The exhaustive `stateSpaceSafety` matrix now runs over status × **kind** × 4 flags and proves they agree on all 160 tuples.

---

## 3. `RENEWAL_PENDING_BG` archivable but not restorable (`archive.ts`)

`RESTORABLE_STATUSES` was `new Set(ARCHIVABLE_STATUSES)` on the rationale that "restore targets are exactly the statuses archive can come from — one list, so the two can never disagree." They disagreed: `archiveApplication` gates on `status === 'ACTIVE'` alone, so a renewal parked at the legacy `RENEWAL_PENDING_BG` is archivable today and writes `archivedFromStatus='RENEWAL_PENDING_BG'`; migration `20260806160000` backfills exactly that value for rows archived earlier. Those rows could never be unarchived, against `membership.md`'s *"An abandoned application is archived, never destroyed, and restores to the status it held before."*

The restore set is now derived from the **actual gate** — every status except `ACTIVE` and `ARCHIVED` — which is the eight rel/1.1 listed and the eight the migration backfills. That keeps the "one source" property the original comment wanted, but sources it from the rule that decides the question instead of from a list that answers a different one.

**I deliberately did not add `RENEWAL_PENDING_BG` to `ARCHIVABLE_STATUSES`.** That would have been the tempting one-word fix, and it is wrong twice: it injects `ARCHIVED → RENEWAL_PENDING_BG` into `TRANSITIONS`, which makes the status reachable and deletes the unreachable-legacy signal `machineSpecs.ts` says the report exists to surface (breaking two existing assertions and forcing an artifact regeneration for a pair of arrows nothing draws). The false premise in that list's comment — "nothing is ever archived from it" — is corrected in place, pointing at the gate.

**The divergence is now declared, not merely intended** (review, round 2). The gap that reasoning creates — a runtime restore edge the table does not carry — was left invisible to every test, and `lifecycle.test.ts:220` asserted the *opposite* of what ships while passing green. `RESTORABLE_STATUSES` moves into `lifecycle.ts` beside the other status lists and is exported, so the pure unit suite can see it; test #9 pins it to `[...ARCHIVABLE_STATUSES, ...LEGACY_STATUSES]` and records the undeclared edge instead of denying it. The two lists are linked again — that is what `ARCHIVABLE_STATUSES` was for — while `TRANSITIONS` stays silent, so the unreachable report is exactly as it was.

---

## Per-test table

Red = run against `origin/main`'s source with these tests in place; green = this branch. Full logs kept.

| # | Test | File | on `origin/main` | on branch | Kind |
|---|---|---|---|---|---|
| 1 | `activates a paid PENDING_BG_CLEARANCE household, without dating anyone's own check` | `merge/__tests__/route.integration.test.ts` | **FAIL** | PASS | regression (defect 1) |
| 2 | `never touches a PERSON_AGREEMENT re-pointed onto the survivor` | `merge/__tests__/route.integration.test.ts` | PASS | PASS | **guard** — pins the scope that must not widen |
| 3 | `migrated guards consume fromWhere(<from>)` (new `PENDING_BG_CLEARANCE` row) | `lifecycle/__tests__/guardFromStateParity.test.ts` | **FAIL** | PASS | regression (defect 1, guard shape) |
| 4 | `a settled PERSON_AGREEMENT is not a violation — the signature alone completes it` | `app/__tests__/lifecycleReconcile.integration.test.ts` | **FAIL** | PASS | regression (defect 2, end-to-end through the scanner) |
| 5 | `active-is-bg-cleared is the MEMBERSHIP convergence, and holds for the other kinds` | `membership/__tests__/lifecycle.test.ts` | **FAIL** | PASS | regression (defect 2, unit) |
| 6 | `an ACTIVE PERSON_AGREEMENT is on-diagram without a clearance` | `membership/__tests__/lifecycle.test.ts` | **FAIL** | PASS | regression (defect 2, `classify` half) |
| 7 | `every (status × kind × 4 flags) tuple is on-diagram-clean or off-diagram-flagged` | `lifecycle/__tests__/stateSpaceSafety.test.ts` | n/a | PASS | **guard** — widens an existing matrix onto the new axis; cannot run on `origin/main` (imports `ALL_KINDS`, added here) |
| 8 | `round-trips a renewal archived from the legacy RENEWAL_PENDING_BG` | `app/__tests__/membershipArchiveAPI.integration.test.ts` | **FAIL** | PASS | regression (defect 3) |
| 9 | `GUARD: the restore set is the archivable set plus the legacy status, and nothing else` | `membership/__tests__/lifecycle.test.ts` | n/a | PASS | **guard** — added in review round 2; cannot run on `origin/main` (imports `RESTORABLE_STATUSES`, exported here) |

Six regression tests, three guards, labelled honestly — #2, #7 and #9 do not fail on `origin/main` and are not claimed as regressions.

The three guards were mutation-tested rather than assumed, since a guard that cannot fail is decoration:

| Mutation | Expected to break | Result |
|---|---|---|
| Add `RENEWAL_PENDING_BG` to `ARCHIVABLE_STATUSES` (the "tempting one-word fix") | #9 + the existing unreachable-legacy assertion | both **FAIL** ✔ |
| Narrow `RESTORABLE_STATUSES` back to `new Set(ARCHIVABLE_STATUSES)` (defect 3, restored) | #9 | **FAIL** ✔ |
| Add `PERSON_BG` to `SETTLES_ON_SIGNATURE` (relaxing the kind that must not be relaxed) | #5 | **FAIL** ✔ |

## Verification

Re-run after review round 2:

- `npm test` (full unit suite) — **276 suites / 2694 tests, all pass** (+1: guard #9)
- `npm run test:integration` — the three suites this PR touches (`membershipArchiveAPI`, `lifecycleReconcile`, `merge/route`) — **85 tests, all pass**
- `npx tsc --noEmit` — **0 errors**
- `npm run lint` — clean, `--max-warnings 0`
- `git diff --name-only origin/main...HEAD -- checkin-app/src/security/` — **empty**; the boundary-isolation gate is untouched
- No migration, no schema change, no generated-artifact change — round 2 touches three files: `lifecycle.ts`, `archive.ts`, `lifecycle.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier

