### PR TITLE
feat(schema): intake-note snapshot + acknowledgement columns on OrgMembershipProcess

### DIFF
--- a/checkin-app/prisma/migrations/20260811120000_org_membership_process_intake_note_ack/migration.sql
+++ b/checkin-app/prisma/migrations/20260811120000_org_membership_process_intake_note_ack/migration.sql
@@ -1,0 +1,14 @@
+-- Expand-only: three nullable columns and their FK. The previous release serves
+-- traffic against this schema for the whole drain window and never names these
+-- columns in a SELECT, so its reads are unaffected (rule 1).
+-- Wrapped because the columns and the constraint must land together: Prisma does
+-- not transact a migration file on Postgres (rule 5).
+BEGIN;
+
+ALTER TABLE "OrgMembershipProcess" ADD COLUMN     "intakeNoteSnapshot" TEXT,
+ADD COLUMN     "noteAckAt" TIMESTAMP(3),
+ADD COLUMN     "noteAckById" INTEGER;
+
+ALTER TABLE "OrgMembershipProcess" ADD CONSTRAINT "OrgMembershipProcess_noteAckById_fkey" FOREIGN KEY ("noteAckById") REFERENCES "Person"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+COMMIT;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -179,6 +179,7 @@ model Person {
   bgAttestations      BackgroundCheckAttestation[] @relation("BgAttestations")
   bgAttestationsAsSubject BackgroundCheckAttestation[] @relation("BgAttestationSubject")
   personBgProcesses   OrgMembershipProcess[]       @relation("PersonBgSubject")
+  intakeNoteAcks      OrgMembershipProcess[]       @relation("IntakeNoteReads")
   corporationLeads    CorporationLead[]
   corporationMembers  CorporationMember[]
   programVolunteers   ProgramVolunteer[]
@@ -517,6 +518,20 @@ model OrgMembershipProcess {
   renewalReminderSentAt DateTime?
   /// @sensitivity:internal
   isPaymentPlanRequested Boolean @default(false)
+  /// The household's intake note as submitted with this application. A snapshot, not
+  /// a live read: the household may edit or clear Household.intakeNotes afterwards,
+  /// and the audit question is what the applicant actually said. Disclosure-equivalent
+  /// to the note itself, so it carries the note's tier; deleted with the process.
+  /// @sensitivity:pii
+  intakeNoteSnapshot    String?
+  /// Who read the snapshot, and when. Staff-action audit metadata like every other
+  /// actor/stamp pair on this model (manualPaymentById, bgClearedAt) — internal, not
+  /// public: who has read a family's note is not a fact the row publishes.
+  /// @sensitivity:internal
+  noteAckById           Int?
+  noteAckBy             Person?                 @relation("IntakeNoteReads", fields: [noteAckById], references: [id])
+  /// @sensitivity:internal
+  noteAckAt             DateTime?
 
   attestations BackgroundCheckAttestation[]
 

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -98,6 +98,9 @@ export const classifications = {
         certificationNote: 'internal',
         renewalReminderSentAt: 'internal',
         isPaymentPlanRequested: 'internal',
+        intakeNoteSnapshot: 'pii',
+        noteAckById: 'internal',
+        noteAckAt: 'internal',
     },
     BackgroundCheckAttestation: {
         id: 'public',
@@ -401,6 +404,7 @@ export const relations = {
         bgAttestations: { model: 'BackgroundCheckAttestation', isList: true },
         bgAttestationsAsSubject: { model: 'BackgroundCheckAttestation', isList: true },
         personBgProcesses: { model: 'OrgMembershipProcess', isList: true },
+        intakeNoteAcks: { model: 'OrgMembershipProcess', isList: true },
         corporationLeads: { model: 'CorporationLead', isList: true },
         corporationMembers: { model: 'CorporationMember', isList: true },
         programVolunteers: { model: 'ProgramVolunteer', isList: true },
@@ -443,6 +447,7 @@ export const relations = {
     OrgMembershipProcess: {
         orgMembership: { model: 'OrgMembership', isList: false },
         subjectPerson: { model: 'Person', isList: false },
+        noteAckBy: { model: 'Person', isList: false },
         attestations: { model: 'BackgroundCheckAttestation', isList: true },
     },
     BackgroundCheckAttestation: {

--- a/docs/in-design/INTAKE_NOTE_ACKNOWLEDGEMENT.md
+++ b/docs/in-design/INTAKE_NOTE_ACKNOWLEDGEMENT.md
@@ -33,10 +33,11 @@ would not otherwise need.
   gate membership, and does not enter the background-check review. Those
   couplings were removed on purpose and this does not restore them.
 - **Cost:** three columns on the existing process record and a migration, one
-  mutation, the snapshot write at two sites, one board-facing list, **a boundary
-  PR raising `OrgMembershipProcess` to `pii` and re-clearing the four routes that
-  return it**, and the security-registry grant the list needs — the boundary work
-  shipping as its own change, before the route.
+  mutation, the snapshot write at two sites, one board-facing list, **raising
+  `OrgMembershipProcess` to `pii` and re-clearing the four routes that return
+  it — which rides with the schema change rather than a boundary PR of its own**,
+  and the security-registry grant the list needs, shipping as its own change
+  before the route.
 - **What this PR does not do:** it does not edit `docs/rules/membership.md`. The
   access rule is relaxed to its policy limit by the implementation PR, using the
   replacement text fixed below.
@@ -299,15 +300,37 @@ Three columns on `OrgMembershipProcess`, not a new model:
   /// what the applicant actually said.
   /// @sensitivity:pii
   intakeNoteSnapshot String?
-  /// @sensitivity:public
+  /// Who read the snapshot, and when. Staff-action audit metadata like every other
+  /// actor/stamp pair on this model — internal, not public: who has read a family's
+  /// note is not a fact the row publishes.
+  /// @sensitivity:internal
   noteAckById        Int?
   noteAckBy          Person?  @relation("IntakeNoteReads", fields: [noteAckById], references: [id])
-  /// @sensitivity:public
+  /// @sensitivity:internal
   noteAckAt          DateTime?
 ```
 
 `Person` gains the matching `intakeNoteAcks OrgMembershipProcess[] @relation("IntakeNoteReads")`
 back-relation; Prisma will not generate without both sides.
+
+**The acknowledgement pair is `internal`, not `public`.** It records *which
+internal actor* acknowledged and when — a workflow stamp, not member-facing data.
+Every other staff-action actor/stamp pair on this model is `internal`
+(`manualPaymentById`, `bgClearedAt`, `contractSignedAt`, `paidAt`,
+`renewalReminderSentAt`); what is `public` on `OrgMembershipProcess` is the row's
+own identity and shape (`id`, `kind`, `orgMembershipId`, `subjectPersonId`,
+`createdAt`). `SECURITY-POLICY.md`'s tier table puts this in `internal` by name:
+*"Role/audit metadata."* The repo also carries the alternative going wrong —
+`BackgroundCheckAttestation.reviewerId` is `public`, and `registry.ts` has to
+defend against it at the route because it *"would tell reviewer B that reviewer A
+already signed off"*. "Who has read this family's note" is the same shape of fact,
+and `internal` is strictly narrower than `public`, so it widens nothing this
+design contemplated.
+
+The tier is load-bearing downstream rather than a detail: it is what makes the
+board list's registry entry need `everyones:internal` **alongside**
+`everyones:pii`, to render "acknowledged by X at T". Read as `public`, that entry
+would appear to need the `pii` band alone.
 
 Snapshotting at submit rather than acknowledging a live string is what makes the
 record answerable a week later. It settles two questions outright — there is no
@@ -411,10 +434,13 @@ re-cleared against the new tier:
 | `GET /api/membership/reviews` | `everyones:pii`, `member`, `public` |
 | `GET /api/finance-ops/membership-payment-plans` | `everyones:pii` and below |
 
-That, plus regenerating `src/security/generated/classifications.ts`, is a
-boundary change, and AGENTS.md's boundary-isolation rule ships it **in its own
-PR** with no feature code. The previous revision's Cost budgeted the new list's
-registry grant and not this; it is priced below.
+That re-clearing, plus regenerating `src/security/generated/classifications.ts`,
+**rides with the schema change rather than shipping in its own PR**:
+`security-boundary-isolation.yml` excludes
+`checkin-app/src/security/generated/*` from `is_boundary()`, and annotating new
+columns is not the re-tier of an existing field that its only other trigger looks
+for. The previous revision's Cost budgeted the new list's registry grant and not
+this re-clearing; it is priced below.
 
 **The argument that keeps the note narrow today does not transfer, and this
 paragraph exists so the next person finds that out from the doc rather than the
@@ -514,11 +540,14 @@ it. 1 and 3 are now answered; only 2 is open.
   `orgMembershipProcess.update` in `submitIntake`; in `beginRenewal`, a new read
   of the household's note plus a write placed inside the existing conditional
   `updateMany`, with the byte-identical skip at both.
-- **The boundary PR that raises `OrgMembershipProcess`'s ceiling to `pii`.**
-  Re-clear the four registered routes that return the model against the new tier
-  and regenerate `src/security/generated/classifications.ts`. Ships alone, no
-  feature code, per AGENTS.md's boundary-isolation rule. **The previous revision
-  missed this item entirely.**
+- **Raising `OrgMembershipProcess`'s ceiling to `pii` — which rides with the
+  schema change rather than shipping alone.** Re-clear the four registered routes
+  that return the model against the new tier and regenerate
+  `src/security/generated/classifications.ts`. There is no separate boundary PR:
+  `security-boundary-isolation.yml` excludes
+  `checkin-app/src/security/generated/*` from `is_boundary()`, and its only other
+  trigger is a re-tier of an existing field, which annotating new columns is not.
+  **The previous revision missed this item entirely.**
 - One board-facing list route and screen.
 - **The security-registry grant for that list, as its own change, merged before
   the route.** The registry carries an explicit guard against granting a
@@ -528,9 +557,9 @@ it. 1 and 3 are now answered; only 2 is open.
 - **The two `docs/rules/membership.md` amendments, in the implementation PR** —
   text fixed above, so this is transcription rather than a decision.
 
-Both boundary items above are boundary-only and may ship as one PR or two; what
-AGENTS.md fixes is that no feature code rides along, and that the registry entry
-lands before the route that uses it.
+The registry grant is the only boundary item above; what AGENTS.md fixes is that
+no feature code rides along, and that the registry entry lands before the route
+that uses it.
 
 No cutover: nothing in flight is held, and no existing row needs moving. Per §4.2
 there is no migration document, because nothing here expires on a nameable date.


### PR DESCRIPTION
Schema half of the intake-note acknowledgement design — `docs/in-design/INTAKE_NOTE_ACKNOWLEDGEMENT.md` (#1525, merged). Three nullable columns and the `Person` back-relation, so the snapshot write sites and the board-facing list can be built. **Nothing writes or reads them yet**; the app-code half lands separately.

## This is not a boundary PR, and that is a mechanical result

The design's Cost section budgets "the boundary PR that raises `OrgMembershipProcess`'s ceiling to `pii`", shipping alone per the AGENTS.md boundary-isolation rule. Read against the workflow, that PR does not exist: **there is no boundary file to isolate.**

`.github/workflows/security-boundary-isolation.yml` decides this in two places.

**1. The generated classifications file is explicitly *not* a boundary file.** `is_boundary()` returns false for it before any other case is tried:

```
checkin-app/src/security/generated/*) return 1 ;;
```

**2. The only other trigger is a RE-TIER, which this is not.** The workflow re-reads the classifications diff and pairs removed `field: 'tier'` lines against added ones:

```
REMOVED=$(echo "$DIFF" | grep -E "^-\s+\w+: '" | ...)
ADDED=$(echo "$DIFF"   | grep -E "^\+\s+\w+: '" | ...)
```

`RETIER` is set only when the *same field name* appears on both sides with different tiers. This diff adds three lines and removes none, so `REMOVED` is empty and `RETIER` stays empty. The workflow header names this case by hand:

> Purely ADDITIVE classification changes (new models/fields from normal feature work) are exempt — **annotating a new column is not a boundary change to existing data.**

AGENTS.md agrees once read precisely: it lists "a re-tier of an existing field's `@sensitivity`" as boundary. `intakeNoteSnapshot` is not an existing field.

With no boundary file and no re-tier, `BOUNDARY_TOUCHED` is 0 and the job exits at *"No security-boundary changes in this PR — nothing to isolate."* Verified by running the job's own `is_boundary` + re-tier logic verbatim against this branch's `BASE...HEAD`:

```
BOUNDARY_FILES=[]
RETIER=[]
VERDICT: No security-boundary changes in this PR — nothing to isolate. (exit 0)
```

**The corollary matters more than the verdict.** `is_companion()` does *not* list `checkin-app/prisma/migrations/**` — only `prisma/schema.prisma`. So had this genuinely been a boundary change, the migration could not have ridden with it, and schema and migration would have had to split. Isolation is therefore not merely unnecessary here; packaging schema + migration + classifications together is the *only* shape that works, and adding any `src/security/**` edit to this PR would break it.

## Re-clearing the four routes

`docs/security/SECURITY-POLICY.md` §"Adding a field": *"Every existing view that grants `*:<that-tier>` will now expose it automatically."* Exposure is tier-driven, so re-clearing means checking each route's granted bands against what its query actually puts in the bag. All four verified against `registry.ts` and the handlers on `main`:

| Route | Granted bands | Query shape | New `pii` column on the wire? |
|---|---|---|---|
| `POST /api/membership-audit/person-agreement` | `everyones:internal`, `public` | hand-built `{id, kind, status}` literal | **No** — not in the bag, and no `pii` band to pass it |
| `GET /api/membership-ops/applications` | `everyones:pii/personal/internal`, `member`, `public` | explicit `select` (9 scalars) | **No** — not selected |
| `GET /api/membership/reviews` | `everyones:pii`, `member`, `public` | explicit `select` | **No** — not selected |
| `GET /api/finance-ops/membership-payment-plans` | `everyones:pii/personal/internal`, `member`, `public` | `include:` — **whole row** | **Yes**, once written |

No registry edit is required, and none is made. The doc's table is confirmed on the one point it flagged: `person-agreement` has no `pii` band at all, so the snapshot is stripped there outright.

The fourth row is the one the design did not anticipate. `GET /api/finance-ops/membership-payment-plans` reads with `include:` and no top-level `select`, so Prisma returns every column and the stripper — correctly — passes `intakeNoteSnapshot` under `everyones:pii`. Its audience is `anyRole: ['isSysadmin', 'isBoardMember']`, squarely inside the amended access rule, so this is authorized rather than a leak. **It is inert in this PR** (nothing writes the column), which is why it is recorded here rather than fixed here: tightening an app route would be feature code, and the exposure begins the moment the write site lands. Flagged to the app-code half.

## `internal`, not `public`, for the two acknowledgement columns

The doc sketches `@sensitivity:public` on `noteAckById` and `noteAckAt`. This ships them as `internal`.

They are a staff-action actor/timestamp pair, and every other such pair on this model is `internal` — `manualPaymentById`, `bgClearedAt`, `contractSignedAt`, `paidAt`, `renewalReminderSentAt`. What is `public` on `OrgMembershipProcess` is the row's own identity and shape (`id`, `kind`, `orgMembershipId`, `subjectPersonId`, `createdAt`). The tier table in `SECURITY-POLICY.md` puts this squarely in `internal`: *"Role/audit metadata."*

The repo also carries a live example of the alternative going wrong. `BackgroundCheckAttestation.reviewerId` is `public`, and `registry.ts` has to defend against it at the route:

> `reviewerId` is public-tier and would tell reviewer B that reviewer A already signed off, which the deliberate `_count`-only shape exists to prevent.

"Who has read this family's note" is the same shape of fact. `internal` is strictly narrower than the doc proposed, so it cannot widen anything the design contemplated.

## The migration

Ran the repo's `migration-safety` checklist against `checkin-app/docs/DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md`.

- **Rule 1, expand-only.** Three nullable columns and one FK. Nothing dropped, renamed, or tightened.
- **Rule 5, wrapped.** `BEGIN;`/`COMMIT;` — Prisma does not transact a migration file on Postgres, and the columns and their constraint must land together or the chain wedges with the columns half-present.
- **Rule 8, no index.** `noteAckById` is never a query predicate; the board list filters on `intakeNoteSnapshot IS NOT NULL AND noteAckAt IS NULL`, and the byte-identical skip filters on `orgMembershipId`, which is already indexed. Add a partial index when the list is measurably slow, not before.
- **Cross-PR timestamps.** No other open PR carries a migration (checked across every open PR's file list), so nothing interleaves with `20260811120000`.
- **Non-TS readers.** Nothing to cut over — no model or column is removed or renamed, so no shell SQL, `tableName` literal, `VOCABULARY.md` entry, or seed reference changes.
- **FK deletion behaviour.** `ON DELETE SET NULL`, matching the sibling `subjectPerson` relation. People are tombstoned rather than deleted here, so it never fires.

### The drain-window probe

Migrations complete *before* `aws ecs update-service`, so the previous release serves live traffic against the fully-migrated schema for the whole drain window. #1586 shipped a rename that broke exactly this and needed #1606 to put the physical column back. Three nullable columns should be safe — this proves it instead of asserting it.

Two Postgres 15 databases, both built to the **currently deployed release's** chain (`v1.1.1`, ending at `20260724120000_purge_adult_dob`; its 17 shared migration files verified byte-identical to `main`'s), then populated **using v1.1.1's own generated Prisma client** — households, people, a membership, a `PENDING_PAYMENT` payment-plan process and a `PERSON_BG` process:

- **A** — then migrated with everything on `origin/main`, *without* this branch.
- **B** — then migrated with `origin/main` **plus this migration**.

v1.1.1's client is byte-comparable to what v1.1.1 shipped: `prisma`/`@prisma/client` are `7.8.0` on both refs. The same client binary then ran v1.1.1's real access patterns against each database — the `include:`-with-no-select whole-row read that #1586 broke, the tight `select` read, `Person -> personBgProcesses` traversal, an `update` by id, a status-conditional `updateMany`, a `create` that names none of the new columns, and the household note write.

```
[probea] OK — v1.1.1 client reads and writes cleanly against the migrated schema
[probeb] OK — v1.1.1 client reads and writes cleanly against the migrated schema
```

A passing **A** is what makes **B** attributable: the baseline is clean, so a failure in B would have been this migration's. The old client's `SELECT` enumerates columns explicitly and names none of the three, and its `INSERT` omits them — which is only safe because all three are nullable with no default. Also asserted directly: `certifiedById` is still readable under its own name (the #1606 `@map` still holding), and the old client's result object has no `intakeNoteSnapshot` key.

## Verification

- `tsc --noEmit` — 0 errors
- `eslint --max-warnings 0` — clean
- `prisma migrate diff --from-config-datasource --to-schema` — *No difference detected* (migration reproduces the schema on an empty DB)
- `check-route-coverage --strict` — 0 errors
- Unit: **278 suites / 2726 tests** passed
- Integration: **136 suites / 1471 tests** passed

## Left for the app-code half

- **`GET /api/finance-ops/membership-payment-plans` will carry the note** the moment a write site lands — authorized (board/sysadmin) but a second board surface showing the note off-list. Tighten to a `select`, or accept it deliberately.
- **The board list's registry entry needs `everyones:internal`**, not just `everyones:pii`, to render "acknowledged by X at T" — a consequence of the `internal` tiering above. It ships registry-first, in its own boundary PR, before the route.
- **`OrgMembershipProcess` stays in `OPT_OUT_PENDING_ROUTE`** and now carries `pii`. The design's warning applies from this merge on: whoever ships the household-facing status route that set anticipates will be binding a model carrying pii.
- The two `docs/rules/membership.md` amendments, with the replacement text fixed in the design doc. Not touched here.

Design: `docs/in-design/INTAKE_NOTE_ACKNOWLEDGEMENT.md` (#1525).
