### PR TITLE
ci(discussions): read-only staleness audit for release-planning discussions (no-model comparison for #1602)

### DIFF
--- a/.github/workflows/discussion-milestone-audit.yml
+++ b/.github/workflows/discussion-milestone-audit.yml
@@ -23,5 +23,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           NUM: ${{ inputs.discussion }}
+        # Without pipefail the job's status is `tee`'s, so a failed audit reports
+        # green; `2>&1` puts the error in the summary instead of leaving it blank.
+        shell: bash
         run: |
-          scripts/discussion-milestone-audit.sh "$NUM" | tee -a "$GITHUB_STEP_SUMMARY"
+          set -euo pipefail
+          scripts/discussion-milestone-audit.sh "$NUM" 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/discussion-milestone-audit.yml
+++ b/.github/workflows/discussion-milestone-audit.yml
@@ -1,0 +1,27 @@
+name: Discussion milestone audit
+
+# Read-only. No secrets, no discussion triggers, no writes — the job is a
+# report, so the token is read-only and there is nothing here to hijack.
+on:
+  workflow_dispatch:
+    inputs:
+      discussion:
+        description: Discussion number to audit
+        required: true
+
+permissions:
+  contents: read
+  issues: read
+  discussions: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ inputs.discussion }}
+        run: |
+          scripts/discussion-milestone-audit.sh "$NUM" | tee -a "$GITHUB_STEP_SUMMARY"

