### PR TITLE
fix(auth): kiosk attendance polls rejected as replays (double signature verification)

### DIFF
--- a/checkin-app/src/app/__tests__/attendanceKioskAuth.test.ts
+++ b/checkin-app/src/app/__tests__/attendanceKioskAuth.test.ts
@@ -1,0 +1,99 @@
+/**
+ * GET /api/attendance — kiosk auth with the REAL verify-kiosk module.
+ *
+ * The route resolves an optional session (denied-household gate) and then runs
+ * its own kiosk signature verification. Session resolution must not verify the
+ * kiosk signature itself: verification consumes the single-use nonce, so a
+ * request verified twice fails its second check as a replay. These tests pin
+ * that a kiosk poll authenticates in one pass — attendance.integration.test.ts
+ * can't see this because it mocks @/lib/verify-kiosk, which has no nonce state.
+ */
+import crypto from 'crypto';
+import { GET } from '@/app/api/attendance/route';
+import { getServerSession } from 'next-auth/next';
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/getFullAttendance', () => ({
+    getFullAttendance: jest.fn().mockResolvedValue({
+        attendance: [],
+        counts: { total: 0 },
+        safety: {},
+    }),
+}));
+
+function makeKeypair() {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const rawPublicHex = (publicKey.export({ type: 'spki', format: 'der' }) as Buffer)
+        .subarray(-32)
+        .toString('hex');
+    // Mirrors verify-kiosk.ts — nonce is bound INTO the signed payload.
+    const sign = (ts: string, nonce: string, method: string, path: string, body: string) =>
+        crypto.sign(null, Buffer.from(`${ts}:${nonce}:${method}:${path}:${body}`), privateKey).toString('hex');
+    return { rawPublicHex, sign };
+}
+
+// The verify module's nonce cache is module-global and persists across tests,
+// so every valid-signature case must use a fresh nonce.
+let nonceCounter = 0;
+const freshNonce = () => `attendance-auth-nonce-${++nonceCounter}`;
+
+function attendanceReq(headers: Record<string, string>) {
+    return new Request('http://localhost/api/attendance', {
+        method: 'GET',
+        headers,
+    }) as unknown as import('next/server').NextRequest;
+}
+
+function signedHeaders(signer: ReturnType<typeof makeKeypair>, nonce: string) {
+    const ts = String(Math.floor(Date.now() / 1000));
+    return {
+        'x-kiosk-timestamp': ts,
+        'x-kiosk-nonce': nonce,
+        'x-kiosk-signature': signer.sign(ts, nonce, 'GET', '/api/attendance', ''),
+    };
+}
+
+describe('GET /api/attendance — real kiosk signature wiring', () => {
+    const ORIG_KEY = process.env.KIOSK_PUBLIC_KEY;
+    let signer: ReturnType<typeof makeKeypair>;
+
+    beforeEach(() => {
+        (getServerSession as jest.Mock).mockResolvedValue(null);
+        signer = makeKeypair();
+        process.env.KIOSK_PUBLIC_KEY = signer.rawPublicHex;
+    });
+
+    afterAll(() => {
+        if (ORIG_KEY === undefined) delete process.env.KIOSK_PUBLIC_KEY;
+        else process.env.KIOSK_PUBLIC_KEY = ORIG_KEY;
+    });
+
+    it('a signed kiosk poll authenticates in a single pass (nonce not consumed twice)', async () => {
+        const res = await GET(attendanceReq(signedHeaders(signer, freshNonce())));
+        const json = await res.json();
+        expect(res.status).toBe(200);
+        expect(json.signedRequest).toBe(true);
+        expect(json.access).toBe('full');
+    });
+
+    it('an actual replay (same nonce sent twice) is still rejected', async () => {
+        const headers = signedHeaders(signer, freshNonce());
+        const first = await GET(attendanceReq(headers));
+        expect(first.status).toBe(200);
+
+        const second = await GET(attendanceReq(headers));
+        const json = await second.json();
+        expect(second.status).toBe(401);
+        expect(json.error).toBe('Replay detected');
+    });
+
+    it('kiosk headers with a bad signature are rejected', async () => {
+        const headers = signedHeaders(signer, freshNonce());
+        headers['x-kiosk-signature'] = '00'.repeat(64);
+        const res = await GET(attendanceReq(headers));
+        expect(res.status).toBe(401);
+    });
+});

