### PR TITLE
fix(facility-ops): make the Operations grant reachable — sidebar entry and a live index

### DIFF
--- a/checkin-app/src/__tests__/pageRegistry.test.ts
+++ b/checkin-app/src/__tests__/pageRegistry.test.ts
@@ -55,8 +55,8 @@ describe('Facility Ops directory agrees with the section gates', () => {
     expect(entryFor(href).visible(ops, true, null)).toBe(roles.includes('isOperations'));
   });
 
-  it('hides the /facility-ops index from operations (it redirects into Visits)', () => {
-    expect(entryFor('/facility-ops').visible(ops, true, null)).toBe(false);
+  it('lists the /facility-ops index to operations (it redirects into their first visible tab)', () => {
+    expect(entryFor('/facility-ops').visible(ops, true, null)).toBe(true);
   });
 
   it('still shows every Facility Ops entry to a board member', () => {

--- a/checkin-app/src/app/facility-ops/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/__tests__/page.test.tsx
@@ -1,15 +1,26 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock factories run hoisted, before imports exist
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
-
-import { redirect } from "next/navigation";
-import { resetRtl } from "@/test-helpers/rtl";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
+import { renderWithProviders, setSession, resetRtl, router } from "@/test-helpers/rtl";
 import FacilityOpsIndex from "../page";
 
 beforeEach(() => resetRtl());
 
-describe("facility-ops index page", () => {
-  it("redirects to the visits tab", () => {
-    expect(() => FacilityOpsIndex()).not.toThrow();
-    expect(redirect).toHaveBeenCalledWith("/facility-ops/visits");
-  });
+describe("FacilityOpsIndex", () => {
+    it("redirects a board member / sysadmin to /facility-ops/visits", async () => {
+        setSession({ id: 1, isSysadmin: true });
+        renderWithProviders(<FacilityOpsIndex />);
+
+        await Promise.resolve();
+        expect(router.replace).toHaveBeenCalledWith("/facility-ops/visits");
+    });
+
+    it("redirects an operations user to /facility-ops/print-badges — a page they can stay on", async () => {
+        setSession({ id: 2, isOperations: true });
+        renderWithProviders(<FacilityOpsIndex />);
+
+        await Promise.resolve();
+        expect(router.replace).toHaveBeenCalledWith("/facility-ops/print-badges");
+    });
 });

--- a/checkin-app/src/app/facility-ops/page.tsx
+++ b/checkin-app/src/app/facility-ops/page.tsx
@@ -1,5 +1,28 @@
-import { redirect } from "next/navigation";
+"use client";
 
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+
+import { visibleFacilityLinks } from "@/lib/facilityNav";
+
+import { PageLoader } from "@/components/ui/PageLoader";
+/**
+ * /facility-ops has no content of its own — it redirects to the caller's first
+ * visible tab. Client-side because the destination depends on the session
+ * (board/sysadmin→visits, operations→print-badges). The layout enforces access.
+ */
 export default function FacilityOpsIndex() {
-  redirect("/facility-ops/visits");
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "authenticated") {
+      router.replace(visibleFacilityLinks(session?.user)[0]?.href ?? "/");
+    }
+  }, [status, session, router]);
+
+  return (
+    <PageLoader />
+  );
 }

--- a/checkin-app/src/components/AppFrame.tsx
+++ b/checkin-app/src/components/AppFrame.tsx
@@ -51,6 +51,7 @@ import type { TodoCounts } from '@/app/api/nav/todo-counts/route';
 import { navBadgeFor, leadsAnyProgram } from '@/components/navBadges';
 import { CountBadge, badgeIntentFor } from '@/components/ui/CountBadge';
 import type { SessionUser } from '@/types/auth';
+import { FACILITY_SECTION_ROLES } from '@/lib/facilityNav';
 
 type NavItem = {
   href: string;
@@ -102,7 +103,9 @@ const NAV_ITEMS: NavItem[] = [
     href: '/facility-ops',
     label: 'Facility Ops',
     icon: <IconBuildingWarehouse size={18} />,
-    visible: (u) => !!u?.isSysadmin || !!u?.isBoardMember,
+    // Same union the section layout gates on — operations reach the two aggregate
+    // tools (#1633), so they get the nav entry too. Derived, never a second table.
+    visible: (u) => FACILITY_SECTION_ROLES.some((r) => !!u?.[r]),
   },
   {
     href: '/membership-ops',

--- a/checkin-app/src/components/__tests__/AppFrame.test.tsx
+++ b/checkin-app/src/components/__tests__/AppFrame.test.tsx
@@ -98,6 +98,16 @@ describe("AppFrame", () => {
     expect(screen.queryByText("Membership Audit")).not.toBeInTheDocument();
   });
 
+  it("shows Facility Ops to an operations-only user (#1633's aggregate-tools grant)", () => {
+    setSession({ id: 4, isOperations: true });
+    renderFrame();
+
+    expect(screen.getByText("Facility Ops")).toBeInTheDocument();
+    // Operations-only: the board-only sections stay hidden — the entry appeared
+    // because of the union, not because the gate got sloppy.
+    expect(screen.queryByText("Membership Audit")).not.toBeInTheDocument();
+  });
+
   it("badges the reviewer-only Membership Ops nav with the green can-act-on count", () => {
     setSession({ id: 3, isBackgroundCheckReviewer: true });
     mockedUseTodoCounts.mockReturnValue({

--- a/checkin-app/src/components/pageRegistry.ts
+++ b/checkin-app/src/components/pageRegistry.ts
@@ -96,8 +96,9 @@ export const PAGES: PageEntry[] = [
   // Facility Ops — board, plus operations on the two aggregate tools (#1633:
   // operations reach attendance in aggregate only). Visits, Badges (the raw
   // badge-event log) and Corrections are one person's record, so they stay
-  // board-only — as does the index, which redirects to /facility-ops/visits.
-  { href: '/facility-ops', label: 'Facility Ops', section: 'Facility Ops', visible: BOARD },
+  // board-only. The index redirects to the caller's first visible tab, so it is
+  // listed to anyone the section admits.
+  { href: '/facility-ops', label: 'Facility Ops', section: 'Facility Ops', visible: BOARD_OR_OPS },
   { href: '/facility-ops/badges', label: 'Badges', section: 'Facility Ops', visible: BOARD },
   { href: '/facility-ops/print-badges', label: 'Print Badges', section: 'Facility Ops', visible: BOARD_OR_OPS },
   { href: '/facility-ops/trends', label: 'Trends', section: 'Facility Ops', visible: BOARD_OR_OPS },


### PR DESCRIPTION
## What

#1623 gave operations two Facility Ops tools (Participation Trends, Print ID Badges — decision #1633) but no way to reach them: the sidebar's "Facility Ops" entry was board/sysadmin-only, and `/facility-ops` was a bare server redirect into `/facility-ops/visits`, a tab that ejects operations back to `/`. A typed URL was a dead end and the nav item never appeared.

## Reuse, not a third copy

Both fixes read from `lib/facilityNav.ts`, the table #1623 introduced — no new permission table, helper, or abstraction:

- The sidebar entry (`AppFrame.tsx`) now gates on `FACILITY_SECTION_ROLES`, the same derived union the section layout (`facility-ops/layout.tsx`) already gates on via `useRequireRole`.
- The index (`facility-ops/page.tsx`) redirects to `visibleFacilityLinks(session?.user)[0]?.href`, the same helper the layout uses to render tabs.

This is relevant to open issue **#1569** (the index directory forking the section permission table) — this PR does not make that fork worse; it reads the same source of truth `#1569` is about, it doesn't retype it.

## The index shape

Follows the existing `shop-ops` `defaultShopTab` precedent exactly: a client component using `useSession` + `router.replace` + `<PageLoader />`, because the destination depends on the session. The layout still enforces access.

## Behaviour preserved for board/sysadmin

`FACILITY_NAV_LINKS` is ordered Visit History, Raw Badge Events, Print ID Badges, Participation Trends, Corrections. Board/sysadmin's first visible link is still "Visit History", so `/facility-ops` lands them exactly where it always did (`/facility-ops/visits`). Operations' first visible link is "Print ID Badges" (`/facility-ops/print-badges`) — the first tab in that list they're actually allowed to open.

## pageRegistry

The index row's `visible` moved `BOARD` → `BOARD_OR_OPS` (already defined in the file) because the hub now lands operations on a tab they can open, not one that ejects them. The block comment's "the index, which redirects to /facility-ops/visits" claim was falsified by this PR — the index now redirects to the caller's first visible tab, so it's fixed to say that and to explain why the index row is listed to anyone the section admits.

## Tests

Three files, each written to fail on unmodified `origin/main` and pass with the fix:

- `checkin-app/src/components/__tests__/AppFrame.test.tsx` — new test: an operations-only user sees "Facility Ops" in the nav and does not see a board-only section ("Membership Audit"), proving the entry appeared because of the union, not a sloppy gate. Existing tests (plain signed-in user, certifier) are untouched and still assert Facility Ops is absent for them.
- `checkin-app/src/app/facility-ops/__tests__/page.test.tsx` — rewritten for the client component (mirrors `shop-ops/__tests__/page.test.tsx`): board/sysadmin → `/facility-ops/visits`, operations → `/facility-ops/print-badges`.
- `checkin-app/src/__tests__/pageRegistry.test.ts` — flipped the existing `it('hides the /facility-ops index from operations...')` (premise falsified by this PR) to assert it's now listed, and renamed it to say why.

### Red/green evidence

**AppFrame.test.tsx** — reverted `visible` to `(u) => !!u?.isSysadmin || !!u?.isBoardMember`:
```
TestingLibraryElementError: Unable to find an element with the text: Facility Ops.
  at Object.getByText (src/components/__tests__/AppFrame.test.tsx:105:19)
Test Suites: 1 failed, 1 total
Tests:       1 failed, 13 passed, 14 total
```
Restored → 14/14 pass.

**facility-ops/page.tsx** — reverted to the original `redirect("/facility-ops/visits")`:
```
● FacilityOpsIndex › redirects a board member / sysadmin to /facility-ops/visits
  expect(jest.fn()).toHaveBeenCalledWith(...expected)
  Expected: "/facility-ops/visits"
  Number of calls: 0

● FacilityOpsIndex › redirects an operations user to /facility-ops/print-badges — a page they can stay on
  expect(jest.fn()).toHaveBeenCalledWith(...expected)
  Expected: "/facility-ops/print-badges"
  Number of calls: 0

Test Suites: 1 failed, 1 total
Tests:       2 failed, 2 total
```
Restored → 2/2 pass.

**pageRegistry.test.ts** — reverted the index row to `visible: BOARD`:
```
● Facility Ops directory agrees with the section gates › lists the /facility-ops index to operations (it redirects into their first visible tab)
  expect(received).toBe(expected) // Object.is equality
  Expected: true
  Received: false
    at Object.toBe (src/__tests__/pageRegistry.test.ts:59:64)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 9 passed, 10 total
```
Restored → 10/10 pass.

### Full verification (clean, on the restored diff)

- `npx tsc --noEmit` → exit 0
- `npm run lint` → exit 0
- Full unit run: `Test Suites: 278 passed, 278 total` / `Tests: 2728 passed, 2728 total`

Context: #1623, #1633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5G65FwpM4kezxE2dCXier
