### PR TITLE
fix(print-badges): resolve badge names against the active membership

### DIFF
--- a/checkin-app/src/__tests__/badgeDisplayNames.test.ts
+++ b/checkin-app/src/__tests__/badgeDisplayNames.test.ts
@@ -25,4 +25,23 @@ describe('computeDisplayNames', () => {
     it('shows bare first name for the entry lacking a last name; others disambiguate around it', () => {
         expect(run(['John', 'John Smith'])).toEqual(['John', 'John S.']);
     });
+
+    it('disambiguates against the cohort, not the printed batch', () => {
+        const cohort = [
+            { id: 1, name: 'John Smith' },
+            { id: 2, name: 'John Doe' },
+            { id: 3, name: 'Jane Roe' },
+        ];
+        // One badge printed alone still reads as it does when the whole cohort is printed.
+        expect(computeDisplayNames([cohort[0]], cohort).get(1)).toBe('John S.');
+        expect(computeDisplayNames(cohort, cohort).get(1)).toBe('John S.');
+        // A cohort member with a unique first name keeps the bare first name.
+        expect(computeDisplayNames([cohort[2]], cohort).get(3)).toBe('Jane');
+    });
+
+    it('disambiguates a non-cohort subject against the cohort', () => {
+        const cohort = [{ id: 1, name: 'John Smith' }];
+        // A guest badge (not an active member) still has to be distinguishable from the members.
+        expect(computeDisplayNames([{ id: 9, name: 'John Doe' }], cohort).get(9)).toBe('John D.');
+    });
 });

--- a/checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx
@@ -40,10 +40,18 @@ const withInactive = [
   { id: 3, name: "Lapsed Larry", email: "larry@example.com", isMember: false },
 ];
 
