### PR TITLE
feat(print-badges): hide inactive people behind a default-on filter

### DIFF
--- a/checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx
@@ -35,6 +35,11 @@ const participants = [
   { id: 2, name: "Bo Board", email: "bo@example.com", isMember: true, isBoardMember: true },
 ];
 
+const withInactive = [
+  participants[0],
+  { id: 3, name: "Lapsed Larry", email: "larry@example.com", isMember: false },
+];
+
 describe("facility-ops/print-badges page", () => {
   it("loads and renders the participant roster", async () => {
     setSession({ id: 1, isSysadmin: true });
@@ -72,5 +77,37 @@ describe("facility-ops/print-badges page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Generate Badge (2)" }));
 
     await waitFor(() => expect(global.URL.createObjectURL).toHaveBeenCalled());
+  });
+
+  it("hides inactive people by default and reveals them when unchecked", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/people/search": { people: withInactive } });
+    renderWithProviders(<PrintBadgesPage />);
+    await screen.findByText("Kim Keyholder");
+
+    const filter = screen.getByRole("checkbox", { name: /hide inactive/i });
+    expect(filter).toBeChecked();
+    expect(screen.queryByText("Lapsed Larry")).not.toBeInTheDocument();
+
+    fireEvent.click(filter);
+    expect(await screen.findByText("Lapsed Larry")).toBeInTheDocument();
+  });
+
+  it("drops hidden people from the selection count, so the PDF matches the button", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/people/search": { people: withInactive } });
+    renderWithProviders(<PrintBadgesPage />);
+    await screen.findByText("Kim Keyholder");
+
+    const filter = screen.getByRole("checkbox", { name: /hide inactive/i });
+    fireEvent.click(filter); // reveal the inactive person
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select all" }));
+    expect(screen.getByRole("button", { name: "Generate Badge (2)" })).toBeInTheDocument();
+
+    fireEvent.click(filter); // hide again — the inactive person must leave the print run
+    expect(screen.getByRole("button", { name: "Generate Badge (1)" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Generate Sticker (1)" })).toBeInTheDocument();
+    // and "select all" still reads as fully selected over what is actually visible
+    expect(screen.getByRole("checkbox", { name: "Select all" })).toBeChecked();
   });
 });

