### PR TITLE
🛡️ Sentinel: [MEDIUM] Remove stack traces from database logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Found early returns checking buffer lengths (e.g., `providedBuffer.length !== expectedBuffer.length`) on webhook secrets and cron auth tokens before using `crypto.timingSafeEqual`.
 **Learning:** Returning early on length mismatch leaks the exact length of the expected secret.
 **Prevention:** Hash both the expected and provided secrets to a fixed length (e.g., using SHA-256) before passing them to `crypto.timingSafeEqual` to avoid leaking secret lengths while still safely catching any mismatch.
+
+## 2026-06-30 - Sensitive Data Exposure in Error Logs
+**Vulnerability:** The application was persisting full error stack traces in the database (`ErrorLog` table), which were then exposed to administrative users in the frontend dashboard.
+**Learning:** Storing stack traces in database tables exposed to application dashboards can leak internal server information, directory structures, and dependency details to unauthorized or unnecessary users, aiding potential attackers.
+**Prevention:** Never persist raw error stack traces in database tables meant for application dashboards. Send stack traces only to secure, centralized logging infrastructure (e.g., via `console.error`) and store only generic or safe error messages in the database.

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -1228,8 +1228,6 @@ model ErrorLog {
   /// @sensitivity:internal
   message   String
   /// @sensitivity:internal
-  stack     String?
-  /// @sensitivity:internal
   context   Json?
 }
 

--- a/checkin-app/src/components/admin/ErrorLogPanel.tsx
+++ b/checkin-app/src/components/admin/ErrorLogPanel.tsx
@@ -8,7 +8,6 @@ type ErrorLogRow = {
   timestamp: string;
   route: string | null;
   message: string;
-  stack: string | null;
   context: unknown;
 };
 
@@ -51,7 +50,7 @@ export function ErrorLogPanel() {
     <Card withBorder radius="md" padding="lg">
       <Title order={4} mb="md">Recent Backend Errors</Title>
       <Text c="dimmed" size="sm" mb="md">
-        Up to 100 most recent entries (auto-purged after 30 days). Click a row to expand stack/context.
+        Up to 100 most recent entries (auto-purged after 30 days). Click a row to expand context.
       </Text>
       <Table.ScrollContainer minWidth={600}>
         <Table striped highlightOnHover verticalSpacing="sm">
@@ -79,19 +78,13 @@ export function ErrorLogPanel() {
                   <Table.Tr>
                     <Table.Td colSpan={3}>
                       <Stack gap="xs">
-                        {e.stack && (
-                          <div>
-                            <Text size="xs" fw={700} tt="uppercase" c="dimmed">Stack</Text>
-                            <Code block fz="xs">{e.stack}</Code>
-                          </div>
-                        )}
                         {e.context != null && (
                           <div>
                             <Text size="xs" fw={700} tt="uppercase" c="dimmed">Context</Text>
                             <Code block fz="xs">{JSON.stringify(e.context, null, 2)}</Code>
                           </div>
                         )}
-                        {!e.stack && e.context == null && (
+                        {e.context == null && (
                           <Text c="dimmed" size="sm">No additional detail.</Text>
                         )}
                       </Stack>

--- a/checkin-app/src/components/admin/__tests__/ErrorLogPanel.test.tsx
+++ b/checkin-app/src/components/admin/__tests__/ErrorLogPanel.test.tsx
@@ -10,7 +10,6 @@ const errors = [
     timestamp: "2026-06-01T12:00:00Z",
     route: "/api/checkin",
     message: "Boom",
-    stack: "Error: Boom\n  at x",
     context: { userId: 9 },
   },
 ];
@@ -23,16 +22,16 @@ describe("ErrorLogPanel", () => {
     expect(screen.getByText("/api/checkin")).toBeInTheDocument();
   });
 
-  it("expands and collapses a row to show stack/context", async () => {
+  it("expands and collapses a row to show context", async () => {
     mockFetchJson({ "/api/system-status/errors": { errors } });
     renderWithProviders(<ErrorLogPanel />);
     const row = await screen.findByText("Boom");
 
     fireEvent.click(row);
-    expect(await screen.findByText(/Error: Boom/)).toBeInTheDocument();
+    expect(await screen.findByText(/userId/)).toBeInTheDocument();
 
     fireEvent.click(row);
-    expect(screen.queryByText(/Error: Boom/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/userId/)).not.toBeInTheDocument();
   });
 
   it("shows the empty message when there are no errors", async () => {

--- a/checkin-app/src/lib/logger.ts
+++ b/checkin-app/src/lib/logger.ts
@@ -17,13 +17,15 @@ export async function logBackendError(error: unknown, route?: string, context?: 
     try {
         const message = error instanceof Error ? error.message : String(error);
         const stack = error instanceof Error ? error.stack : undefined;
+        if (stack) {
+            console.error("Backend Error Trace:", stack);
+        }
 
         // 1. Insert the new error log
         await prisma.errorLog.create({
             data: {
                 message,
                 route,
-                stack,
                 context: context ? JSON.parse(JSON.stringify(context)) : undefined, // Ensure it's JSON serializable
             }
         });

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -319,7 +319,6 @@ export const classifications = {
         timestamp: 'internal',
         route: 'internal',
         message: 'internal',
-        stack: 'internal',
         context: 'internal',
     },
     SystemMetricLog: {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application was persisting full error stack traces in the database (`ErrorLog` table), which were then exposed to administrative users in the frontend dashboard.
🎯 **Impact:** Storing stack traces in database tables exposed to application dashboards can leak internal server information, directory structures, and dependency details to unauthorized or unnecessary users, aiding potential attackers.
🔧 **Fix:** Modified `logBackendError` to stop writing `stack` to the database. Instead, stack traces are safely printed to `console.error` for secure backend logging infrastructure. Removed frontend display of `stack`.
✅ **Verification:** Verify that error stacks are logged to the console but not saved in the database or displayed in the UI.

---
*PR created automatically by Jules for task [779595296636711210](https://jules.google.com/task/779595296636711210) started by @dkaygithub*