--- a/scripts/discussion-milestone-audit.sh
+++ b/scripts/discussion-milestone-audit.sh
@@ -38,8 +38,10 @@ parse_candidates() {
 milestone_from_title() { grep -oE 'v[0-9]+\.[0-9]+' <<<"$1" | head -1 || true; }
 
 self_test() {
-  local got want
-  got=$(parse_candidates <<'FIXTURE'
+  # The fixture is read into a variable first: bash 3.2's `$( )` scanner cannot
+  # skip heredoc bodies, and this one contains both `#` and `'`.
+  local fixture got want
+  IFS= read -r -d '' fixture <<'FIXTURE' || true
 ## Candidates
 
 - [ ] **#1409** — roster "Pending Since" always reads *Unknown*
@@ -52,7 +54,7 @@ self_test() {
 Prose mentioning #9999 is not a candidate.
 | #1508 already carries v1.2 | table row, not a box |
 FIXTURE
-)
+  got=$(printf '%s' "$fixture" | parse_candidates)
   want=$'unchecked\t1409\nchecked\t1487\nunchecked\t1435\nunchecked\t1520\nchecked\t1441\nchecked\t1134'
   diff <(echo "$got") <(echo "$want") || { echo "FAIL: parse_candidates"; exit 1; }
   test "$(milestone_from_title 'v1.2 — leaders can trust their screen')" = v1.2 || { echo "FAIL: milestone"; exit 1; }
@@ -76,19 +78,28 @@ MS=$(milestone_from_title "$TITLE")
 # Dedupe by number, preferring "checked" (sorts before "unchecked").
 CANDS=$(parse_candidates <<<"$BODY" | sort -t$'\t' -k2,2n -k1,1 | awk -F'\t' '!seen[$2]++')
 
+ERR=$(mktemp "${TMPDIR:-/tmp}/dma.XXXXXX"); trap 'rm -f "$ERR"' EXIT
+
 closed=(); elsewhere=(); notissue=(); nchk=0; nunchk=0
 while IFS=$'\t' read -r st n; do
   [ -n "${n:-}" ] || continue
   if [ "$st" = checked ]; then nchk=$((nchk + 1)); else nunchk=$((nunchk + 1)); fi
-  meta=$(gh api "repos/$REPO/issues/$n" --jq '[.state,(.pull_request!=null),(.milestone.title//"")]|@tsv' 2>/dev/null) \
-    || { notissue+=("- **#$n** ($st) — not an issue in this repo (a discussion, or deleted)"); continue; }
+  # Only a real 404 is a finding. A rate limit, a 5xx or a broken token is a
+  # broken run, and must not be reported as something wrong with the discussion.
+  if ! meta=$(gh api "repos/$REPO/issues/$n" --jq '[.state,(.pull_request!=null),(.milestone.title//"")]|@tsv' 2>"$ERR"); then
+    grep -q 'HTTP 404' "$ERR" || { echo "gh api failed reading issue #$n:" >&2; cat "$ERR" >&2; exit 1; }
+    notissue+=("- **#$n** ($st) — not an issue in this repo (a discussion, or deleted)")
+    continue
+  fi
   IFS=$'\t' read -r state ispr msname <<<"$meta"
   if [ "$ispr" = true ]; then
     notissue+=("- **#$n** ($st) — is a pull request, not an issue")
     continue
   fi
   [ "$state" = open ] || closed+=("- **#$n** ($st) — is **$state**")
-  [ -z "$msname" ] || [ "$msname" = "$MS" ] || elsewhere+=("- **#$n** ($st) — already on milestone **$msname**")
+  if [ -n "$MS" ] && [ -n "$msname" ] && [ "$msname" != "$MS" ]; then
+    elsewhere+=("- **#$n** ($st) — already on milestone **$msname**")
+  fi
 done <<<"$CANDS"
 
 MSJSON=$(gh api "repos/$REPO/milestones?state=all&per_page=100" --paginate \
@@ -97,6 +108,10 @@ MSNUM=$(jq -r '.number // empty' <<<"$MSJSON"); MSSTATE=$(jq -r '.state // empty
 
 unlisted=()
 if [ -n "$MSNUM" ]; then
+  # Assigned, not `< <(…)`: a failed listing must abort the run, not silently
+  # report an empty milestone.
+  ONMS=$(gh api "repos/$REPO/issues?milestone=$MSNUM&state=all&per_page=100" --paginate \
+    --jq '.[] | select(.pull_request == null) | [.number, .state] | @tsv')
   while IFS=$'\t' read -r n state; do
     [ -n "${n:-}" ] || continue
     cut -f2 <<<"$CANDS" | grep -qx "$n" && continue
@@ -105,8 +120,7 @@ if [ -n "$MSNUM" ]; then
     else
       unlisted+=("- **#$n** ($state) — **not mentioned anywhere** in the discussion")
     fi
-  done < <(gh api "repos/$REPO/issues?milestone=$MSNUM&state=all&per_page=100" --paginate \
-    --jq '.[] | select(.pull_request == null) | [.number, .state] | @tsv')
+  done <<<"$ONMS"
 fi
 
 section() { local h=$1; shift; printf '### %s\n\n' "$h"
@@ -114,14 +128,14 @@ section() { local h=$1; shift; printf '### %s\n\n' "$h"
 
 printf '## Staleness audit — [#%s](%s)\n\n%s\n\n' "$NUM" "$URL" "$TITLE"
 printf 'Target milestone from the title: **%s** — ' "${MS:-(none found)}"
-if [ -z "$MS" ]; then echo "the title names no \`vMAJOR.MINOR\`, so nothing below is milestone-scoped."
+if [ -z "$MS" ]; then echo "the title names no \`vMAJOR.MINOR\`, so the two milestone-scoped sections are skipped."
 elif [ -z "$MSNUM" ]; then echo "does not exist yet."
 else echo "exists (#$MSNUM, **$MSSTATE**)."; fi
 printf '\nCandidates parsed: **%s** checked, **%s** unchecked.\n\n' "$nchk" "$nunchk"
 
 section "Candidates that are closed" ${closed[@]+"${closed[@]}"}
-section "Candidates already on a different milestone" ${elsewhere[@]+"${elsewhere[@]}"}
+if [ -n "$MS" ]; then section "Candidates already on a different milestone" ${elsewhere[@]+"${elsewhere[@]}"}; fi
 section "Candidates that are not issues" ${notissue[@]+"${notissue[@]}"}
-section "On **${MS:-?}** but not a candidate" ${unlisted[@]+"${unlisted[@]}"}
+if [ -n "$MS" ]; then section "On **$MS** but not a candidate" ${unlisted[@]+"${unlisted[@]}"}; fi
 
 echo "_Read-only: this run made no writes and called no model._"

--- a/scripts/discussion-milestone-audit.sh
+++ b/scripts/discussion-milestone-audit.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Read-only staleness audit for a release-planning discussion.
+#
+#   scripts/discussion-milestone-audit.sh <discussion-number>
+#   scripts/discussion-milestone-audit.sh --self-test
+#
+# No model, no API key, no writes. The discussion body is untrusted public text,
+# and the only thing it can do here is choose which public issue numbers get
+# READ. A number that turns out not to be an issue is reported, never followed.
+set -euo pipefail
+
+# ── parsing: no network, exercised by --self-test ────────────────────────────
+# A candidate is a task-list line. Bold `**#N**` refs win, because the real
+# discussions bold candidates and leave prose refs ("design merged in PR #1515")
+# plain. A task line with no bold ref falls back to plain `#N`, so an
+# off-convention line is flagged rather than silently dropped.
+parse_candidates() {
+  awk '
+    /^[ \t]*[-*][ \t]+\[[ xX]\][ \t]/ {
+      state = ($0 ~ /^[ \t]*[-*][ \t]+\[[xX]\]/) ? "checked" : "unchecked"
+      n = 0; s = $0
+      while (match(s, /\*\*#[0-9]+\*\*/)) {
+        print state "\t" substr(s, RSTART + 3, RLENGTH - 5); n++
+        s = substr(s, RSTART + RLENGTH)
+      }
+      if (n == 0) {
+        s = $0
+        while (match(s, /#[0-9]+/)) {
+          print state "\t" substr(s, RSTART + 1, RLENGTH - 1)
+          s = substr(s, RSTART + RLENGTH)
+        }
+      }
+    }'
+}
+
+# Same convention apply.sh uses in #1602: the milestone is the first vMAJOR.MINOR
+# in the title, so no text in the body can name one.
+milestone_from_title() { grep -oE 'v[0-9]+\.[0-9]+' <<<"$1" | head -1 || true; }
+
+self_test() {
+  local got want
+  got=$(parse_candidates <<'FIXTURE'
+## Candidates
+
+- [ ] **#1409** — roster "Pending Since" always reads *Unknown*
+- [x] **#1487** — age on the card
+- [ ] **#1435** + **#1520** — one box, two issues
+- [x] **#1441** — dates required *(design merged in PR #1515)*
+  - [X] #1134 — plain ref, indented, uppercase X
+- [ ] no number on this line at all
+
+Prose mentioning #9999 is not a candidate.
+| #1508 already carries v1.2 | table row, not a box |
+FIXTURE
+)
+  want=$'unchecked\t1409\nchecked\t1487\nunchecked\t1435\nunchecked\t1520\nchecked\t1441\nchecked\t1134'
+  diff <(echo "$got") <(echo "$want") || { echo "FAIL: parse_candidates"; exit 1; }
+  test "$(milestone_from_title 'v1.2 — leaders can trust their screen')" = v1.2 || { echo "FAIL: milestone"; exit 1; }
+  test -z "$(milestone_from_title 'no version here')" || { echo "FAIL: milestone empty"; exit 1; }
+  echo "OK: 3 checks"
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit 0; }
+
+NUM="${1:?usage: discussion-milestone-audit.sh <discussion-number> | --self-test}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}}"
+
+D=$(gh api graphql -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F number="$NUM" -f query='
+query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){
+  discussion(number:$number){number title url body}}}' --jq '.data.repository.discussion')
+[ -n "$D" ] && [ "$D" != null ] || { echo "no discussion #$NUM in $REPO" >&2; exit 1; }
+
+TITLE=$(jq -r .title <<<"$D"); BODY=$(jq -r .body <<<"$D"); URL=$(jq -r .url <<<"$D")
+MS=$(milestone_from_title "$TITLE")
+
+# Dedupe by number, preferring "checked" (sorts before "unchecked").
+CANDS=$(parse_candidates <<<"$BODY" | sort -t$'\t' -k2,2n -k1,1 | awk -F'\t' '!seen[$2]++')
+
+closed=(); elsewhere=(); notissue=(); nchk=0; nunchk=0
+while IFS=$'\t' read -r st n; do
+  [ -n "${n:-}" ] || continue
+  if [ "$st" = checked ]; then nchk=$((nchk + 1)); else nunchk=$((nunchk + 1)); fi
+  meta=$(gh api "repos/$REPO/issues/$n" --jq '[.state,(.pull_request!=null),(.milestone.title//"")]|@tsv' 2>/dev/null) \
+    || { notissue+=("- **#$n** ($st) — not an issue in this repo (a discussion, or deleted)"); continue; }
+  IFS=$'\t' read -r state ispr msname <<<"$meta"
+  if [ "$ispr" = true ]; then
+    notissue+=("- **#$n** ($st) — is a pull request, not an issue")
+    continue
+  fi
+  [ "$state" = open ] || closed+=("- **#$n** ($st) — is **$state**")
+  [ -z "$msname" ] || [ "$msname" = "$MS" ] || elsewhere+=("- **#$n** ($st) — already on milestone **$msname**")
+done <<<"$CANDS"
+
+MSJSON=$(gh api "repos/$REPO/milestones?state=all&per_page=100" --paginate \
+  | jq -s --arg t "$MS" 'add // [] | map(select(.title == $t)) | .[0] // {}')
+MSNUM=$(jq -r '.number // empty' <<<"$MSJSON"); MSSTATE=$(jq -r '.state // empty' <<<"$MSJSON")
+
+unlisted=()
+if [ -n "$MSNUM" ]; then
+  while IFS=$'\t' read -r n state; do
+    [ -n "${n:-}" ] || continue
+    cut -f2 <<<"$CANDS" | grep -qx "$n" && continue
+    if grep -qE "(^|[^0-9])#$n([^0-9]|$)" <<<"$BODY"; then
+      unlisted+=("- **#$n** ($state) — mentioned in the body's prose, but not a candidate box")
+    else
+      unlisted+=("- **#$n** ($state) — **not mentioned anywhere** in the discussion")
+    fi
+  done < <(gh api "repos/$REPO/issues?milestone=$MSNUM&state=all&per_page=100" --paginate \
+    --jq '.[] | select(.pull_request == null) | [.number, .state] | @tsv')
+fi
+
+section() { local h=$1; shift; printf '### %s\n\n' "$h"
+  if [ "$#" -eq 0 ]; then echo "_none_"; else printf '%s\n' "$@"; fi; echo; }
+
+printf '## Staleness audit — [#%s](%s)\n\n%s\n\n' "$NUM" "$URL" "$TITLE"
+printf 'Target milestone from the title: **%s** — ' "${MS:-(none found)}"
+if [ -z "$MS" ]; then echo "the title names no \`vMAJOR.MINOR\`, so nothing below is milestone-scoped."
+elif [ -z "$MSNUM" ]; then echo "does not exist yet."
+else echo "exists (#$MSNUM, **$MSSTATE**)."; fi
+printf '\nCandidates parsed: **%s** checked, **%s** unchecked.\n\n' "$nchk" "$nunchk"
+
+section "Candidates that are closed" ${closed[@]+"${closed[@]}"}
+section "Candidates already on a different milestone" ${elsewhere[@]+"${elsewhere[@]}"}
+section "Candidates that are not issues" ${notissue[@]+"${notissue[@]}"}
+section "On **${MS:-?}** but not a candidate" ${unlisted[@]+"${unlisted[@]}"}
+
+echo "_Read-only: this run made no writes and called no model._"


### PR DESCRIPTION
This is the version @thpr asked for on #1602: *"A script that reads the discussion body's checked boxes and reports what has gone stale gets all of it, with no injection surface, no API key, and no secret to add."* It sits next to #1602 rather than replacing it, so the build-at-all decision has both shapes to weigh. Neither this nor #1602 should merge on autopilot.

It also happens to be what a local, human-previewed run would consume — the report below is the input a human would read before deciding to touch anything.

**127 lines of bash, 27 of YAML. No new dependencies (`gh` + `jq` + `awk`).**

## What it does

Given a discussion number, it reads the body, pulls candidate issue numbers out of the task-list boxes, and then reads each one's live state and milestone. It reports:

- candidates that are **closed**
- candidates already on a **different** milestone
- candidates that **are not issues** — a PR number or a discussion number in a box
- issues **already on the target milestone** that the discussion does not list, split into "mentioned in prose" and "not mentioned anywhere"
- whether the milestone exists yet, and whether it is open or closed

## What it does not do

- **No writes.** Every call is a GET. It cannot create a milestone, assign an issue, or post a comment.
- **No model.** No `ANTHROPIC_API_KEY`, no secret to add to this repo, nothing to rotate.
- **No injection surface.** The untrusted body text does exactly one thing: it selects which **public issue numbers** get read. There is no other channel out of the parser — a number is a number. If a box holds a number that is not an issue, that is *reported as a finding*, never followed. Both branches are confirmed against the live API: `#1602` (a PR) comes back with `pull_request != null`; a discussion number 404s.
- **No `discussion` triggers.** The workflow is `workflow_dispatch` only, so nobody outside the repo can start it, and the input reaches the shell through `env:` rather than `${{ }}` interpolation.

## The discussion format it assumes

Derived from the two real planning discussions, #1598 and #1599 — stated plainly because the parser is the whole trust boundary:

1. **Milestone name = the first `vMAJOR.MINOR` in the discussion title.** Same rule `apply.sh` uses in #1602. `"v1.2 — Program leaders can trust their screen"` → `v1.2`. Nothing in the *body* can name a milestone.
2. **A candidate is a markdown task-list line** — `- [ ]` or `- [x]`, any indent, `*` bullets and uppercase `[X]` accepted.
3. **On a task line, bold `**#N**` refs win.** Both real discussions bold their candidates and leave prose refs plain, which matters: `- [ ] **#1441** — program dates required *(design merged in PR #1515)*` has to yield `1441` and not `1515`. If a task line has *no* bold ref, it falls back to every plain `#N` on that line — an off-convention line gets flagged rather than silently dropped.
4. **One box may hold several issues.** `- [ ] **#1435** + **#1520**` yields both.
5. **Checked and unchecked are tracked separately** and both are audited. In practice this matters more than the reviewer's phrasing suggests: right now *every* box in both live discussions is unchecked, and the closed-candidate finding below comes off an unchecked one. Auditing only checked boxes would report nothing at all today.

Assumptions 3 and 5 are the ones most likely to be wrong later. Both fail loudly (a wrong number gets looked up and reported), never silently.

## Sample report — real run against #1598

Verbatim stdout, nothing edited:

```markdown
## Staleness audit — [#1598](https://github.com/innovationtreehouse/checkin/discussions/1598)

v1.2 — Program leaders can trust their screen (candidates, not committed)

Target milestone from the title: **v1.2** — exists (#2, **open**).

Candidates parsed: **0** checked, **8** unchecked.

### Candidates that are closed

- **#1435** (unchecked) — is **closed**

### Candidates already on a different milestone

_none_

### Candidates that are not issues

_none_

### On **v1.2** but not a candidate

- **#1508** (open) — mentioned in the body's prose, but not a candidate box
- **#1154** (open) — **not mentioned anywhere** in the discussion

_Read-only: this run made no writes and called no model._
```

That is both findings #1602's PR body claims for the model version — the closed candidate (#1435, closed by PR #1555 two days before the discussion was written) and the milestone already holding issues the list does not name — recovered with no model in the loop. The prose/never-mentioned split is a little extra: #1508 is at least discussed in #1598's conditionals table, #1154 is not in that discussion at all.

#1599 was also run: milestone `v1.3` does not exist yet, 10 unchecked candidates, nothing stale. It correctly excludes the `PR #1515` and `PR #1457` refs that sit in prose on candidate lines.

## How to run it

Locally, needing nothing but an authenticated `gh`:

```sh
scripts/discussion-milestone-audit.sh 1598
```

In CI, Actions → **Discussion milestone audit** → Run workflow, with the discussion number. Output goes to the job summary. The job's token is `contents: read`, `issues: read`, `discussions: read`.

## The check

```sh
scripts/discussion-milestone-audit.sh --self-test
# OK: 3 checks
```

Parsing is factored into one function with no network in it, so the check feeds a fixture body straight through it and `diff`s the extracted `state<TAB>number` pairs. The fixture covers the cases the real discussions actually contain: checked and unchecked, an indented uppercase `[X]` with a plain ref, two issues in one box, a bold candidate on a line that also names a PR, a box with no number, and prose and table refs that must *not* be picked up. No framework — same shape as the existing `scripts/test-*.sh`, which are also run by hand.

## Not built

Any write path, a diff-since-last-run, caching, and a scheduled trigger — a report nobody asked for on a cadence is just a notification to mute. Dispatch it when a decision is near.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Je395cjSLG1YPZzRsT7LG9
