### PR TITLE
fix(time): resolve the display timezone through context, not module state

### DIFF
--- a/checkin-app/src/app/__tests__/layout.test.tsx
+++ b/checkin-app/src/app/__tests__/layout.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import RootLayout from "../layout";
-import { APP_TIMEZONE, formatDateTime, setDisplayTimezone } from "@/lib/time";
+import { useOrgTime } from "@/components/TimezoneProvider";
 
 // The layout's own DB read: stubbed so this stays a composition test, but its value
 // still has to reach the formatters — that wiring is the point of the second case.
@@ -80,12 +80,11 @@ const INSTANT = "2026-09-01T02:30:00.000Z";
 
 // Formats during its own render — i.e. inside the provider the layout wraps it in.
 function Stamp() {
+  const { formatDateTime } = useOrgTime();
   return <div>{formatDateTime(INSTANT)}</div>;
 }
 
 describe("RootLayout", () => {
-  afterEach(() => setDisplayTimezone(APP_TIMEZONE));
-
   it("renders its children inside the provider chrome", async () => {
     render(
       await RootLayout({

--- a/checkin-app/src/app/attendance/current/page.tsx
+++ b/checkin-app/src/app/attendance/current/page.tsx
@@ -10,7 +10,8 @@ import {
   Alert, Anchor, Badge, Box, Button, Card, Center, Group, Loader, Modal, Paper,
   SimpleGrid, Stack, Text, TextInput, Title,
 } from "@mantine/core";
-import { formatTime, isYouth } from "@/lib/time";
+import { isYouth } from "@/lib/time";
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { PageContainer } from "@/components/ui/PageContainer";
 import { formatPhone } from "@/lib/phone";
 import { getKioskDisplayNames } from "@/lib/kiosk-names";
@@ -48,6 +49,7 @@ type LimitedResponse = { access: "limited"; counts: Counts; safety: SafetyFlags;
 type AttendanceResponse = FullResponse | LimitedResponse;
 
 function KioskDisplayInner() {
+  const { formatTime } = useOrgTime();
   const searchParams = useSearchParams();
   const [isKioskMode, setIsKioskMode] = useState(searchParams.get("mode") === "kiosk");
   const { data: session } = useSession();

--- a/checkin-app/src/app/attendance/household/page.tsx
+++ b/checkin-app/src/app/attendance/household/page.tsx
@@ -7,7 +7,8 @@ import { notifications } from "@mantine/notifications";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
-import { formatDateOnly, formatVisitRange, formatDateTime, toDatetimeLocal } from "@/lib/time";
+import { formatDateOnly, toDatetimeLocal } from "@/lib/time";
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { AttendanceTabs } from "../AttendanceTabs";
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -17,6 +18,7 @@ type Visit = { id: number; person?: { name: string }; event?: { name: string }; 
 // trust-first terms as their own (design 1256_ATTENDANCE_CORRECTION_SURFACE.md
 // §3) — the server flags significant changes to the board.
 export default function HouseholdCheckins() {
+  const { formatVisitRange, formatDateTime } = useOrgTime();
   const { ready, loading: authLoading, user } = useRequireRole([]);
   const [visits, setVisits] = useState<Visit[]>([]);
   const [filterDate, setFilterDate] = useState("");

--- a/checkin-app/src/app/attendance/my-visits/page.tsx
+++ b/checkin-app/src/app/attendance/my-visits/page.tsx
@@ -8,7 +8,8 @@ import { PageContainer } from "@/components/ui/PageContainer";
 import { PageLoader } from "@/components/ui/PageLoader";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
-import { formatVisitRange, toDatetimeLocal } from "@/lib/time";
+import { toDatetimeLocal } from "@/lib/time";
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { AttendanceTabs } from "../AttendanceTabs";
 
 type Visit = {
@@ -22,6 +23,7 @@ type Visit = {
 // deletable, no approval step — significant changes are flagged to the board
 // server-side (trust-first, design doc 1256_ATTENDANCE_CORRECTION_SURFACE.md).
 export default function MyVisits() {
+  const { formatVisitRange } = useOrgTime();
   const { ready, loading: authLoading } = useRequireRole([]);
   const [visits, setVisits] = useState<Visit[] | null>(null);
   const [error, setError] = useState("");

--- a/checkin-app/src/app/facility-ops/badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/badges/page.tsx
@@ -6,7 +6,7 @@ import { notifications } from '@mantine/notifications';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
 import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
-import { formatDateTime } from '@/lib/time';
+import { useOrgTime } from '@/components/TimezoneProvider';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 type BadgeEvent = {
@@ -16,16 +16,18 @@ type BadgeEvent = {
   location?: string;
 };
 
-const COLUMNS: DataTableColumn<BadgeEvent>[] = [
-  { header: 'ID', render: (b) => b.id, sortBy: (b) => b.id },
-  { header: 'Time', render: (b) => formatDateTime(b.timestamp), sortBy: (b) => b.timestamp },
-  { header: 'Participant', render: (b) => b.person?.name || 'Unknown', sortBy: (b) => b.person?.name },
-  { header: 'Email', render: (b) => b.person?.email, sortBy: (b) => b.person?.email },
-  { header: 'Location', render: (b) => b.location || 'Front Door', sortBy: (b) => b.location },
-];
-
 export default function AdminBadgesPage() {
   const { ready, loading: authLoading } = useRequireRole(['isSysadmin']);
+  const { formatDateTime } = useOrgTime();
+
+  // Built here, not at module scope: the time column needs the org zone from context.
+  const COLUMNS: DataTableColumn<BadgeEvent>[] = [
+    { header: 'ID', render: (b) => b.id, sortBy: (b) => b.id },
+    { header: 'Time', render: (b) => formatDateTime(b.timestamp), sortBy: (b) => b.timestamp },
+    { header: 'Participant', render: (b) => b.person?.name || 'Unknown', sortBy: (b) => b.person?.name },
+    { header: 'Email', render: (b) => b.person?.email, sortBy: (b) => b.person?.email },
+    { header: 'Location', render: (b) => b.location || 'Front Door', sortBy: (b) => b.location },
+  ];
 
   const [loading, setLoading] = useState(true);
   const [badges, setBadges] = useState<BadgeEvent[]>([]);

--- a/checkin-app/src/app/facility-ops/corrections/page.tsx
+++ b/checkin-app/src/app/facility-ops/corrections/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Alert, Badge, Group, SegmentedControl, Stack, Switch, Table, Text } from "@mantine/core";
 import { useRequireRole } from "@/hooks/useRequireRole";
 import { PageLoader } from "@/components/ui/PageLoader";
-import { formatDateTime } from "@/lib/time";
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { MAX_ROWS } from "@/lib/corrections";
 import { SYSTEM_ACTOR } from "@/lib/auditActor";
 import type { PeriodType } from "@/lib/timePeriods";
@@ -87,6 +87,7 @@ function nameFor(id: number | null, people: Map<number, PersonRef>): string {
 // touched that field — render "—", never infer a value: arrivedVia and
 // departedVia are not stamped onto a self-correction's newData.
 function VisitTimes({ v }: { v: VisitPick }) {
+  const { formatDateTime } = useOrgTime();
   if (!v || (!("arrivedAt" in v) && !("departedAt" in v))) {
     return <Text c="dimmed" size="sm">—</Text>;
   }
@@ -120,6 +121,7 @@ function ActorBadge({ cls }: { cls: "self" | "proxy" | "system" | "unknown" }) {
 }
 
 export default function CorrectionsPage() {
+  const { formatDateTime } = useOrgTime();
   const { ready, loading: authLoading } = useRequireRole(["isSysadmin", "isBoardMember"]);
 
   const [period, setPeriod] = useState<PeriodType>("month");

--- a/checkin-app/src/app/facility-ops/visits/page.tsx
+++ b/checkin-app/src/app/facility-ops/visits/page.tsx
@@ -7,7 +7,8 @@ import { IconChevronDown, IconChevronUp, IconDeviceLaptop, IconLock, IconRobot, 
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { AlertBanner, type AlertTone } from '@/components/admin/AlertBanner';
 import { notifications } from '@mantine/notifications';
-import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
+import { toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { MAX_VISIT_MS } from '@/lib/visitTimes';
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -66,6 +67,7 @@ const sortValue = (v: Visit, key: SortKey): string | number => {
 };
 
 export default function AdminVisitsPage() {
+  const { formatDateTime } = useOrgTime();
   const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
 
   const [loading, setLoading] = useState(true);

--- a/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
@@ -7,7 +7,7 @@ import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { formatDateTime } from '@/lib/time';
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -25,6 +25,7 @@ type MembershipPaymentPlanRequest = {
 };
 
 export default function MembershipPaymentPlansPage() {
+  const { formatDateTime } = useOrgTime();
   const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
 
   const [requests, setRequests] = useState<MembershipPaymentPlanRequest[]>([]);

--- a/checkin-app/src/app/finance-ops/payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/payment-plan/page.tsx
@@ -7,7 +7,7 @@ import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { formatDateTime } from '@/lib/time';
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { sharesHousehold } from '@/lib/conflictOfInterest';
 import { formatCents } from '@inventory/money';
@@ -37,6 +37,7 @@ type PaymentPlanRequest = {
 };
 
 export default function PendingParticipantsPage() {
+  const { formatDateTime } = useOrgTime();
   const { user: me, ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
   // Conflict of interest: no actor may approve their OWN household member's plan
   // (mirrors the server guard). UX only — server enforces.

--- a/checkin-app/src/app/finance-ops/payments/page.tsx
+++ b/checkin-app/src/app/finance-ops/payments/page.tsx
@@ -7,7 +7,8 @@ import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { formatDateTime, relTime } from '@/lib/time';
+import { relTime } from '@/lib/time';
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { formatCents } from '@inventory/money';
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -72,6 +73,7 @@ function describeSync(run: SyncRun): string {
 }
 
 export default function PaymentProblemsPage() {
+  const { formatDateTime } = useOrgTime();
   const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
 
   const [rows, setRows] = useState<PaymentException[]>([]);

--- a/checkin-app/src/app/finance-ops/shopify-holds/page.tsx
+++ b/checkin-app/src/app/finance-ops/shopify-holds/page.tsx
@@ -7,7 +7,7 @@ import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
 import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
 import { useRequireRole } from '@/hooks/useRequireRole';
-import { formatDateTime } from '@/lib/time';
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
 import { sharesHousehold } from '@/lib/conflictOfInterest';
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -29,6 +29,7 @@ type HoldFailedRow = {
 type Target = { programId: number; participantId: number } | null;
 
 export default function ShopifyHoldsPage() {
+  const { formatDateTime } = useOrgTime();
   const { user: me, ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
   // Conflict of interest mirrors the scholarship queue: no actor may approve/deny
   // their OWN household's request (server enforces; this is UX). It does NOT gate

--- a/checkin-app/src/app/my-activities/events/page.tsx
+++ b/checkin-app/src/app/my-activities/events/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Alert, Badge, Button, Card, Group, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { notifications } from "@mantine/notifications";
-import { formatDateTime, formatTime } from '@/lib/time';
+import { useOrgTime } from '@/components/TimezoneProvider';
 import type { RSVPStatus } from '@/types/rsvp';
 
 import { PageLoader } from "@/components/ui/PageLoader";
@@ -45,6 +45,7 @@ const RSVP_OPTIONS: { status: RsvpStatus; label: string; color: string }[] = [
 ];
 
 export default function ParticipantEventsDashboard() {
+  const { formatDateTime, formatTime } = useOrgTime();
   const { data: session, status } = useSession();
   const router = useRouter();
   const [events, setEvents] = useState<EventData[]>([]);

--- a/checkin-app/src/app/my-programs/conflicts/page.tsx
+++ b/checkin-app/src/app/my-programs/conflicts/page.tsx
@@ -6,7 +6,7 @@ import { Badge, Button, Card, Group, Stack, Table, Text } from "@mantine/core";
 import { modals } from "@mantine/modals";
 import { notifications } from "@mantine/notifications";
 import { IconTrash } from "@tabler/icons-react";
-import { formatDate, formatVisitRange } from "@/lib/time";
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { useConflicts } from "@/hooks/useConflicts";
 import { notifyNavRefresh } from "@/lib/nav-refresh";
 import type { AttendanceConflict, ConflictVisit } from "@/lib/attendanceConflicts";
@@ -116,6 +116,7 @@ function VisitRow({
   deleting: number | null;
   onDelete: (visitId: number) => void;
 }) {
+  const { formatDate, formatVisitRange } = useOrgTime();
   const via = [visit.arrivedVia, visit.departedVia].filter(Boolean).join(" / ") || "—";
   return (
     <Table.Tr>

--- a/checkin-app/src/app/program-ops/programs/[id]/ProgramEventsTab.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/ProgramEventsTab.tsx
@@ -3,11 +3,12 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Anchor, Button, Group, Table, Text, Title } from '@mantine/core';
-import { formatDateTime } from '@/lib/time';
+import { useOrgTime } from '@/components/TimezoneProvider';
 
 type ProgramEvent = { id: number; name: string; startAt: string; endAt: string; attendanceConfirmedAt: string | null };
 
 export function ProgramEventsTab({ programId, events }: { programId: number; events: ProgramEvent[] }) {
+  const { formatDateTime } = useOrgTime();
   const router = useRouter();
 
   return (

--- a/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/ProgramRosterTab.tsx
@@ -5,7 +5,8 @@ import { Alert, Badge, Box, Button, Card, Checkbox, Group, Modal, SimpleGrid, St
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { EntityPicker } from '@/components/admin/EntityPicker';
-import { calculateAge, formatDateTime } from '@/lib/time';
+import { calculateAge } from '@/lib/time';
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { formatPhone } from '@/lib/phone';
 import type { ProgramDetail, ParticipantOption } from './page';
 
@@ -25,6 +26,7 @@ type ProgramRosterTabProps = {
 };
 
 export function ProgramRosterTab({ programId, program, isSysAdminOrBoard, fetchProgram }: ProgramRosterTabProps) {
+  const { formatDateTime } = useOrgTime();
   const [saving, setSaving] = useState(false);
   const [enrollError, setEnrollError] = useState("");
   const [newVolId, setNewVolId] = useState("");

--- a/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/[id]/page.tsx
@@ -7,7 +7,8 @@ import { Alert, Badge, Button, Card, Checkbox, Container, Group, Modal, Select, 
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
 import { AlertBanner } from '@/components/admin/AlertBanner';
-import { formatDateTime, toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
+import { toDatetimeLocal, fromDatetimeLocal } from '@/lib/time';
+import { useOrgTime } from '@/components/TimezoneProvider';
 import { MAX_VISIT_MS } from '@/lib/visitTimes';
 import type { RSVPStatus } from '@/types/rsvp';
 
@@ -54,6 +55,7 @@ const RSVP_BADGE: Record<RSVPStatus, { label: string; color: string }> = {
 };
 
 export default function EventAdminPage({ params }: { params: Promise<{ id: string }> }) {
+  const { formatDateTime } = useOrgTime();
   const { id } = use(params);
   const { user: sessionUser, loading: authLoading, ready } = useRequireRole([]);
   const router = useRouter();

--- a/checkin-app/src/components/TimezoneProvider.tsx
+++ b/checkin-app/src/components/TimezoneProvider.tsx
@@ -29,6 +29,8 @@ export function useDisplayTimezone(): string {
     return useContext(TimezoneContext);
 }
 
+type ZoneFreeOptions = Omit<Intl.DateTimeFormatOptions, 'timeZone'>;
+
 /**
  * The instant formatters bound to this tree's configured zone — the client-side seam
  * for `lib/time`, whose raw formatters take the zone explicitly. Safe to call from
@@ -37,8 +39,6 @@ export function useDisplayTimezone(): string {
  * `timeZone` is omitted from the options: the tree's zone always wins, so accepting
  * one and discarding it would be the same silent-wrong-zone footgun this seam closes.
  */
-type ZoneFreeOptions = Omit<Intl.DateTimeFormatOptions, 'timeZone'>;
-
 export function useOrgTime() {
     const timeZone = useDisplayTimezone();
     return useMemo(

--- a/checkin-app/src/components/TimezoneProvider.tsx
+++ b/checkin-app/src/components/TimezoneProvider.tsx
@@ -1,19 +1,52 @@
 "use client";
 
-import { setDisplayTimezone } from '@/lib/time';
+import { createContext, useContext, useMemo } from 'react';
+import {
+    APP_TIMEZONE,
+    formatDate,
+    formatDateTime,
+    formatTime,
+    formatVisitRange,
+    type DateInput,
+} from '@/lib/time';
 
 /**
- * Installs the organisation's configured display timezone (AppSettings.timezone) for the
- * instant formatters in lib/time, which client components call as plain functions from
- * render bodies, memos and callbacks alike.
+ * Carries the organisation's configured display timezone (AppSettings.timezone) into
+ * client components. The root layout (a server component) resolves it per request and
+ * feeds it in here; leaf components read it via `useOrgTime()`.
  *
- * A provider rather than a prop: the formatters are called from leaf components all over
- * the tree, most of them client pages with no server parent to thread a prop from. The
- * value is installed during render, not in an effect, so children — including their
- * server-rendered first pass — format in the configured zone from the start rather than
- * flashing the fallback.
+ * Context rather than module state: on the server one module instance is shared by every
+ * concurrent request, so an installed value belongs to whichever request wrote it last.
  */
+const TimezoneContext = createContext<string>(APP_TIMEZONE);
+
 export function TimezoneProvider({ value, children }: { value: string; children: React.ReactNode }) {
-    setDisplayTimezone(value);
-    return <>{children}</>;
+    return <TimezoneContext.Provider value={value || APP_TIMEZONE}>{children}</TimezoneContext.Provider>;
+}
+
+/** The organisation's display timezone for this render tree. */
+export function useDisplayTimezone(): string {
+    return useContext(TimezoneContext);
+}
+
+/**
+ * The instant formatters bound to this tree's configured zone — the client-side seam
+ * for `lib/time`, whose raw formatters take the zone explicitly. Safe to call from
+ * render bodies, memos and callbacks, since it returns plain functions.
+ */
+export function useOrgTime() {
+    const timeZone = useDisplayTimezone();
+    return useMemo(
+        () => ({
+            formatDate: (date: DateInput, options?: Intl.DateTimeFormatOptions) =>
+                formatDate(date, { ...options, timeZone }),
+            formatTime: (date: DateInput, options?: Intl.DateTimeFormatOptions) =>
+                formatTime(date, { ...options, timeZone }),
+            formatDateTime: (date: DateInput, options?: Intl.DateTimeFormatOptions) =>
+                formatDateTime(date, { ...options, timeZone }),
+            formatVisitRange: (arrived: DateInput, departed?: DateInput) =>
+                formatVisitRange(arrived, departed, timeZone),
+        }),
+        [timeZone],
+    );
 }

--- a/checkin-app/src/components/TimezoneProvider.tsx
+++ b/checkin-app/src/components/TimezoneProvider.tsx
@@ -33,16 +33,21 @@ export function useDisplayTimezone(): string {
  * The instant formatters bound to this tree's configured zone — the client-side seam
  * for `lib/time`, whose raw formatters take the zone explicitly. Safe to call from
  * render bodies, memos and callbacks, since it returns plain functions.
+ *
+ * `timeZone` is omitted from the options: the tree's zone always wins, so accepting
+ * one and discarding it would be the same silent-wrong-zone footgun this seam closes.
  */
+type ZoneFreeOptions = Omit<Intl.DateTimeFormatOptions, 'timeZone'>;
+
 export function useOrgTime() {
     const timeZone = useDisplayTimezone();
     return useMemo(
         () => ({
-            formatDate: (date: DateInput, options?: Intl.DateTimeFormatOptions) =>
+            formatDate: (date: DateInput, options?: ZoneFreeOptions) =>
                 formatDate(date, { ...options, timeZone }),
-            formatTime: (date: DateInput, options?: Intl.DateTimeFormatOptions) =>
+            formatTime: (date: DateInput, options?: ZoneFreeOptions) =>
                 formatTime(date, { ...options, timeZone }),
-            formatDateTime: (date: DateInput, options?: Intl.DateTimeFormatOptions) =>
+            formatDateTime: (date: DateInput, options?: ZoneFreeOptions) =>
                 formatDateTime(date, { ...options, timeZone }),
             formatVisitRange: (arrived: DateInput, departed?: DateInput) =>
                 formatVisitRange(arrived, departed, timeZone),

--- a/checkin-app/src/components/__tests__/TimezoneProvider.test.tsx
+++ b/checkin-app/src/components/__tests__/TimezoneProvider.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { TimezoneProvider } from '@/components/TimezoneProvider';
-import { APP_TIMEZONE, formatDateTime, setDisplayTimezone } from '@/lib/time';
+import { TimezoneProvider, useOrgTime } from '@/components/TimezoneProvider';
 import { pinTimezone } from '@/test-helpers/tz';
 
 // 9:30 PM Aug 31 in Chicago, 11:30 AM Sep 1 in Tokyo — a different hour AND a
@@ -8,6 +7,7 @@ import { pinTimezone } from '@/test-helpers/tz';
 const INSTANT = '2026-09-01T02:30:00.000Z';
 
 function Stamp() {
+    const { formatDateTime } = useOrgTime();
     return <span data-testid="stamp">{formatDateTime(INSTANT)}</span>;
 }
 
@@ -15,7 +15,6 @@ describe('TimezoneProvider', () => {
     // The process zone is deliberately not the org zone: these assertions must
     // follow the configured setting, not whatever the machine is running in.
     pinTimezone('America/Chicago');
-    afterEach(() => setDisplayTimezone(APP_TIMEZONE));
 
     it('renders an instant in the configured org timezone, not the compiled-in default', () => {
         render(

--- a/checkin-app/src/components/__tests__/TimezoneProvider.test.tsx
+++ b/checkin-app/src/components/__tests__/TimezoneProvider.test.tsx
@@ -28,6 +28,17 @@ describe('TimezoneProvider', () => {
         expect(text).not.toContain('8/31/2026');
     });
 
+    // Type-level guard: the tree's zone always wins, so the options must not
+    // advertise a `timeZone` the formatter would accept and then discard.
+    it('rejects a caller-supplied timeZone at compile time', () => {
+        function Rejected() {
+            const { formatDate } = useOrgTime();
+            // @ts-expect-error timeZone is omitted from the accepted options
+            return <>{formatDate(INSTANT, { timeZone: 'Asia/Tokyo' })}</>;
+        }
+        expect(Rejected).toBeDefined();
+    });
+
     it('falls back to APP_TIMEZONE when the configured zone is missing', () => {
         render(
             <TimezoneProvider value={''}>

--- a/checkin-app/src/components/__tests__/timezoneIsolation.test.tsx
+++ b/checkin-app/src/components/__tests__/timezoneIsolation.test.tsx
@@ -9,15 +9,13 @@ import { pinTimezone } from '@/test-helpers/tz';
 const INSTANT = '2026-09-01T02:30:00.000Z';
 
 // Request A's leaf suspends on a slow read and formats only once it resolves, so its
-// render lands after another request has already rendered.
+// render lands after another request has already rendered. Rebuilt per test: `open`
+// latches and never resets, so a shared gate would leave a second test's LateStamp
+// never suspending — the interleave would not happen and the test would pass green
+// while asserting nothing.
 let release!: () => void;
-const gate = new Promise<void>((r) => {
-    release = r;
-});
+let gate!: Promise<void>;
 let open = false;
-void gate.then(() => {
-    open = true;
-});
 
 function LateStamp() {
     const { formatDateTime } = useOrgTime();
@@ -34,6 +32,16 @@ function Stamp() {
 // request, so a zone held in module state belongs to whichever request wrote it last.
 describe('concurrent renders do not share a display timezone', () => {
     pinTimezone('America/Chicago');
+
+    beforeEach(() => {
+        open = false;
+        gate = new Promise<void>((r) => {
+            release = r;
+        });
+        void gate.then(() => {
+            open = true;
+        });
+    });
 
     it('keeps request A in its own zone while request B renders in another', async () => {
         // Request A: the org's configured zone, New York. Its leaf suspends.

--- a/checkin-app/src/components/__tests__/timezoneIsolation.test.tsx
+++ b/checkin-app/src/components/__tests__/timezoneIsolation.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, act } from '@testing-library/react';
+import { Suspense } from 'react';
+import { TimezoneProvider, useOrgTime } from '@/components/TimezoneProvider';
+import { APP_TIMEZONE } from '@/lib/time';
+import { pinTimezone } from '@/test-helpers/tz';
+
+// 10:30 PM Aug 31 in New York, 9:30 PM Aug 31 in Chicago — one hour apart, which is
+// the reported symptom: a visit time rendered an hour off.
+const INSTANT = '2026-09-01T02:30:00.000Z';
+
+// Request A's leaf suspends on a slow read and formats only once it resolves, so its
+// render lands after another request has already rendered.
+let release!: () => void;
+const gate = new Promise<void>((r) => {
+    release = r;
+});
+let open = false;
+void gate.then(() => {
+    open = true;
+});
+
+function LateStamp() {
+    const { formatDateTime } = useOrgTime();
+    if (!open) throw gate;
+    return <span data-testid="late">{formatDateTime(INSTANT)}</span>;
+}
+
+function Stamp() {
+    const { formatDateTime } = useOrgTime();
+    return <span data-testid="b">{formatDateTime(INSTANT)}</span>;
+}
+
+// On the server a single lib/time module instance is shared by every concurrent
+// request, so a zone held in module state belongs to whichever request wrote it last.
+describe('concurrent renders do not share a display timezone', () => {
+    pinTimezone('America/Chicago');
+
+    it('keeps request A in its own zone while request B renders in another', async () => {
+        // Request A: the org's configured zone, New York. Its leaf suspends.
+        render(
+            <TimezoneProvider value="America/New_York">
+                <Suspense fallback={<span data-testid="pending" />}>
+                    <LateStamp />
+                </Suspense>
+            </TimezoneProvider>,
+        );
+
+        // Request B renders meanwhile; its settings read threw and fell back.
+        render(
+            <TimezoneProvider value={APP_TIMEZONE}>
+                <Stamp />
+            </TimezoneProvider>,
+        );
+
+        // Request A's leaf finally renders.
+        await act(async () => {
+            release();
+            await gate;
+        });
+
+        expect(screen.getByTestId('b').textContent).toContain('9:30');
+        expect(screen.getByTestId('late').textContent).toContain('10:30');
+    });
+});

--- a/checkin-app/src/lib/__tests__/time.test.ts
+++ b/checkin-app/src/lib/__tests__/time.test.ts
@@ -1,4 +1,7 @@
-import { formatDate, formatTime, formatDateTime, formatVisitRange, APP_TIMEZONE, setDisplayTimezone, getDisplayTimezone, toDatetimeLocal, fromDatetimeLocal, formatDateOnly, parseDateOnly, isYouth, calculateAge, orgCalendarDay } from '../time';
+import { formatDate, formatTime, formatDateTime, formatVisitRange, APP_TIMEZONE, toDatetimeLocal, fromDatetimeLocal, formatDateOnly, parseDateOnly, isYouth, calculateAge, orgCalendarDay } from '../time';
+
+/** The instant formatters take the zone explicitly; these suites pass the org default. */
+const TZ = { timeZone: APP_TIMEZONE };
 
 describe('calendar-date helpers', () => {
   it('stores a picked date at UTC midnight', () => {
@@ -13,7 +16,7 @@ describe('calendar-date helpers', () => {
     const stored = parseDateOnly('2026-09-01')!;
     expect(formatDateOnly(stored)).toBe('9/1/2026');
     // formatDate is for instants: UTC midnight rendered in Chicago is the day before
-    expect(formatDate(stored)).toBe('8/31/2026');
+    expect(formatDate(stored, TZ)).toBe('8/31/2026');
   });
 
   it('round-trips picked date → stored value → display and input value', () => {
@@ -155,28 +158,28 @@ describe('time.ts formatting utilities', () => {
 
   it('formatDate formats dates correctly in Central Time', () => {
     // 12:00 UTC is 06:00 CST (or 07:00 CDT depending on daylight savings, normally Jest uses the system timezone but we forced the options timeZone)
-    const formatted = formatDate(testDate);
+    const formatted = formatDate(testDate, TZ);
     // Since we aren't strict on the exact locale string structure (which varies based on the environment), we just check it returns a string for now, or mock Intl
     expect(typeof formatted).toBe('string');
     expect(formatted.length).toBeGreaterThan(0);
   });
 
   it('formatTime formats time correctly', () => {
-    const formatted = formatTime(testDate);
+    const formatted = formatTime(testDate, TZ);
     expect(typeof formatted).toBe('string');
     expect(formatted.length).toBeGreaterThan(0);
   });
 
   it('formatDateTime formats date and time correctly', () => {
-    const formatted = formatDateTime(testDate);
+    const formatted = formatDateTime(testDate, TZ);
     expect(typeof formatted).toBe('string');
     expect(formatted.length).toBeGreaterThan(0);
   });
   
   it('returns empty string when date is null', () => {
-    expect(formatDate(null)).toBe('');
-    expect(formatTime(null)).toBe('');
-    expect(formatDateTime(null)).toBe('');
+    expect(formatDate(null, TZ)).toBe('');
+    expect(formatTime(null, TZ)).toBe('');
+    expect(formatDateTime(null, TZ)).toBe('');
   });
 });
 
@@ -184,33 +187,23 @@ describe('time.ts formatting utilities', () => {
 // formatter must move with it, while the calendar-date reader must not.
 describe('configured display timezone', () => {
   const instant = '2026-09-01T02:30:00.000Z'; // 9:30 PM Aug 31 Chicago, 11:30 AM Sep 1 Tokyo
-  afterEach(() => setDisplayTimezone(APP_TIMEZONE));
 
-  it('defaults to APP_TIMEZONE', () => {
-    expect(getDisplayTimezone()).toBe(APP_TIMEZONE);
-    expect(formatDate(instant)).toBe('8/31/2026');
+  it('renders an instant in the org default when that is the configured zone', () => {
+    expect(formatDate(instant, TZ)).toBe('8/31/2026');
   });
 
   it('moves every instant formatter to the configured zone', () => {
-    setDisplayTimezone('Asia/Tokyo');
-    expect(formatDate(instant)).toBe('9/1/2026');
-    expect(formatTime(instant, { hour: 'numeric', minute: '2-digit' })).toBe('11:30 AM');
-    expect(formatDateTime(instant)).toContain('9/1/2026');
-    expect(formatVisitRange(instant)).toBe('11:30 AM-');
+    expect(formatDate(instant, { timeZone: 'Asia/Tokyo' })).toBe('9/1/2026');
+    expect(formatTime(instant, { timeZone: 'Asia/Tokyo', hour: 'numeric', minute: '2-digit' })).toBe('11:30 AM');
+    expect(formatDateTime(instant, { timeZone: 'Asia/Tokyo' })).toContain('9/1/2026');
+    expect(formatVisitRange(instant, null, 'Asia/Tokyo')).toBe('11:30 AM-');
   });
 
   it('leaves the calendar-date reader UTC-pinned — a day has no zone', () => {
-    setDisplayTimezone('Asia/Tokyo');
-    expect(formatDateOnly('2026-09-01T00:00:00.000Z')).toBe('9/1/2026');
-    setDisplayTimezone('Pacific/Honolulu');
-    expect(formatDateOnly('2026-09-01T00:00:00.000Z')).toBe('9/1/2026');
-  });
-
-  it('treats an empty configured zone as the fallback', () => {
-    setDisplayTimezone('');
-    expect(getDisplayTimezone()).toBe(APP_TIMEZONE);
-    setDisplayTimezone(null);
-    expect(getDisplayTimezone()).toBe(APP_TIMEZONE);
+    const midnight = '2026-09-01T00:00:00.000Z';
+    expect(formatDateOnly(midnight)).toBe('9/1/2026');
+    // the instant formatter does move, which is the distinction being guarded
+    expect(formatDate(midnight, { timeZone: 'Pacific/Honolulu' })).toBe('8/31/2026');
   });
 });
 
@@ -219,19 +212,19 @@ describe('formatVisitRange', () => {
   const departed = '2024-03-07T20:19:00Z'; // 2:19 PM CST, 44 min later
 
   it('shows start-end and length once departed, no seconds', () => {
-    const r = formatVisitRange(arrived, departed);
+    const r = formatVisitRange(arrived, departed, APP_TIMEZONE);
     expect(r).toBe('1:35 PM-2:19 PM (44 minutes)');
   });
 
   it('singularizes a one-minute visit', () => {
-    expect(formatVisitRange(arrived, '2024-03-07T19:36:00Z')).toBe('1:35 PM-1:36 PM (1 minute)');
+    expect(formatVisitRange(arrived, '2024-03-07T19:36:00Z', APP_TIMEZONE)).toBe('1:35 PM-1:36 PM (1 minute)');
   });
 
   it('shows an open-ended range while active', () => {
-    expect(formatVisitRange(arrived, null)).toBe('1:35 PM-');
+    expect(formatVisitRange(arrived, null, APP_TIMEZONE)).toBe('1:35 PM-');
   });
 
   it('returns empty string with no arrival', () => {
-    expect(formatVisitRange(null)).toBe('');
+    expect(formatVisitRange(null, null, APP_TIMEZONE)).toBe('');
   });
 });

--- a/checkin-app/src/lib/time.ts
+++ b/checkin-app/src/lib/time.ts
@@ -1,49 +1,42 @@
 /**
  * Seed default and offline fallback only — NOT the display zone. The organisation's
  * display zone is the editable `AppSettings.timezone` (lib/appSettings.ts), which the
- * server resolves per request and installs here via `setDisplayTimezone`.
+ * server resolves per request and passes to the formatters below.
  */
 export const APP_TIMEZONE = 'America/Chicago';
 
-let displayTimezone: string = APP_TIMEZONE;
+/** An instant, in any of the shapes the formatters accept. */
+export type DateInput = Date | string | number | null | undefined;
 
 /**
- * Install the organisation's configured display zone for the instant formatters below.
- * Client components get it from `<TimezoneProvider>` (fed by the root layout); server
- * callers, which run in a separate module instance, pass `{ timeZone }` per call instead.
- * An empty value falls back to APP_TIMEZONE.
+ * Options for the instant formatters. `timeZone` is required so the organisation's
+ * configured zone is always passed in rather than read from ambient state: client
+ * components get it from `useOrgTime()`, server callers from `resolveDisplayTimezone()`.
  */
-export function setDisplayTimezone(timezone: string | null | undefined): void {
-    displayTimezone = timezone || APP_TIMEZONE;
-}
-
-/** The zone the instant formatters are currently rendering in. */
-export function getDisplayTimezone(): string {
-    return displayTimezone;
-}
+export type ZonedOptions = Intl.DateTimeFormatOptions & { timeZone: string };
 
 /**
- * Returns a localized date string for an instant, in the organisation's display timezone
+ * Returns a localized date string for an instant, in the given timezone
  */
-export function formatDate(date: Date | string | number | null | undefined, options?: Intl.DateTimeFormatOptions): string {
+export function formatDate(date: DateInput, options: ZonedOptions): string {
     if (!date) return '';
-    return new Date(date).toLocaleDateString(undefined, { timeZone: displayTimezone, ...options });
+    return new Date(date).toLocaleDateString(undefined, options);
 }
 
 /**
- * Returns a localized time string in the organisation's display timezone
+ * Returns a localized time string in the given timezone
  */
-export function formatTime(date: Date | string | number | null | undefined, options?: Intl.DateTimeFormatOptions): string {
+export function formatTime(date: DateInput, options: ZonedOptions): string {
     if (!date) return '';
-    return new Date(date).toLocaleTimeString(undefined, { timeZone: displayTimezone, ...options });
+    return new Date(date).toLocaleTimeString(undefined, options);
 }
 
 /**
- * Returns a combined localized date and time string in the organisation's display timezone
+ * Returns a combined localized date and time string in the given timezone
  */
-export function formatDateTime(date: Date | string | number | null | undefined, options?: Intl.DateTimeFormatOptions): string {
+export function formatDateTime(date: DateInput, options: ZonedOptions): string {
     if (!date) return '';
-    return new Date(date).toLocaleString(undefined, { timeZone: displayTimezone, ...options });
+    return new Date(date).toLocaleString(undefined, options);
 }
 
 /**
@@ -68,11 +61,12 @@ export function relTime(when: string | Date, now: Date | number = Date.now()): s
  * Times are shown without seconds.
  */
 export function formatVisitRange(
-    arrived: Date | string | number | null | undefined,
-    departed?: Date | string | number | null | undefined,
+    arrived: DateInput,
+    departed: DateInput,
+    timeZone: string,
 ): string {
     if (!arrived) return '';
-    const hm: Intl.DateTimeFormatOptions = { hour: 'numeric', minute: '2-digit' };
+    const hm: ZonedOptions = { timeZone, hour: 'numeric', minute: '2-digit' };
     const start = formatTime(arrived, hm);
     if (!departed) return `${start}-`;
     const mins = Math.round((new Date(departed).getTime() - new Date(arrived).getTime()) / 60000);
@@ -140,11 +134,9 @@ const ORG_DAY_PARTS = new Intl.DateTimeFormat('en-US', {
  * day from a moment: the zone is named rather than inherited from the process.
  * See docs/conventions.md, "A day is not a moment".
  *
- * Pinned to APP_TIMEZONE, not the configured display zone: `getDisplayTimezone()` is
- * only installed by `<TimezoneProvider>`, which runs on the client, so a server age
- * gate would read the fallback while the browser read the setting and the two would
- * disagree about who is 18. ponytail: a settings-aware variant has to be async (the
- * zone comes from the database), so it waits until the org actually moves zones.
+ * Pinned to APP_TIMEZONE, not the configured display zone, so a server age gate and
+ * the browser cannot disagree about who is 18. ponytail: a settings-aware variant has
+ * to be async (the zone comes from the database), so it waits until the org moves zones.
  */
 export function orgCalendarDay(instant: Date | string | number = new Date()): Date {
     const p = Object.fromEntries(


### PR DESCRIPTION
The organisation's display timezone lived in a mutable module-level variable in
`lib/time`, which `TimezoneProvider` wrote during render. On the server that module is a
per-process singleton shared by every concurrent request, so the zone in effect belonged
to whichever request rendered its provider most recently — not to the request whose page
was being formatted. Check-in and departure times rendered an hour off for the request
that lost the race.

The window is not theoretical. `resolveDisplayTimezone()` falls back to `APP_TIMEZONE`
(`America/Chicago`) whenever the settings read throws, and Aurora scales to zero here, so
a cold process serves some requests the fallback and others the configured
`America/New_York` while both write the same variable.

## The fix

The zone now flows through a React context, which is per-render-tree and therefore cannot
be shared between concurrent requests. This is the pattern `EnvProvider` already uses in
this repo for the same job — carrying a server-resolved value into client components.

The raw formatters in `lib/time` take the zone in their options, and the type makes it
**required**:

```ts
export type ZonedOptions = Intl.DateTimeFormatOptions & { timeZone: string };
export function formatDateTime(date: DateInput, options: ZonedOptions): string
```

That matters more than it looks. Removing the global without requiring the zone would
have traded a rare race for a common footgun: every one of the 39 client call sites that
today gets the right zone by accident would silently fall back to the compiled-in default
instead, which is exactly what `docs/conventions.md` ("A moment is displayed in the zone
the organisation configured, never one compiled in") forbids. Requiring it makes that a
compile error rather than a wrong time on a screen.

Client components get the formatters pre-bound to the tree's zone from `useOrgTime()`, so
call sites are unchanged:

```tsx
const { formatDateTime } = useOrgTime();
```

`setDisplayTimezone` and `getDisplayTimezone` are deleted. The two server callers
(`notifications.ts`, `attendance/manual/[id]/route.ts`) already passed `{ timeZone }`
explicitly and are untouched.

`formatDateOnly` remains UTC-pinned and is deliberately not part of this change — a day
still has no zone.

## Red, then green

The regression test is `src/components/__tests__/timezoneIsolation.test.tsx`. It renders
two trees, one per "request": request A is in `America/New_York` and suspends before its
leaf formats; request B then renders in the `APP_TIMEZONE` fallback; A's leaf finally
renders. That is the production interleave — provider A, provider B, then A's leaf —
made deterministic with a promise gate instead of timing.

Against `origin/main`'s source (`git checkout origin/main -- checkin-app/src`, scenario
written against main's API, since the fix necessarily changes how a leaf obtains the
zone):

```
FAIL src/components/__tests__/timezoneIsolation.test.tsx
  ✕ keeps request A in its own zone while request B renders in another
    Expected substring: "10:30"
    Received string:    "8/31/2026, 9:30:00 PM"
```

Request A rendered 9:30 PM — request B's Chicago — instead of its own 10:30 PM New York.
An hour off, which is the reported symptom.

On this branch:

```
Test Suites: 277 passed, 277 total
Tests:       2691 passed, 2691 total
```

**One honest caveat about that pair of runs.** The two files are not byte-identical, and
cannot be: the fix removes the global the old leaf read, so the leaf must obtain the zone
differently. What is identical between the red and green runs is the scenario — the same
two providers, the same interleave, the same instant, the same two assertions. Only the
three lines by which a leaf gets its zone differ. A single unchanged file cannot span
both APIs, and I would rather say that than imply a stronger proof than exists.

Control run: the full suite is green on pristine `origin/main` too (276 suites, 2691
tests), so the branch result is not being read against a broken baseline.

## Verified

- `npx tsc --noEmit` — clean, 0 errors. The two known-environmental
  `@aws-sdk/client-lambda` errors did not appear after a fresh `npm ci`.
- `npm run lint` — clean.
- `git diff --name-only origin/main...HEAD -- checkin-app/src/security/` — empty.

## Out of scope, but found while working

Three files hardcode `America/Chicago` inline rather than reading the configured zone, so
they will render the wrong time for an organisation in any other zone. They are a
separate defect from this race — no shared mutable involved — and fixing them here would
have buried this diff:

- `src/app/attendance/certifications/page.tsx:195`
- `src/app/my-programs/attendance/page.tsx:60`
- `src/app/program-ops/events/page.tsx:16`

## Not verified

- No browser or deployed-environment check; the evidence is the unit suite, tsc and lint.
- The SSR bleed is reproduced through client-render suspension in jsdom, not through an
  actual concurrent Next.js server render. The mechanism is the same shared module
  instance, but I did not stand up two real overlapping HTTP requests.
- `src/app/safety/trusted-adults/__tests__/page.test.tsx` failed once during a full run on
  this branch, on a `waitFor` against a fetch mock. It passes in isolation on both this
  branch and `origin/main`, and passed on a full re-run here. It has no reference to
  `lib/time` or `TimezoneProvider`. I believe it is a flake rather than fallout from this
  change, but I saw it fail once and am not going to claim more certainty than that.
