### PR TITLE
docs(rules): record the operations reach into attendance as aggregate only

### DIFF
--- a/docs/rules/attendance-checkin.md
+++ b/docs/rules/attendance-checkin.md
@@ -163,6 +163,12 @@ Things the app takes as true because they are handled outside it.
 - The board and sysadmins edit or delete any visit, and record one for someone
   else at any past time — the walk-in nobody badged in.  [Decision]
 
+- Operations reach attendance in aggregate only — the trends, and printing the ID
+  badges. One person's record sits outside that reach: operations do not record,
+  correct or remove a visit, do not read the raw badge events behind one, and do
+  not review other people's corrections. Running the facility works off the shape
+  of attendance, not off who was there when.  [Decision — *Principle: least privilege*]
+
 - A visit recorded for someone else is always a closed one: it says they came and
   left. Putting someone on the list of who is in the building now follows from a
   badge at the kiosk, never from staff saying so.  [Decision — deliberate limit]


### PR DESCRIPTION
## What

One rule line in `docs/rules/attendance-checkin.md`, in Procedure → The visit record:

> Operations reach attendance in aggregate only — the trends, and printing the ID badges. One person's record sits outside that reach: operations do not record, correct or remove a visit, do not read the raw badge events behind one, and do not review other people's corrections. Running the facility works off the shape of attendance, not off who was there when.  [Decision — *Principle: least privilege*]

Register only. No code, no gate, no boundary file.

## Why

#1476 asks whether `isOperations` joins the `GET/POST/PATCH/DELETE /api/facility/visits` gate. The answer is **no**, and the line above is the general form of it rather than a note about one route: operations sees the aggregate, not the individual record.

The issue's own framing was that widening a gate is a board call and not a default to take inside a feature PR. That is why the answer is written into the register first, on its own, before anything is built against it.

## What this does to the surrounding work

- **The existing rule needs no amendment.** "The board and sysadmins edit or delete any visit, and record one for someone else at any past time" stays true — the decision keeps operations out, so the new line sits beside it rather than qualifying it.
- **#1623 is mostly answered by this.** That PR grants operations all four Facility Ops tools, including visits `PATCH`/`DELETE` and the raw badge-event screen. Both are excluded here, so the grant it is blocked on does not arrive. Its review findings 1, 2 and 6 all hang off the visits grant and go with it, and finding 4's dead Corrections tab resolves as "operations never reaches Corrections".
- **What is left implementable:** trends and print ID badges for operations, plus the navigation entries, plus the pre-existing bug that `facility-ops/badges` bounces board members off a page its API serves them. None of that is in this PR.

## Reviewer note

The wording distinguishes *printing the ID badges* from the raw badge-event log, because `/facility-ops/badges` is the latter and reading it as the former would grant exactly what this rule withholds.

Design for #1476 — no closing keyword: the residual grant is still to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)