### PR TITLE
fix(attendance): the roster mark stamps LEAD_MARKED on the visits it creates

### DIFF
--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -265,7 +265,10 @@ describe('AuditLog Integration Tests', () => {
         // newData is now a raw JSON object (legacy rows may still be strings).
         const newData = normalizeAuditData(log?.newData) as Record<string, unknown>;
         expect(newData.type).toBe('lead_attendance_correction');
-        expect(newData.arrivedVia).toBe('WEB');
+        // The update branch leaves arrivedVia alone, so the audit must not claim
+        // it changed; the departure the lead typed IS staff-asserted.
+        expect(newData).not.toHaveProperty('arrivedVia');
+        expect(newData.departedVia).toBe('LEAD_MARKED');
     });
 
     it('should generate an AuditLog when an Admin edits participant PII', async () => {

--- a/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
+++ b/checkin-app/src/app/__tests__/eventCancelAndManualAttendance.integration.test.ts
@@ -355,6 +355,92 @@ describe('PATCH /api/events/[id] — cancel, manual attendance, past-event guard
         });
     });
 
+    // ─── 2c. VISIT SOURCE ON A ROSTER MARK ──────────────────────────────────
+
+    // arrivedVia is how the arrival was MEASURED, so only a visit this mark
+    // creates is LEAD_MARKED. Stamping it unconditionally would relabel a real
+    // badge-in as staff-asserted and drop it out of facility/trends, which
+    // excludes LEAD_MARKED — trading an over-count for an under-count on
+    // exactly the people who did scan in.
+    describe('manualEditAttendance — arrivedVia/departedVia', () => {
+        it('stamps LEAD_MARKED on both fields of a visit it creates', async () => {
+            const event = await makeEvent('source-create', -3 * HOUR);
+            const arrival = new Date(Date.now() - 150 * MIN);
+            const departure = new Date(Date.now() - 30 * MIN);
+
+            const res = await patch(event.id, {
+                action: 'manualEditAttendance',
+                participantId,
+                status: 'Present',
+                arrivedAt: arrival.toISOString(),
+                departedAt: departure.toISOString(),
+            });
+            expect(res.status).toBe(200);
+
+            const visit = await prisma.visit.findFirstOrThrow({ where: { personId: participantId, associatedEventId: event.id } });
+            expect(visit.arrivedVia).toBe('LEAD_MARKED');
+            expect(visit.departedVia).toBe('LEAD_MARKED');
+
+            const audit = await prisma.auditLog.findFirstOrThrow({
+                where: { tableName: 'Visit', affectedEntityId: visit.id, action: 'CREATE' },
+            });
+            expect(audit.newData).toMatchObject({ arrivedVia: 'LEAD_MARKED', departedVia: 'LEAD_MARKED' });
+        });
+
+        it('leaves an adopted walk-in on its measured SCANNER arrival', async () => {
+            const event = await makeEvent('source-adopt', -1 * HOUR);
+            const walkIn = await prisma.visit.create({
+                data: {
+                    personId: participantId, arrivedAt: new Date(Date.now() - 90 * MIN),
+                    departedAt: null, associatedEventId: null, arrivedVia: 'SCANNER',
+                },
+            });
+
+            const res = await patch(event.id, {
+                action: 'manualEditAttendance',
+                participantId,
+                status: 'Present',
+                arrivedAt: new Date(Date.now() - 80 * MIN).toISOString(),
+                departedAt: null,
+            });
+            expect(res.status).toBe(200);
+
+            const after = await prisma.visit.findUniqueOrThrow({ where: { id: walkIn.id } });
+            expect(after.associatedEventId).toBe(event.id); // adopted
+            expect(after.arrivedVia).toBe('SCANNER');       // still a measured arrival
+            expect(after.departedVia).toBeNull();           // no departure supplied
+
+            // The audit must not claim a field it did not write.
+            const audit = await prisma.auditLog.findFirstOrThrow({
+                where: { tableName: 'Visit', affectedEntityId: walkIn.id, action: 'EDIT' },
+            });
+            expect(audit.newData).not.toHaveProperty('arrivedVia');
+        });
+
+        it('keeps the arrival source but stamps the departure a lead types on an existing visit', async () => {
+            const event = await makeEvent('source-edit-existing', -4 * HOUR);
+            const existing = await prisma.visit.create({
+                data: {
+                    personId: participantId, arrivedAt: new Date(Date.now() - 200 * MIN),
+                    departedAt: null, associatedEventId: event.id, arrivedVia: 'SCANNER',
+                },
+            });
+
+            const res = await patch(event.id, {
+                action: 'manualEditAttendance',
+                participantId,
+                status: 'Present',
+                arrivedAt: new Date(Date.now() - 200 * MIN).toISOString(),
+                departedAt: new Date(Date.now() - 60 * MIN).toISOString(),
+            });
+            expect(res.status).toBe(200);
+
+            const after = await prisma.visit.findUniqueOrThrow({ where: { id: existing.id } });
+            expect(after.arrivedVia).toBe('SCANNER');        // not overwritten
+            expect(after.departedVia).toBe('LEAD_MARKED');   // the lead asserted this
+        });
+    });
+
     // ─── 3. PAST-EVENT GUARD ────────────────────────────────────────────────
 
     describe('past-event editTime — rejected', () => {

--- a/checkin-app/src/app/api/events/[id]/route.ts
+++ b/checkin-app/src/app/api/events/[id]/route.ts
@@ -347,12 +347,16 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                     where: { personId: targetId, associatedEventId: eventId, ...LIVE_VISIT }
                 });
 
