### PR TITLE
feat(membership): set the documented 1 September membership-year boundary (turns on annual renewal org-wide)

### DIFF
--- a/checkin-app/prisma/migrations/20260811130000_board_settings_year_boundary_default/migration.sql
+++ b/checkin-app/prisma/migrations/20260811130000_board_settings_year_boundary_default/migration.sql
@@ -1,0 +1,9 @@
+-- The membership year runs 1 September to 31 August (docs/rules/membership.md), but
+-- orgMembershipYearBoundary is nullable with no default and only the settings UI has
+-- ever written it. Badges print the year only for a household that settled the current
+-- renewal cycle, and a null boundary fails closed to no year on any badge — so set the
+-- documented boundary on the singleton that already exists in every environment.
+-- Value-only and idempotent; a board-set boundary is never overwritten.
+UPDATE "BoardSettings"
+SET "orgMembershipYearBoundary" = DATE '2026-09-01'
+WHERE "orgMembershipYearBoundary" IS NULL;


### PR DESCRIPTION
## What this actually does

One `UPDATE` on the `BoardSettings` singleton. It is not a badge detail — **it is the
switch that turns the annual-renewal machine on org-wide.**

`orgMembershipYearBoundary` is nullable with no default, and only the settings UI has ever
written it. Every renewal code path null-gates on it, so it is off today in every
environment. Setting it flips all of these at once, with **today already inside the Jul 1
window** (`RENEWAL_LEAD_MONTHS = 2` against a 1 Sep boundary):

- **`runRenewalSweep`** (`lib/membership/renewal.ts:143`) returns `"no membership-year
  boundary configured"` today. After this, the next `GET /api/cron/membership-renewals`
  opens a `PENDING_RENEWAL` `OrgMembershipProcess` for **every ACTIVE membership**. The
  skip clause only spares memberships with an in-flight or settled-this-cycle RENEWAL, and
  with the boundary null none has ever been opened — so the first sweep is a full-population
  write.
- **`membership/renewal-status`** starts showing members a due date.
- **`nav/todo-counts`** drops its unset-boundary todo.
- **`membership-audit/turning-18`** goes from an empty list to a populated one.
- **`settings/outreach`** gains a `nextDeadline`; the `lib/outreach/recipients` renewal
  audience becomes non-empty.
- **`bgValidUntilBoundary`** starts returning dates, so `membership-ops/households` rows
  gain `bgValidUntil`, and `householdBgIsFresh` changes what `beginRenewal` pre-clears.

**No mass mailing.** `docs/backlog/CUJS.md:227` records the reminder engine as gutted —
`cron/membership-renewals` opens `PENDING_RENEWAL` and sends zero email, with a test
asserting "the machine never emails". So this is a mass **write** plus member-visible
"your renewal is due" state, not a blast to the membership.

## Needs an explicit ack before merge

This is board policy, not a code fix. **Do not merge without explicit board/reviewer
acknowledgement** that the renewal cycle should switch on now and that the first cron sweep
opening a PENDING_RENEWAL per ACTIVE membership is intended.

## The value

`DATE '2026-09-01'`, from `docs/rules/membership.md:19` — *"The membership year runs 1
September to 31 August. One boundary applies to the whole organisation."*

## Migration shape

Value-only, single statement, no schema change, idempotent, non-destructive. `WHERE
… IS NULL` means a board-set boundary is never overwritten, so re-running is a no-op and a
board that has already chosen a different date keeps it. The singleton is created by `GET
/api/settings/membership`'s upsert and already exists in every environment, which is why a
schema `@default` (INSERT-only) would not reach it. Old code in the rolling-deploy drain
window reads a set boundary exactly as it reads any board-set one.

Timestamp is `20260811130000`, deliberately distinct from PR #1640's
`20260811120000_org_membership_process_intake_note_ack` so Prisma's ordering is explicit
rather than by directory-name accident. The two are independent — this writes a value to
`BoardSettings`, #1640 adds columns to `OrgMembershipProcess`.

## Why it is its own PR

Split out of #1641 (badge membership year) at review request:
https://github.com/innovationtreehouse/checkin/pull/1641#pullrequestreview-4902794160

#1641 does not need it. A null boundary already fails closed to a blank year on every
badge, which is the same renewal prompt that PR wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je395cjSLG1YPZzRsT7LG9