+// The active membership — wider than what the search returns, and the only thing badge names
+// may depend on. Kim Kowalski is a member who is NOT in the search results above.
+const orgMembers = [
+  { id: 1, name: "Kim Keyholder" },
+  { id: 2, name: "Bo Board" },
+  { id: 4, name: "Kim Kowalski" },
+];
+
 describe("facility-ops/print-badges page", () => {
   it("loads and renders the participant roster", async () => {
     setSession({ id: 1, isSysadmin: true });
-    mockFetchJson({ "/api/people/search": { people: participants } });
+    mockFetchJson({ "/api/people/search": { people: participants }, "/api/shop/org-members": { orgMembers } });
     renderWithProviders(<PrintBadgesPage />);
 
     expect(await screen.findByText("Kim Keyholder")).toBeInTheDocument();
@@ -54,7 +62,7 @@ describe("facility-ops/print-badges page", () => {
 
   it("re-searches participants as the search box changes", async () => {
     setSession({ id: 1, isSysadmin: true });
-    const fetchMock = mockFetchJson({ "/api/people/search": { people: participants } });
+    const fetchMock = mockFetchJson({ "/api/people/search": { people: participants }, "/api/shop/org-members": { orgMembers } });
     renderWithProviders(<PrintBadgesPage />);
     await screen.findByText("Kim Keyholder");
 
@@ -65,9 +73,35 @@ describe("facility-ops/print-badges page", () => {
     );
   });
 
+  it("shows the badge name resolved against the whole active membership, not the listed rows", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/people/search": { people: participants }, "/api/shop/org-members": { orgMembers } });
+    renderWithProviders(<PrintBadgesPage />);
+
+    // Kim collides with Kim Kowalski, who is a member but not on screen — the badge still needs
+    // the last initial. Bo is unique in the membership, so a bare first name.
+    expect(await screen.findByText("Kim Ke.")).toBeInTheDocument();
+    expect(screen.getByText("Bo")).toBeInTheDocument();
+  });
+
+  it("holds badge generation until the member roster has loaded", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    // No org-members route: the roster never resolves, so a badge would carry an unresolved name.
+    // The page logs that failure, which jest-fail-on-console would otherwise treat as a defect.
+    const logged = jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetchJson({ "/api/people/search": { people: participants } });
+    renderWithProviders(<PrintBadgesPage />);
+    await screen.findByText("Kim Keyholder");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select all" }));
+    expect(screen.getByRole("button", { name: "Generate Badge (2)" })).toBeDisabled();
+    await waitFor(() => expect(logged).toHaveBeenCalled());
+    logged.mockRestore();
+  });
+
   it("selects participants and generates a badge PDF", async () => {
     setSession({ id: 1, isSysadmin: true });
-    mockFetchJson({ "/api/people/search": { people: participants } });
+    mockFetchJson({ "/api/people/search": { people: participants }, "/api/shop/org-members": { orgMembers } });
     renderWithProviders(<PrintBadgesPage />);
     await screen.findByText("Kim Keyholder");
 
@@ -81,7 +115,7 @@ describe("facility-ops/print-badges page", () => {
 
   it("hides inactive people by default and reveals them when unchecked", async () => {
     setSession({ id: 1, isSysadmin: true });
-    mockFetchJson({ "/api/people/search": { people: withInactive } });
+    mockFetchJson({ "/api/people/search": { people: withInactive }, "/api/shop/org-members": { orgMembers } });
     renderWithProviders(<PrintBadgesPage />);
     await screen.findByText("Kim Keyholder");
 
@@ -95,7 +129,7 @@ describe("facility-ops/print-badges page", () => {
 
   it("drops hidden people from the selection count, so the PDF matches the button", async () => {
     setSession({ id: 1, isSysadmin: true });
-    mockFetchJson({ "/api/people/search": { people: withInactive } });
+    mockFetchJson({ "/api/people/search": { people: withInactive }, "/api/shop/org-members": { orgMembers } });
     renderWithProviders(<PrintBadgesPage />);
     await screen.findByText("Kim Keyholder");
 

--- a/checkin-app/src/app/facility-ops/print-badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import QRCode from "qrcode";
@@ -10,6 +10,7 @@ import { notifications } from "@mantine/notifications";
 import { DataTable, type DataTableColumn } from "@/components/admin/DataTable";
 import BadgeDocument from "@/components/admin/BadgeDocument";
 import StickerDocument from "@/components/admin/StickerDocument";
+import { computeDisplayNames } from "@/components/admin/badgeNames";
 
 type ParticipantRow = {
   id: number;
@@ -25,6 +26,9 @@ export default function PrintBadgesPage() {
   const router = useRouter();
 
   const [participants, setParticipants] = useState<ParticipantRow[]>([]);
+  // The active membership, which is what badge names are disambiguated against. `null` until it
+  // loads: printing before then would stamp names computed against an empty cohort.
+  const [memberCohort, setMemberCohort] = useState<{ id: number; name: string }[] | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [hideInactive, setHideInactive] = useState(true);
@@ -61,6 +65,36 @@ export default function PrintBadgesPage() {
     }
   }, [status, fetchParticipants]);
 
+  // Cohort is search-independent, so it loads once rather than per keystroke.
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/shop/org-members');
+        if (!res.ok) throw new Error(`org-members responded ${res.status}`);
+        const data = await res.json();
+        if (!cancelled) setMemberCohort(data.orgMembers ?? []);
+      } catch (e) {
+        console.error("Failed to load the active member roster:", e);
+        notifications.show({
+          color: 'red',
+          message: 'Could not load the active member roster, so badge names cannot be resolved. Reload to retry.',
+          autoClose: false,
+        });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [status]);
+
+  const displayNames = useMemo(
+    () => computeDisplayNames(
+      participants.map(p => ({ id: p.id, name: p.name ?? '' })),
+      (memberCohort ?? []).map(m => ({ id: m.id, name: m.name ?? '' })),
+    ),
+    [participants, memberCohort],
+  );
+
   const toggleSelection = (id: number) => {
     const newSet = new Set(selectedIds);
     if (newSet.has(id)) newSet.delete(id);
@@ -83,6 +117,8 @@ export default function PrintBadgesPage() {
 
   const generate = async (kind: 'badge' | 'sticker') => {
     if (selectedVisible.length === 0) return;
+    // Badges carry the disambiguated name; stickers carry the full one, so only badges need the cohort.
+    if (kind === 'badge' && !memberCohort) return;
     setIsGenerating(true);
 
     try {
@@ -94,10 +130,12 @@ export default function PrintBadgesPage() {
             margin: 1,
             color: { dark: '#000000', light: '#FFFFFF' }
           });
-          // `name` feeds both documents: BadgeDocument disambiguates it, StickerDocument prints it raw.
+          // StickerDocument prints `name` raw; BadgeDocument prints `displayName`, the one
+          // disambiguated against the active membership.
           return {
             id: p.id,
             name: p.name ?? '',
+            displayName: displayNames.get(p.id) ?? '',
             qrDataUri,
           };
         })
@@ -152,6 +190,12 @@ export default function PrintBadgesPage() {
       render: (p) => <Text fw={600}>{p.name || 'N/A'}</Text>,
     },
     {
+      header: 'Badge name',
+      render: (p) => (memberCohort
+        ? <Text>{displayNames.get(p.id) || `User #${p.id}`}</Text>
+        : <Text c="dimmed">—</Text>),
+    },
+    {
       header: 'Membership',
       render: (p) => (p.isMember ? <Text c="green">Active</Text> : <Text c="red">Inactive</Text>),
     },
@@ -187,7 +231,7 @@ export default function PrintBadgesPage() {
           checked={hideInactive}
           onChange={(e) => setHideInactive(e.currentTarget.checked)}
         />
-        <Button onClick={() => generate('badge')} disabled={selectedVisible.length === 0 || isGenerating} loading={isGenerating}>
+        <Button onClick={() => generate('badge')} disabled={selectedVisible.length === 0 || isGenerating || !memberCohort} loading={isGenerating}>
           Generate Badge ({selectedVisible.length})
         </Button>
         <Button color="grape" onClick={() => generate('sticker')} disabled={selectedVisible.length === 0 || isGenerating} loading={isGenerating}>

--- a/checkin-app/src/components/admin/BadgeDocument.tsx
+++ b/checkin-app/src/components/admin/BadgeDocument.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo } from 'react';
 import { Document, Page, Text, View, StyleSheet, Image, Font } from '@react-pdf/renderer';
-import { computeDisplayNames, membershipYearLabel } from './badgeNames';
+import { membershipYearLabel } from './badgeNames';
 
 // Font registration for a modern sans-serif look
 Font.register({
@@ -90,12 +90,13 @@ const styles = StyleSheet.create({
 
 interface ParticipantBadge {
     id: number;
-    name: string;
+    // The name as printed, already disambiguated against the active membership by the caller
+    // (computeDisplayNames) — not against this batch, so a badge reads the same on every reprint.
+    displayName: string;
     qrDataUri: string;
 }
 
 export default function BadgeDocument({ badges }: { badges: ParticipantBadge[] }) {
-    const displayNames = useMemo(() => computeDisplayNames(badges), [badges]);
     const yearLabel = useMemo(() => membershipYearLabel(new Date()), []);
 
     // We chunk the badges into arrays of 8, because Avery 5390 takes 8 per page
@@ -148,7 +149,7 @@ export default function BadgeDocument({ badges }: { badges: ParticipantBadge[] }
                                     </View>
 
                                     <View style={styles.nameContainer}>
-                                        <Text style={styles.nameText}>{displayNames.get(badge.id) || `User #${badge.id}`}</Text>
+                                        <Text style={styles.nameText}>{badge.displayName || `User #${badge.id}`}</Text>
                                     </View>
                                 </View>
                             ))}

--- a/checkin-app/src/components/admin/__tests__/BadgeDocument.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/BadgeDocument.test.tsx
@@ -24,7 +24,7 @@ describe("BadgeDocument", () => {
     // Every fixture row carries both role flags, so a pill that came back would render.
     const badges = Array.from({ length: 9 }, (_, i) => ({
       id: i + 1,
-      name: `Person ${i + 1}`,
+      displayName: `Person ${i + 1}`,
       isBoardMember: true,
       isKeyholder: true,
       qrDataUri: `data:image/png;base64,QR${i}`,

--- a/checkin-app/src/components/admin/badgeNames.ts
+++ b/checkin-app/src/components/admin/badgeNames.ts
@@ -9,38 +9,47 @@ export function membershipYearLabel(now: Date): string {
     return `${startYear}-${startYear + 1}`;
 }
 
-// First name only, adding the minimum last-name prefix needed to disambiguate within this batch.
+type NamedPerson = { id: number; name: string };
+
+// First name only, adding the minimum last-name prefix needed to disambiguate within `cohort`.
 // Unique first name → first name alone. Collision → shortest prefix (1+ chars) that no other
-// same-first-name badge shares; a partial prefix gets a trailing "." (e.g. "John S.", "John Sm.").
+// same-first-name person shares; a partial prefix gets a trailing "." (e.g. "John S.", "John Sm.").
 // True duplicates (identical full name) fall back to the full last name.
-export function computeDisplayNames(badges: { id: number; name: string }[]): Map<number, string> {
+//
+// `cohort` is the population a name has to be unique against — the active membership, not the
+// batch being printed. A person's badge must read the same whether they are printed alone or
+// alongside the whole roster, so each subject is resolved against the cohort (minus itself) and
+// never against its fellow subjects.
+export function computeDisplayNames(
+    subjects: NamedPerson[],
+    cohort: NamedPerson[] = subjects,
+): Map<number, string> {
     const parse = (full: string) => {
         const parts = (full || '').trim().split(/\s+/);
         return { first: parts[0] || '', last: parts.slice(1).join(' ') };
     };
-    const parsed = badges.map(b => ({ id: b.id, ...parse(b.name) }));
-    const groups = new Map<string, typeof parsed>();
-    for (const p of parsed) {
-        const key = p.first.toLowerCase();
-        (groups.get(key) ?? groups.set(key, []).get(key)!).push(p);
+    const groups = new Map<string, { id: number; last: string }[]>();
+    for (const c of cohort) {
+        const { first, last } = parse(c.name);
+        const key = first.toLowerCase();
+        (groups.get(key) ?? groups.set(key, []).get(key)!).push({ id: c.id, last });
     }
     const result = new Map<number, string>();
-    for (const group of groups.values()) {
-        for (const p of group) {
-            if (group.length === 1 || !p.last) {
-                result.set(p.id, p.first || `User #${p.id}`);
-                continue;
-            }
-            const others = group.filter(o => o !== p);
-            let len = 1;
-            while (len < p.last.length &&
-                others.some(o => o.last.slice(0, len).toLowerCase() === p.last.slice(0, len).toLowerCase())) {
-                len++;
-            }
-            const prefix = p.last.slice(0, len);
-            const abbreviated = prefix.length < p.last.length;
-            result.set(p.id, `${p.first} ${prefix}${abbreviated ? '.' : ''}`);
+    for (const s of subjects) {
+        const { first, last } = parse(s.name);
+        const others = (groups.get(first.toLowerCase()) ?? []).filter(o => o.id !== s.id);
+        if (others.length === 0 || !last) {
+            result.set(s.id, first || `User #${s.id}`);
+            continue;
         }
+        let len = 1;
+        while (len < last.length &&
+            others.some(o => o.last.slice(0, len).toLowerCase() === last.slice(0, len).toLowerCase())) {
+            len++;
+        }
+        const prefix = last.slice(0, len);
+        const abbreviated = prefix.length < last.length;
+        result.set(s.id, `${first} ${prefix}${abbreviated ? '.' : ''}`);
     }
     return result;
 }


### PR DESCRIPTION
## What changed

A badge's printed name was computed over whichever people happened to be in the batch being printed (`computeDisplayNames(badges)` inside `BadgeDocument`). The same person therefore got a different name depending on who was printed alongside them: **"Kim"** when printed alone, **"Kim Ke."** when printed next to Kim Kowalski. A reprint could contradict the badge already clipped to somebody's shirt.

Disambiguation now runs against the **active membership** — the population a badge name has to be unique within — and never against the batch.

- `computeDisplayNames(subjects, cohort = subjects)` resolves each subject against the cohort **minus itself** (matched by id), so a person printed alone and the whole roster printed at once yield the same name. Default argument keeps the single-argument call sites behaving exactly as before.
- The print-badges page loads that cohort once from `GET /api/shop/org-members` — already the active-org-member roster, and both `isSysadmin` and `isBoardMember` hold the full view, which is exactly the gate on `/facility-ops`. No new route, so no security-registry change.
- Badge generation is held until the cohort arrives, rather than silently stamping names computed against an empty cohort. A failed roster load logs and notifies instead of printing wrong names.
- The resolved name is exposed as a **"Badge name" column** on the screen — the proof asked for in the issue, and the same value the PDF prints.
- `BadgeDocument` takes `displayName` as given instead of recomputing it, so the column and the PDF are one computation rather than two that can drift.

Stickers are deliberately unchanged: they carry the full name, not the disambiguated one.

## Why

Fixes #1625. The issue is two parts — (1) the name must depend only on the active membership, not on who is being printed right now, and (2) surface the final name as a column as proof. Both are here.

## Reviewer notes

- The cohort universe is `ACTIVE_ORG_MEMBER_PERSON_WHERE` (household membership `ACTIVE`), matching how the page's own Membership column derives `isMember`. Someone printable but not an active member (a guest badge) is still disambiguated *against* that cohort, so their name stays distinguishable from any member's — and stays a pure function of themselves plus the roster.
- `/api/people/search` caps at 200 rows, which is part of why the old batch-scoped computation could never be stable; the cohort fetch does not go through that route.
- #1634 also edits this page (hides inactive rows, #1626). The changes are disjoint in intent but both touch the column list — expect a small conflict there.

## Testing

- `npx tsc --noEmit` clean; eslint clean.
- `npm test -- --testPathPatterns "print-badges|BadgeDocument|badgeDisplayNames|StickerDocument"` → 14 passed, 4 suites.
- New cases: disambiguation against the cohort rather than the printed batch; a non-cohort subject resolved against the cohort; the page showing "Kim Ke." for a collision with a member who is *not* on screen; badge generation disabled until the roster loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)