### PR TITLE
docs(agents): move the lint/type-suppression rules into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,20 @@ Design rationale, regressions-to-learn-from, and past approaches live in
 `docs/` and PR history — not in code comments. (This file's own flow-test
 section is an example: the failure stories sit in docs, not in the source.)
 
+## Lint and type errors
+
+A suppressed error is an error the next reader cannot see. Fix what the tool is
+pointing at, not the fact that it is pointing.
+
+- **Never fix a lint error by disabling the linter.** No
+  `// eslint-disable-next-line`, no `/* eslint-disable */`, no
+  `@ts-expect-error`, no `@ts-ignore`.
+- **Never fix a type error with an `any` coercion.** Type the variables,
+  parameters and return signatures properly. Where the type isn't immediately
+  obvious, use `unknown` and narrow it, or define the interface.
+- **Address the root cause** — the logic, the missing type, the interface that
+  wasn't imported — rather than the message.
+
 ## Test classes
 
 There are **three** classes of tests. Run all commands from `checkin-app/`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,11 +1,7 @@
 # Agent Instructions & Guidelines
 
 > **Start with [AGENTS.md](AGENTS.md)** — the shared, canonical orientation for
-> all agents in this repo (repo layout, test classes, docs map, and the
-> commenting strategy). The rules below are Gemini-specific additions on top of
-> it. Keep the two cross-consistent.
-
-## Code Quality & Linting
-- **NEVER fix lint errors by disabling the linter.** Do not use `// eslint-disable-next-line`, `/* eslint-disable */`, `@ts-expect-error`, or `@ts-ignore` to suppress errors.
-- **NEVER fix TypeScript errors by using `any` coercions.** Always properly type variables, parameters, and return signatures. If a type isn't immediately obvious, define an interface or use `unknown` and perform proper type narrowing.
-- Address the root cause of the lint or type error by modifying the logic, defining missing types, or importing the correct interfaces.
+> all agents in this repo (repo layout, code quality and linting, test classes,
+> docs map, and the commenting strategy). Every rule that applies to more than
+> one agent lives there. This file holds Gemini-specific additions on top of it,
+> and is empty until there are some.


### PR DESCRIPTION
## What changed

`GEMINI.md`'s one content section, "Code Quality & Linting", moves into `AGENTS.md` as a new `## Lint and type errors` section. `GEMINI.md` reduces to its pointer block.

Four rules, moved verbatim in substance and rewritten in the destination file's voice (short paragraph, bold-led bullets):

- never fix a lint error by disabling the linter — no `// eslint-disable-next-line`, `/* eslint-disable */`, `@ts-expect-error`, `@ts-ignore`
- never fix a type error with an `any` coercion
- use `unknown` plus narrowing, or define the interface
- address the root cause, not the message

Nothing added, nothing dropped.

## Why

Those rules are not Gemini-specific. They govern every agent working in this repo, and a grep confirms they existed nowhere else — `docs/conventions.md` covers neither lint suppression nor `any` coercions. So Claude and Jules never saw them, and any agent but Gemini could suppress an error and be within the written rules.

`docs/conventions.md` §"We name the role, not the vendor" already describes this exact defect: a rule that looks universal, binds one product, and leaves every other agent silently unbound while reviewers watch the named product obey it. `GEMINI.md` predates that convention.

## Why AGENTS.md and not docs/conventions.md

Both were candidates. `docs/conventions.md` holds build conventions about the product, each written as a failure-mode narrative, and it is followed from the docs map rather than loaded. These four rules are about agent behaviour when a tool complains, and they only work if the agent has already read them. `AGENTS.md` is auto-loaded every session, so that is where they went. Nothing landed in `docs/conventions.md`, so no back-reference is needed there.

## For the reviewer

- **Placement is deliberate.** The new section sits after `## Comments` and before `## Test classes`, with the other cross-cutting build rules. Another branch is adding a `## Your own open PRs` section immediately before `## Reviewing a PR`; this diff stays clear of that region.
- **`GEMINI.md` stays as a file.** Gemini auto-loads that filename and would otherwise find nothing. It now says that shared rules live in `AGENTS.md` and that Gemini-specific additions go in `GEMINI.md`.
- **No speculative edits.** `CLAUDE.md` imports `AGENTS.md` via `@AGENTS.md`, so it picks up the new section with no change. `.jules/sentinel.md` already links `../AGENTS.md` and is a security-learnings log rather than instructions. Both verified, neither touched.

Docs only. No code, no tests, no schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)