--- a/checkin-app/src/app/facility-ops/print-badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/page.tsx
@@ -27,6 +27,7 @@ export default function PrintBadgesPage() {
   const [participants, setParticipants] = useState<ParticipantRow[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [hideInactive, setHideInactive] = useState(true);
   const [isGenerating, setIsGenerating] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -67,24 +68,27 @@ export default function PrintBadgesPage() {
     setSelectedIds(newSet);
   };
 
+  // Every count, every checkbox and the PDF itself read `visible`/`selectedVisible`,
+  // never `participants`/`selectedIds` — a hidden person can't leak into a print run.
+  const visible = hideInactive ? participants.filter(p => p.isMember) : participants;
+  const selectedVisible = visible.filter(p => selectedIds.has(p.id));
+
   const toggleAll = () => {
-    if (selectedIds.size === participants.length) {
+    if (selectedVisible.length === visible.length) {
       setSelectedIds(new Set());
     } else {
-      setSelectedIds(new Set(participants.map(p => p.id)));
+      setSelectedIds(new Set(visible.map(p => p.id)));
     }
   };
 
   const generate = async (kind: 'badge' | 'sticker') => {
-    if (selectedIds.size === 0) return;
+    if (selectedVisible.length === 0) return;
     setIsGenerating(true);
 
     try {
-      const selectedParticipants = participants.filter(p => selectedIds.has(p.id));
-
       // Add QR code data URIs
       const badgesWithQr = await Promise.all(
-        selectedParticipants.map(async (p) => {
+        selectedVisible.map(async (p) => {
           const qrDataUri = await QRCode.toDataURL(p.id.toString(), {
             width: 200,
             margin: 1,
@@ -130,7 +134,7 @@ export default function PrintBadgesPage() {
       header: (
         <Checkbox
           radius={2}
-          checked={participants.length > 0 && selectedIds.size === participants.length}
+          checked={visible.length > 0 && selectedVisible.length === visible.length}
           onChange={toggleAll}
           aria-label="Select all"
         />
@@ -180,17 +184,22 @@ export default function PrintBadgesPage() {
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.currentTarget.value)}
         />
-        <Button onClick={() => generate('badge')} disabled={selectedIds.size === 0 || isGenerating} loading={isGenerating}>
-          Generate Badge ({selectedIds.size})
+        <Checkbox
+          label="Hide inactive"
+          checked={hideInactive}
+          onChange={(e) => setHideInactive(e.currentTarget.checked)}
+        />
+        <Button onClick={() => generate('badge')} disabled={selectedVisible.length === 0 || isGenerating} loading={isGenerating}>
+          Generate Badge ({selectedVisible.length})
         </Button>
-        <Button color="grape" onClick={() => generate('sticker')} disabled={selectedIds.size === 0 || isGenerating} loading={isGenerating}>
-          Generate Sticker ({selectedIds.size})
+        <Button color="grape" onClick={() => generate('sticker')} disabled={selectedVisible.length === 0 || isGenerating} loading={isGenerating}>
+          Generate Sticker ({selectedVisible.length})
         </Button>
       </Group>
 
       <DataTable
         columns={columns}
-        rows={participants}
+        rows={visible}
         getRowKey={(p) => p.id}
         loading={loading}
         emptyMessage="No participants found."


### PR DESCRIPTION
Fixes #1626

Adds a **"Hide inactive"** checkbox (Mantine `<Checkbox>`, `useState(true)` — the issue says defaults on) to the existing `<Group>` beside the search box on `/facility-ops/print-badges`, following the pattern at `program-ops/events/page.tsx:61-65`.

The predicate is `p.isMember`, already on every row from `/api/people/search` (`route.ts:108`, `personRecordIsActiveOrgMember`). No new helper, no new server call.

## The bug the obvious version ships

`participants` is read in **five** places on this page. A filter that reaches only the table's `rows=` corrupts the other four:

| line | read | left unfiltered |
|---|---|---|
| 71 | `selectedIds.size === participants.length` (toggleAll) | select-all takes the wrong branch |
| 74 | `new Set(participants.map(...))` | select-all silently selects hidden people |
| 83 | `participants.filter(p => selectedIds.has(p.id))` | **the PDF still contains the hidden people** |
| 133 | header checkbox `checked=` | never reaches checked |
| 193 | `rows={participants}` | the one obvious site |

Line 83 is the real defect: select everyone, *then* tick "Hide inactive", and the badges still print for people the operator can no longer see. The button counts would lie about it too.

## The fix

One derived list, every read repointed:

```ts
const visible = hideInactive ? participants.filter(p => p.isMember) : participants;
const selectedVisible = visible.filter(p => selectedIds.has(p.id));
```

- `rows=`, select-all's new set → `visible`
- the generate guard, the badge payload, both button labels and both `disabled` props → `selectedVisible`
- `toggleAll` and the header checkbox → `selectedVisible.length === visible.length`, **not** `selectedIds.size === visible.length` — `selectedIds` can still hold hidden people, so comparing its size leaves the header checkbox unreachable and `toggleAll` on the wrong branch.

`selectedIds` is deliberately **not** pruned in a `useEffect` when the filter flips: more machinery, a state-sync bug class, and it destroys the selection when the operator toggles the filter back off. Hidden ids are inert while hidden.

`DataTable` is untouched — it has 7 consumers and already renders `emptyMessage` for an empty `rows`. Filtering is the caller's job.

## Tests — red then green

`checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx`, two new cases:

1. the checkbox renders **checked by default**, a row with `isMember: false` is absent, unchecking reveals it;
2. **the one that matters** — with the filter off, click select-all, tick "Hide inactive", assert the button reads `Generate Badge (1)` not `(2)`, plus the sticker button and the select-all checkbox state.

Proven red against a naive `rows`-only implementation (same checkbox, same `rows` filter, the other four reads left alone):

```
✕ drops hidden people from the selection count, so the PDF matches the button
  Unable to find an accessible element with the role "button" and name "Generate Badge (1)"
  ...
  Name "Generate Badge (2)":
```

— one visible row, button says 2. Green with this PR: 5/5 in that suite.

The two pre-existing fixtures are both `isMember: true`, so the default-on filter does not disturb the three existing tests.

Full local run on this branch: **tsc 0 errors, lint clean, 278 suites / 2712 unit tests passing** (baseline `origin/main` is 278 / 2710 — the two new cases are the delta). Integration suite unaffected and unchanged: no server, route, or schema code is touched.

## Scope

- `checkin-app/src/app/facility-ops/print-badges/page.tsx` and its test — nothing else.
- `checkin-app/src/security/**` diff is empty.
- Does **not** touch `BadgeDocument.tsx` or the `badgesWithQr` payload object literal (`page.tsx:96-98`), which #1627/#1629 owns. The nearest hunk here ends 5 lines above it.
- Does **not** touch name derivation — that is #1625.
- Known limitation, unchanged by this PR: `/api/people/search` still caps at `take: 200` ordered by descending id, so this filters the 200 rows that came back rather than fetching 200 members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier