### PR TITLE
fix(badges): plain printed badge — no cut guides, no role pills (#1627, #1629)

### DIFF
--- a/checkin-app/src/app/facility-ops/print-badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/page.tsx
@@ -90,12 +90,10 @@ export default function PrintBadgesPage() {
             margin: 1,
             color: { dark: '#000000', light: '#FFFFFF' }
           });
+          // `name` feeds both documents: BadgeDocument disambiguates it, StickerDocument prints it raw.
           return {
             id: p.id,
             name: p.name ?? '',
-            isMember: !!p.isMember,
-            isBoardMember: !!p.isBoardMember,
-            isKeyholder: !!p.isKeyholder,
             qrDataUri,
           };
         })

--- a/checkin-app/src/components/admin/BadgeDocument.tsx
+++ b/checkin-app/src/components/admin/BadgeDocument.tsx
@@ -35,7 +35,6 @@ const styles = StyleSheet.create({
     badge: {
         width: '3.5in',
         height: '2.25in',
-        border: '1px dashed #cccccc', // Faint dashed line to help with cutting if not using perforated sheets
         padding: '0.2in',
         display: 'flex',
         flexDirection: 'column',
@@ -45,7 +44,6 @@ const styles = StyleSheet.create({
     badgeBack: {
         width: '3.5in',
         height: '2.25in',
-        border: '1px dashed #cccccc',
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
@@ -74,24 +72,6 @@ const styles = StyleSheet.create({
         fontSize: 22,
         textAlign: 'center',
     },
-    roleContainer: {
-        flexDirection: 'row',
-        justifyContent: 'center',
-        alignItems: 'center',
-        gap: 6,
-        marginTop: 10,
-    },
-    rolePill: {
-        backgroundColor: '#4ade80', // green
-        paddingVertical: 4,
-        paddingHorizontal: 8,
-        borderRadius: 4,
-    },
-    roleText: {
-        fontFamily: 'Roboto-Bold',
-        fontSize: 10,
-        color: '#fff',
-    },
     logo: {
         width: 150,
         height: 71, // source 1198x568 ≈ 2.11:1
@@ -111,9 +91,6 @@ const styles = StyleSheet.create({
 interface ParticipantBadge {
     id: number;
     name: string;
-    isMember: boolean;
-    isBoardMember: boolean;
-    isKeyholder: boolean;
     qrDataUri: string;
 }
 
@@ -172,19 +149,6 @@ export default function BadgeDocument({ badges }: { badges: ParticipantBadge[] }
 
                                     <View style={styles.nameContainer}>
                                         <Text style={styles.nameText}>{displayNames.get(badge.id) || `User #${badge.id}`}</Text>
-                                    </View>
-
-                                    <View style={styles.roleContainer}>
-                                        {badge.isBoardMember && (
-                                            <View style={{ ...styles.rolePill, backgroundColor: '#3b82f6' }}>
-                                                <Text style={styles.roleText}>BOARD</Text>
-                                            </View>
-                                        )}
-                                        {badge.isKeyholder && (
-                                            <View style={{ ...styles.rolePill, backgroundColor: '#f59e0b' }}>
-                                                <Text style={styles.roleText}>KEYHOLDER</Text>
-                                            </View>
-                                        )}
                                     </View>
                                 </View>
                             ))}

--- a/checkin-app/src/components/admin/__tests__/BadgeDocument.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/BadgeDocument.test.tsx
@@ -20,13 +20,13 @@ jest.mock("@react-pdf/renderer", () => ({
 }));
 
 describe("BadgeDocument", () => {
-  it("renders names, role pills, and chunks front/back pages of 8", () => {
+  it("renders names without role pills, and chunks front/back pages of 8", () => {
+    // Every fixture row carries both role flags, so a pill that came back would render.
     const badges = Array.from({ length: 9 }, (_, i) => ({
       id: i + 1,
       name: `Person ${i + 1}`,
-      isMember: true,
-      isBoardMember: i === 0,
-      isKeyholder: i === 1,
+      isBoardMember: true,
+      isKeyholder: true,
       qrDataUri: `data:image/png;base64,QR${i}`,
     }));
 
@@ -34,8 +34,8 @@ describe("BadgeDocument", () => {
 
     expect(screen.getByText("Person 1")).toBeInTheDocument();
     expect(screen.getByText("Person 9")).toBeInTheDocument();
-    expect(screen.getByText("BOARD")).toBeInTheDocument();
-    expect(screen.getByText("KEYHOLDER")).toBeInTheDocument();
+    expect(screen.queryByText("BOARD")).toBeNull();
+    expect(screen.queryByText("KEYHOLDER")).toBeNull();
     expect(screen.getByText("ID: 1")).toBeInTheDocument();
     expect(screen.getByText("ID: 9")).toBeInTheDocument();
     expect(screen.getAllByText(/^\d{4}-\d{4}$/).length).toBeGreaterThan(0);


### PR DESCRIPTION
Fixes #1627
Fixes #1629

Two deletions to the same file, shipped together because they interleave inside `BadgeDocument.tsx` and both mean the same thing: the printed badge gets plainer.

## #1627 — the dashed cut guides

Deleted `border: '1px dashed #cccccc'` from `styles.badge` and `styles.badgeBack`. The badges print on pre-cut Avery 5390 stock, so the guide can only ever be a line that doesn't line up.

**There is no print stylesheet to scope this to.** The page has no `@media print`, no `@page`, no `window.print()` — it builds a PDF with `@react-pdf/renderer` and downloads it (`print-badges/page.tsx:104-117`). The PDF *is* the print artifact, and `@react-pdf/renderer` has no media-query mechanism, so a print-only rule is not merely unwise here, it is impossible. `BadgeDocument` is never mounted into the DOM — its only call site is `pdf(doc).toBlob()` — so nothing on screen depended on the border either.

In-repo precedent for the same decision: `StickerDocument.tsx:39-40` already carries this exact border commented out.

The border also applied to the blank filler slots (`styles.badge` on the empty `View`s), so a partially-filled sheet no longer prints empty dashed rectangles.

Layout is unaffected: Yoga uses a border-box model, so the explicit `3.5in × 2.25in` footprint is unchanged — two badges still tile exactly inside the `8.5in − 2 × 0.75in = 7in` content box. (Proof that it was border-box already: if it weren't, each badge would exceed 3.5in today and `flexWrap` would already be pushing one badge per row in production. It isn't.)

## #1629 — the role pills, front face only

The printed front keeps exactly three things: the Treehouse logo/wordmark (a single PNG that is both the mark and the name), the membership year, and the person's name. Removed:

- the BOARD pill and the KEYHOLDER pill
- the `roleContainer` that held them
- the now-dead `roleContainer` / `rolePill` / `roleText` style keys (ESLint does not flag unused `StyleSheet.create` keys, so they would have rotted silently)
- `isBoardMember` / `isKeyholder` from the `ParticipantBadge` interface and from the `badgesWithQr` payload, plus `isMember`, which was declared on the interface and read nowhere

### This changes every badge, not just role-holders

Worth stating plainly so it doesn't read as an unrelated regression: today a person with **neither** role still renders an empty flex row, contributing its `marginTop: 10` — 10pt of dead space at the bottom — so their name sits slightly high. Board and keyholder badges push the name higher still. With `roleContainer` gone, `flex: 1` on the name container absorbs the space and **every** badge centres identically. That is the intended result, and it is a visible change to the majority case.

### Not touched, deliberately

- **The back face.** The QR code and the `ID: n` label under it stay. The QR is the check-in mechanism — `client/badge.py` posts the scanned participant id, and the QR payload is exactly `p.id.toString()`. The `ID: n` label is the human-readable fallback when a scan fails. All three items in the issue's whitelist are front-face elements.
- **The on-screen Roles column** on `/facility-ops/print-badges`. The operator still needs to see who is who while selecting people to print; the issue is about the printed artifact. `ParticipantRow` keeps all three flags for that reason.
- **`StickerDocument`.** `print-badges/page.tsx:105-106` passes the *same* `badgesWithQr` array to both documents, and `StickerDocument.tsx:89` prints `badge.name` raw. `name` is therefore retained on the payload with a comment saying so — narrowing it away would have silently changed what stickers print.

## Tests

`BadgeDocument.test.tsx` had `getByText("BOARD")` / `getByText("KEYHOLDER")` asserting the pills were present. Those two assertions are inverted to `queryByText(...)` → `toBeNull()`, against a fixture where **both** flags are true on **all nine** rows, so any pill that came back would render. The name, `ID: n`, membership-year and 4-page chunking assertions are unchanged.

Red → green, both from this branch:

- inverted assertions against the old component → `● BadgeDocument › renders names without role pills…` / `TestingLibraryElementError: Found multiple elements with the text: BOARD` — 1 failed, 1 passed
- after the component change → `Test Suites: 3 passed`, `Tests: 5 passed` (`BadgeDocument`, `StickerDocument`, `print-badges/page`)

### #1627 gets no automated test, on purpose

There is no CSS and no DOM to assert against. `StyleSheet.create` is mocked to the identity function in the test file and the `styles` object is module-private, so the only way to assert "`styles.badge` has no `border`" is to export the styles object *solely for the test* — a test that restates the implementation, can only be written by damaging the module's API, and still cannot catch the actual failure mode, which is a dashed line landing 2mm off an Avery edge. Same for geometry generally: no jest assertion can verify the badge still fits 3.5in × 2.25in or that the name re-centres.

**Manual acceptance steps** (the real verification for #1627 — it needs a human and a printer):

1. Go to `/facility-ops/print-badges` and select **≥ 9 people, including at least one board member and one keyholder**. Nine forces a second page, which exercises the chunking and the blank filler slots.
2. Click **Generate Badge** and open the downloaded PDF.
3. Confirm: no dashed rectangles anywhere, front or back, **including the blank slots on page 2's front**; no BOARD/KEYHOLDER pills; each badge shows the logo, the year and one vertically centred name; the back still shows the QR and `ID: n`, still mirrored to the opposite column.
4. Print one sheet on Avery 5390 stock and confirm alignment is unchanged.

## Verification

Run in a fresh worktree off `origin/main` (`ab339d13`) with a root-level `npm ci` on Node 24.18.0:

| Check | Result |
|---|---|
| `tsc --noEmit` | 0 errors |
| `npm run lint` | clean (`--max-warnings 0`) |
| `npm run test:ci` | 278 suites / 2710 tests passed — identical to the clean `origin/main` baseline |
| `npm run test:integration` | 136 suites / 1462 tests passed |

`git diff -- checkin-app/src/security/` is empty. No route, schema or migration changes.

## Scope notes

- No overlap with #1626, which is in flight on the same page: the only edit here to `print-badges/page.tsx` is the `badgesWithQr` mapping (~lines 93-98). The selection logic, the table columns and the button group are untouched.
- #1628 will make the membership year on the front conditional and lands on the same interface. Adding a field is a merge-conflict surface, not a dependency — this PR is intentionally first because it shrinks the file everything else has to edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
