### PR TITLE
docs(agents): make an agent revise its reviewed PR instead of re-filing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,32 @@ standing as a soft reservation, and never trust it as the only signal.
 Project-field writes need the `project` token scope; if GraphQL returns
 INSUFFICIENT_SCOPES, have the user run `gh auth refresh -s project`.
 
+## Your own open PRs
+
+Before opening a PR, search open **and recently closed** PRs for the same fix —
+by the file you are about to touch and by the finding, not just by title. If one
+exists, that PR *is* the work: push to its branch. A second PR for a fix that
+already has one is never the right move, whoever opened the first.
+
+An open PR you authored carrying **CHANGES_REQUESTED**, or unresolved review
+comments, is your next task — ahead of any new finding. Address it or argue it
+on the thread. Do not leave it and start something else.
+
+- **Never re-file instead of revising.** Abandoning a reviewed PR and opening a
+  fresh one with the same fix launders unaddressed feedback into a clean slate:
+  the same review gets written twice and the defect the first review named ships
+  anyway. This is the failure to avoid, and it has happened: #1479 was told on
+  2026-08-03 that its `sandbox` value broke the dev mail viewer's link
+  click-through; #1617 arrived six days later with the identical flags, the
+  identical claim that links stayed clickable, and no reference to #1479.
+- **Disagreeing is fine; ignoring is not.** If you think a review is wrong —
+  including on security grounds, and including when the reviewer is not the
+  repo owner — say so on the PR and let the owner settle it. Unwillingness to
+  take a reviewer's advice is not a licence to re-file: silence plus a duplicate
+  reads as feedback evasion, and it costs the reviewer the same work twice.
+- Same rule for a finding already **rejected**. Re-raising it needs new evidence
+  named in the body, not a new PR number.
+
 ## Reviewing a PR
 
 A review comment earns its place only if a careful human reading the diff would


### PR DESCRIPTION
## What

Adds a `## Your own open PRs` section to `AGENTS.md`, between the issue workflow and the review guidance.

Three rules:

- **Before opening a PR**, search open *and recently closed* PRs for the same fix — by the file and the finding, not the title. If one exists, push to its branch.
- **An authored PR carrying `CHANGES_REQUESTED`, or unresolved review comments, is the next task**, ahead of any new finding.
- **Never re-file instead of revising.** Disagreement belongs on the thread — including on security grounds, and including when the reviewer is not the repo owner — but being unwilling to take a reviewer's advice is not a licence to open a second PR.

## Why

[#1479](https://github.com/innovationtreehouse/checkin/pull/1479) fixed the `dangerouslySetInnerHTML` XSS in the dev sent-mail viewer. On 2026-08-03 it was told the chosen `sandbox` value broke the page's link click-through — the one thing the page exists for, since a sandbox without `allow-same-origin` still lets the frame navigate itself, so a captured magic link loads under an opaque origin with no `SameSite=Lax` session cookie and no scripts. Sentinel never came back to it.

Six days later it opened [#1617](https://github.com/innovationtreehouse/checkin/pull/1617): identical flags, identical claim in the body that links stayed clickable, no reference to #1479. The same blocking review had to be written a second time, against a second PR, for a defect the first review had already named.

Nothing in `AGENTS.md` told it not to. The issue workflow section covers claiming and closing issues; the review section covers what a *reviewer* should say. Neither covers what an *author* owes a review it has already received. #1479 is now closed as a duplicate; #1617 carries the review, including the two details #1479 got right (the iframe `title`, and `minHeight` over a fixed `height`).

## For the reviewer

- Docs only — no code, no test changes.
- The #1479/#1617 trace is cited inline, matching how this file already cites #300 and #1447 as regressions to learn from.
- `CLAUDE.md` imports this file via `@AGENTS.md` and `GEMINI.md` / `.jules/sentinel.md` both point at it, so no mirroring is needed — Jules is the agent that did this, though, and the rule only binds it if its task prompt actually reads `AGENTS.md`. Worth confirming separately.
- Related follow-up in flight: `GEMINI.md`'s four lint/type rules are not Gemini-specific and are invisible to every other agent. A separate change folds them into the shared file, placed near `## Comments` to avoid colliding with this section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)