--- a/checkin-app/src/lib/auth.ts
+++ b/checkin-app/src/lib/auth.ts
@@ -13,31 +13,37 @@ import type { AuthenticatedUser, BusinessRole, AuthResult } from '@/types/auth';
  */
 async function resolveAuthResult(
     req: NextRequest,
-    body?: string
+    body?: string,
+    opts?: { sessionOnly?: boolean }
 ): Promise<AuthResult> {
-    // 1. Try kiosk signature
-    const pubKeys = getKioskPublicKeys();
-    const hasKioskHeaders = req.headers.get('x-kiosk-signature');
+    // 1. Try kiosk signature. Skipped for session-only resolution: verifying a
+    // signature consumes its single-use nonce, so a caller that discards kiosk
+    // results (getOptionalSessionUser) must not verify here — the kiosk-tolerant
+    // route's own verification of the same request would then see a replay.
+    if (!opts?.sessionOnly) {
+        const pubKeys = getKioskPublicKeys();
+        const hasKioskHeaders = req.headers.get('x-kiosk-signature');
 
-    if (pubKeys.length > 0 && hasKioskHeaders) {
-        const method = req.method;
-        const path = new URL(req.url).pathname;
-        const result = verifyKioskSignature(
-            method, path, body || '',
-            req.headers.get('x-kiosk-timestamp'),
-            req.headers.get('x-kiosk-signature'),
-            req.headers.get('x-kiosk-nonce'),
-            pubKeys
-        );
-        if (result.ok) return { type: 'kiosk' };
-    } else if (pubKeys.length === 0 && config.isLocal()) {
-        // Local laptops only (CHECKIN_ENV=local): treat as kiosk when no signing key is
-        // configured, so the kiosk/check-in flows can be exercised without provisioning keys.
-        // Deliberately NOT enabled on the cloud dev instance (CHECKIN_ENV=dev) — that box is
-        // publicly reachable and must require a real kiosk key, exactly like prod. CHECKIN_ENV
-        // is unset under tests, so this stays off there too.
-        if (hasKioskHeaders || !req.headers.get('cookie')) {
-            return { type: 'kiosk' };
+        if (pubKeys.length > 0 && hasKioskHeaders) {
+            const method = req.method;
+            const path = new URL(req.url).pathname;
+            const result = verifyKioskSignature(
+                method, path, body || '',
+                req.headers.get('x-kiosk-timestamp'),
+                req.headers.get('x-kiosk-signature'),
+                req.headers.get('x-kiosk-nonce'),
+                pubKeys
+            );
+            if (result.ok) return { type: 'kiosk' };
+        } else if (pubKeys.length === 0 && config.isLocal()) {
+            // Local laptops only (CHECKIN_ENV=local): treat as kiosk when no signing key is
+            // configured, so the kiosk/check-in flows can be exercised without provisioning keys.
+            // Deliberately NOT enabled on the cloud dev instance (CHECKIN_ENV=dev) — that box is
+            // publicly reachable and must require a real kiosk key, exactly like prod. CHECKIN_ENV
+            // is unset under tests, so this stays off there too.
+            if (hasKioskHeaders || !req.headers.get('cookie')) {
+                return { type: 'kiosk' };
+            }
         }
     }
 
@@ -71,9 +77,10 @@ async function resolveAuthResult(
  */
 export async function authenticateRequest(
     req: NextRequest,
-    body?: string
+    body?: string,
+    opts?: { sessionOnly?: boolean }
 ): Promise<AuthResult> {
-    const result = await resolveAuthResult(req, body);
+    const result = await resolveAuthResult(req, body, opts);
 
     if (config.isStaging()) {
         const claims = result.type === 'session' ? result.user : null;
@@ -96,7 +103,10 @@ export async function authenticateRequest(
  * authenticateRequest, so it falls through to `undefined` here → sees the
  * public-only view, same as anonymous. Kiosk requests also resolve to
  * `undefined` (this returns only real session users); a kiosk-tolerant route
- * keeps its own kiosk plumbing.
+ * keeps its own kiosk plumbing. Resolution is session-only: kiosk signatures
+ * are NOT verified here, because verification consumes the single-use nonce
+ * and would make the route's own verification of the same request fail as a
+ * replay.
  *
  * Scope: this is for genuinely PUBLIC / optional-session reads only. It is NOT
  * an escape hatch for routes that should require a session — those use withAuth
@@ -106,7 +116,7 @@ export async function authenticateRequest(
  * the auth boundary, alongside authenticateRequest.
  */
 export async function getOptionalSessionUser(req: Request): Promise<AuthenticatedUser | undefined> {
-    const auth = await authenticateRequest(req as NextRequest);
+    const auth = await authenticateRequest(req as NextRequest, undefined, { sessionOnly: true });
     return auth.type === 'session' ? auth.user : undefined;
 }
 


### PR DESCRIPTION
## Problem

The physical kiosk cannot load the attendance roster: every signed `GET /api/attendance` poll returns `401 {"error":"Replay detected"}`, even with a fresh nonce. Verified live against prod from the kiosk Pi.

`getOptionalSessionUser` — added to the route for the denied-household gate — resolves through `resolveAuthResult`, which tries kiosk-signature verification first. That verification **consumes the single-use nonce**, then the kiosk result is discarded (the helper returns only session users). The route then runs its own `verifyKioskSignature` on the same request and the seen-nonce check fires: every kiosk poll is a "replay" of itself.

## Fix

Session-only resolution for `getOptionalSessionUser`: it now skips kiosk verification entirely. Verifying there served no purpose (kiosk results were discarded), and burning the nonce broke the one route that legitimately re-verifies. The `withAuth`/`withKiosk` chokepoint path is unchanged.

## Why CI never caught it

`attendance.integration.test.ts` mocks `@/lib/verify-kiosk`, so the mock had no nonce state. The new regression test (`attendanceKioskAuth.test.ts`) uses the real verify module with real Ed25519 signatures, mirroring `scanAuth.integration.test.ts`: a single signed poll must authenticate in one pass, an actual same-nonce replay must still 401, and a bad signature must still 401. Confirmed the first two fail without the fix.

Ran the kiosk/auth/attendance/scan unit suites (27 suites, 689 tests, green) and `tsc --noEmit`.

## Context

Found while recovering the facility kiosk: the Pi was still on the pre-monorepo `checkin-client` pointed at the decommissioned nip.io backend. After migrating it to the monorepo client and current prod URL, this server-side bug was the remaining blocker — the display stays down until this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)