### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in dev email viewer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Found early returns checking buffer lengths (e.g., `providedBuffer.length !== expectedBuffer.length`) on webhook secrets and cron auth tokens before using `crypto.timingSafeEqual`.
 **Learning:** Returning early on length mismatch leaks the exact length of the expected secret.
 **Prevention:** Hash both the expected and provided secrets to a fixed length (e.g., using SHA-256) before passing them to `crypto.timingSafeEqual` to avoid leaking secret lengths while still safely catching any mismatch.
+
+## 2026-08-09 - XSS Vulnerability in Dev Email Viewer
+**Vulnerability:** Used `dangerouslySetInnerHTML` to render captured raw email bodies in `src/app/dev/sent-mail/page.tsx`.
+**Learning:** Using `dangerouslySetInnerHTML` to render raw HTML from external sources (like emails) exposes the application to Cross-Site Scripting (XSS) attacks, even in development environments, as it bypasses React's escaping mechanisms.
+**Prevention:** To safely render raw HTML in React (e.g., captured email bodies) and mitigate XSS risks without using `dangerouslySetInnerHTML`, use an `iframe` with the `srcDoc` attribute and an appropriate `sandbox` attribute (e.g., `sandbox="allow-popups allow-popups-to-escape-sandbox"`).

--- a/checkin-app/src/app/dev/sent-mail/page.tsx
+++ b/checkin-app/src/app/dev/sent-mail/page.tsx
@@ -64,11 +64,12 @@ export default async function DevSentMailPage() {
                                 <span>{new Date(email.createdAt).toLocaleString()}</span>
                             </div>
                             <div style={{ fontWeight: 600, margin: "0.4rem 0 0.75rem" }}>{email.subject}</div>
-                            <div
-                                style={{ border: "1px solid rgba(0,0,0,0.08)", borderRadius: 6, padding: "0.75rem", background: "#fff", color: "#111" }}
+                            <iframe
+                                style={{ border: "1px solid rgba(0,0,0,0.08)", borderRadius: 6, background: "#fff", width: "100%", height: "400px" }}
                                 // Dev-only rendering of our own captured template HTML so embedded links/tokens
                                 // are clickable. Never runs in prod (page 404s); content is what we ourselves sent.
-                                dangerouslySetInnerHTML={{ __html: email.html }}
+                                srcDoc={email.html}
+                                sandbox="allow-popups allow-popups-to-escape-sandbox"
                             />
                         </li>
                     ))}


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Used `dangerouslySetInnerHTML` to render captured email bodies, which could execute malicious scripts if user input is reflected in the email templates.
🎯 **Impact**: An attacker could inject malicious scripts into emails that would execute when an admin views the dev sent-mail page.
🔧 **Fix**: Replaced `dangerouslySetInnerHTML` with an `iframe` utilizing `srcDoc` and `sandbox` attributes (`allow-popups allow-popups-to-escape-sandbox`) to securely render raw HTML without exposing the parent application context.
✅ **Verification**: Code compiles, linters pass, and the dev sent-mail page renders emails safely in a sandboxed iframe.

---
*PR created automatically by Jules for task [10367505070575511808](https://jules.google.com/task/10367505070575511808) started by @dkaygithub*