+                // arrivedVia records how the arrival was measured, not who last
+                // touched the row, so only a visit this mark creates is staff-
+                // asserted: an adopted walk-in keeps its SCANNER/WEB. A departure
+                // the lead typed is staff-asserted whatever the arrival was.
                 const times = {
                     arrivedAt: arrival!,
                     departedAt: dep,
-                    arrivedVia: "WEB",
-                    departedVia: departedAt ? "WEB" : null
+                    departedVia: departedAt ? "LEAD_MARKED" : null
                 } satisfies Prisma.VisitUncheckedUpdateInput;
+                const createTimes = { ...times, arrivedVia: "LEAD_MARKED" } satisfies Prisma.VisitUncheckedUpdateInput;
 
                 // Every human visit-write logs (design "Audit substrate"), with
                 // secondaryAffectedEntity = the subject so a correction review
@@ -389,7 +393,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                     });
                 } else {
                     const created = await tx.visit.create({
-                        data: { ...times, personId: targetId, associatedEventId: eventId }
+                        data: { ...createTimes, personId: targetId, associatedEventId: eventId }
                     });
                     await tx.auditLog.create({
                         data: {
@@ -398,7 +402,7 @@ export const PATCH = withAuth({}, async (req: Request, auth, { params }: { param
                             tableName: "Visit",
                             affectedEntityId: created.id,
                             secondaryAffectedEntity: targetId,
-                            newData: { ...times, type: "lead_attendance_correction", status: "Present" }
+                            newData: { ...createTimes, type: "lead_attendance_correction", status: "Present" }
                         }
                     });
                 }

--- a/checkin-app/src/app/api/facility/trends/route.ts
+++ b/checkin-app/src/app/api/facility/trends/route.ts
@@ -72,11 +72,10 @@ export const GET = withAuth(
                 deletedAt: null,
                 // Drop staff-asserted arrivals (LEAD_MARKED, and its legacy spelling
                 // SYSTEM): those times are an event window, not a measured duration.
+                // The events roster mark stamps LEAD_MARKED on the visits it creates;
+                // a walk-in it adopts keeps its measured SCANNER/WEB and still counts.
                 // An untagged (null) arrival is an ordinary visit and counts — it needs
                 // the explicit OR, because NULL never satisfies a SQL NOT IN.
-                // ponytail: this only reaches rows that already carry LEAD_MARKED. The
-                // events roster mark stamps WEB, so its visits are still counted as
-                // measured hours until that writer stamps LEAD_MARKED.
                 OR: [
                     { arrivedVia: null },
                     { arrivedVia: { notIn: ["LEAD_MARKED", "SYSTEM"] } },


### PR DESCRIPTION
Fixes #1619.

`LEAD_MARKED` had four readers and zero writers. The roster mark —
`manualEditAttendance` in `api/events/[id]/route.ts` — stamped `WEB`, so the
trends exclusion (`arrivedVia notIn ["LEAD_MARKED", "SYSTEM"]`) matched no live
row: a lead marking twenty participants Present for a three-hour session put
sixty placeholder hours into the Participation Trends chart as measured facility
time.

### Not the one-liner

Swapping `"WEB"` for `"LEAD_MARKED"` in that one shared `times` object would
relabel real badge-ins as staff-asserted and — with #1608's NULL-admitting
exclusion live — drop them out of the chart entirely, trading an over-count for
an under-count on exactly the people who did scan in. `arrivedVia` records **how
the arrival was measured**, not who last touched the row; corrections live in
`AuditLog`. So `times` splits:

| branch | `arrivedVia` | `departedVia` |
|---|---|---|
| create (staff asserted the whole visit) | `LEAD_MARKED` | `LEAD_MARKED` if a departure was typed |
| update (adopted walk-in, or an existing visit for this event) | **untouched** | `LEAD_MARKED` if a departure was typed |

A row already carrying `LEAD_MARKED` keeps it for free. A departure the lead
typed is staff-asserted whatever the arrival was, and does not reach the trends
filter, which keys on `arrivedVia` only.

The update branch's audit `newData` spreads the same `times` that the update
writes, so it no longer claims `arrivedVia` changed when it did not — the
corrections surface already renders an absent key as "—"
(`facility-ops/corrections/page.tsx`). `auditLog.integration.test.ts` asserted
the old `newData.arrivedVia === 'WEB'`; it now asserts the key is absent and the
departure is `LEAD_MARKED`.

Also fixed: the comment above the trends exclusion asserted the opposite of
reality. It now states what is true in present tense.

No change was needed in `lib/visit/significance.ts` — `WEIGHTS.LEAD_MARKED` is
already 2, so a created roster mark scores as staff observation the moment the
writer stamps it.

### Based on #1558, not on `main`

Cut from `claude/1523-significance` and targeted at it. #1558 does not touch the
`arrivedVia` line, but it inserts a closed-visit guard and spreads `...times`
into `newData` in the same block. Splitting `times` while #1558 spreads it is a
non-overlapping-hunk mismerge waiting to happen — `git merge-tree` would exit 0
and leave the create branch spreading the stale object. Written against #1558's
actual shape so the interaction is in the diff instead of at the merge.

**Retarget this to `main` once #1558 lands.** A stacked PR merged into a branch
that has already merged reports `MERGED` while its code never reaches `main`
(the #1447 failure recorded in AGENTS.md), and a closed PR cannot be retargeted.
`closingIssuesReferences` is empty for the same reason — GitHub only registers a
closing keyword on a PR targeting the default branch. The keyword is in both the
body and the commit message, so it takes effect on retarget. After any merge,
confirm with `git show origin/main:checkin-app/src/app/api/events/\[id\]/route.ts`
rather than trusting the PR state.

### History stays over-counted

Roster marks already written as `WEB` are indistinguishable from a member's own
self-report by source, by `associatedEventId`, and by times. The only
discriminator is the `newData.type = "lead_attendance_correction"` audit row. **No
backfill migration here** — the chart's past buckets keep counting those hours as
measured facility time until a maintainer decides to take one. This PR fixes the
writer only.

### Regression test

`eventCancelAndManualAttendance.integration.test.ts` gains three cases: the
create branch stamps both fields, an adopted `SCANNER` walk-in keeps its arrival
(**the guard this issue exists for**), and an existing visit keeps its arrival
while the typed departure becomes `LEAD_MARKED`.

Proven red-then-green against the pre-fix source, and proven to reject the naive
fix:

| source under the test | result |
|---|---|
| pre-fix (`arrivedVia: "WEB"`) | **3 failed**, 11 passed — `Expected "LEAD_MARKED" / Received "WEB"`, `Expected "SCANNER" / Received "WEB"` |
| naive unconditional `LEAD_MARKED` | **2 failed**, 12 passed — `Expected "SCANNER" / Received "LEAD_MARKED"` |
| this PR | 14 passed |

### Verification

**CI did not run on this PR.** Targeting a non-default branch fires exactly one
check — `PR target label` (a labeller, 6s) — and no test, lint, type, or build
job. That near-empty check list is not a pass. Local runs are the proof:

| check | result |
|---|---|
| `npm run test:ci` (unit) | 278 suites, 2710 tests, **all pass** |
| `npm run test:integration` (full, Docker Postgres 15) | 136 suites, 1460 tests, **all pass** |
| `tsc --noEmit --pretty false` | clean, 0 lines of output |
| `npm run lint` (`--max-warnings 0`) | clean |
| `git diff --name-only origin/main -- checkin-app/src/security/` | empty |

`npm ci` was run fresh in the worktree before any of it.

Not verified: no flow test covers this path, and the writer→reader chain is
covered compositionally (this PR asserts what the route writes;
`facilityTrendsAPI.integration.test.ts` already asserts the reader drops
`LEAD_MARKED` and counts everything else) rather than by one end-to-end test.

Adjacent and deliberately untouched: `api/facility/visits/insert/route.ts` also
stamps `arrivedVia: "WEB"` on a staff insert-for-others. It is not in the design
doc's per-writer migration table and is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
