### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS risk by removing dangerouslySetInnerHTML

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Found early returns checking buffer lengths (e.g., `providedBuffer.length !== expectedBuffer.length`) on webhook secrets and cron auth tokens before using `crypto.timingSafeEqual`.
 **Learning:** Returning early on length mismatch leaks the exact length of the expected secret.
 **Prevention:** Hash both the expected and provided secrets to a fixed length (e.g., using SHA-256) before passing them to `crypto.timingSafeEqual` to avoid leaking secret lengths while still safely catching any mismatch.
+
+## 2026-08-15 - [XSS Vulnerability in Email Mock Dev Tool]
+**Vulnerability:** Used `dangerouslySetInnerHTML` to render captured email bodies in the dev-only Sent Mail tool (`checkin-app/src/app/dev/sent-mail/page.tsx`).
+**Learning:** Even in dev-only tools, injecting unsanitized HTML is a security risk. If a malicious user manages to inject a payload into an email body, viewing the sent email could execute the script in the developer's context.
+**Prevention:** To safely render raw HTML in React without using `dangerouslySetInnerHTML`, use an `iframe` with the `srcDoc` attribute and an appropriate `sandbox` attribute (e.g., `sandbox="allow-popups allow-popups-to-escape-sandbox"`).

--- a/checkin-app/src/app/dev/sent-mail/page.tsx
+++ b/checkin-app/src/app/dev/sent-mail/page.tsx
@@ -68,8 +68,10 @@ export default async function DevSentMailPage() {
                                 style={{ border: "1px solid rgba(0,0,0,0.08)", borderRadius: 6, padding: "0.75rem", background: "#fff", color: "#111" }}
                                 // Dev-only rendering of our own captured template HTML so embedded links/tokens
                                 // are clickable. Never runs in prod (page 404s); content is what we ourselves sent.
-                                dangerouslySetInnerHTML={{ __html: email.html }}
-                            />
+                                // Using a sandboxed iframe to prevent XSS from injected payloads in email bodies
+                            >
+                                <iframe srcDoc={email.html} sandbox="allow-popups allow-popups-to-escape-sandbox" style={{ width: "100%", border: "none", minHeight: "200px", display: "block" }} />
+                            </div>
                         </li>
                     ))}
                 </ul>


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The dev-only Sent Mail page (`checkin-app/src/app/dev/sent-mail/page.tsx`) rendered captured email bodies using `dangerouslySetInnerHTML`.
🎯 Impact: If a malicious payload was injected into an email body, it could execute in the developer's browser context when viewing the sent email, posing an XSS risk.
🔧 Fix: Replaced `dangerouslySetInnerHTML` with an `iframe` using `srcDoc` and a restrictive `sandbox` attribute to safely render the HTML content.
✅ Verification: Verified that the email body still renders correctly in the dev tool and that any scripts within the HTML are blocked from execution.

---
*PR created automatically by Jules for task [1534065615611699386](https://jules.google.com/task/1534065615611699386) started by @dkaygithub*