### PR TITLE
fix(corrections): score open-visit deletes as strong (#1630)

### DIFF
--- a/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
@@ -416,10 +416,13 @@ describe('Admin Visits API Integration Tests', () => {
             // Resolved (#1630): the visit is still open, so its score is elapsed
             // time-on-site (~1h, no arrivedVia so weight 1) rather than the old
             // hardcoded 0 — deleting a live check-in no longer scores lowest.
+            // The admin (testAdminId) isn't the visit's own person (testUserId),
+            // so this delete is byProxy too — the route doubles the weight
+            // (significance.ts PROXY_MULTIPLIER), giving ~120, not ~60.
             const significance = (auditLog?.newData as { significance?: { score: number; flagged: boolean } })?.significance;
             expect(significance?.flagged).toBe(true);
-            expect(significance?.score).toBeGreaterThanOrEqual(60);
-            expect(significance?.score).toBeLessThan(65);
+            expect(significance?.score).toBeGreaterThanOrEqual(120);
+            expect(significance?.score).toBeLessThan(130);
         });
     });
 

--- a/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
@@ -413,12 +413,13 @@ describe('Admin Visits API Integration Tests', () => {
             expect(auditLog).not.toBeNull();
             expect((auditLog?.oldData as { id?: number })?.id).toBe(doomed.id);
 
-            // UNRESOLVED (#1630) — 0 is what ships, not what is right. The visit is
-            // still open, so deleteSignificance weighs no duration: deleting a live 6h
-            // scanned visit scores 0, while deleting that same row after checkout
-            // scores 2160. The lowest score destroys the live in-building roster.
-            expect((auditLog?.newData as { significance?: { score: number; flagged: boolean } })?.significance)
-                .toEqual({ score: 0, flagged: true });
+            // Resolved (#1630): the visit is still open, so its score is elapsed
+            // time-on-site (~1h, no arrivedVia so weight 1) rather than the old
+            // hardcoded 0 — deleting a live check-in no longer scores lowest.
+            const significance = (auditLog?.newData as { significance?: { score: number; flagged: boolean } })?.significance;
+            expect(significance?.flagged).toBe(true);
+            expect(significance?.score).toBeGreaterThanOrEqual(60);
+            expect(significance?.score).toBeLessThan(65);
         });
     });
 

--- a/checkin-app/src/lib/visit/__tests__/significance.test.ts
+++ b/checkin-app/src/lib/visit/__tests__/significance.test.ts
@@ -106,6 +106,25 @@ describe("deleteSignificance", () => {
         );
         expect(r.score).toBe(360);
     });
+
+    // #1630: an open visit has no recorded duration to weigh, so it must not
+    // fall back to 0 — that made deleting the live roster the *lowest*-scoring
+    // delete. Score against time on site so far instead.
+    it("an open visit's delete scores elapsed time, not the floor", () => {
+        const r = deleteSignificance(
+            { arrivedAt: at(14), departedAt: null, arrivedVia: "SCANNER", departedVia: null },
+            { now: at(20) },
+        );
+        expect(r).toEqual({ score: 1080, flagged: true }); // 360 min × 3 (SCANNER)
+    });
+
+    it("a closed visit's delete score is unaffected by `now` — duration is already fixed", () => {
+        const r = deleteSignificance(
+            { arrivedAt: at(14), departedAt: at(16), arrivedVia: "SCANNER", departedVia: "SCANNER" },
+            { now: at(23) },
+        );
+        expect(r.score).toBe(360);
+    });
 });
 
 // An adult changing another person's record is itself a flag input (design §3),

--- a/checkin-app/src/lib/visit/__tests__/significance.test.ts
+++ b/checkin-app/src/lib/visit/__tests__/significance.test.ts
@@ -97,6 +97,7 @@ describe("deleteSignificance", () => {
         ).flagged).toBe(true);
         expect(deleteSignificance(
             { arrivedAt: at(14), departedAt: null, arrivedVia: "WEB", departedVia: null },
+            { now: at(15) },
         ).flagged).toBe(true);
     });
 

--- a/checkin-app/src/lib/visit/significance.ts
+++ b/checkin-app/src/lib/visit/significance.ts
@@ -67,8 +67,10 @@ function minutesBetween(a: Date | null, b: Date | null): number {
     return Math.abs(a.getTime() - b.getTime()) / 60000;
 }
 
-/** `byProxy`: the actor is not the visit's person (a household lead acting for a member). */
-export type SignificanceOpts = { byProxy?: boolean };
+/** `byProxy`: the actor is not the visit's person (a household lead acting for
+ * a member). `now`: clock for scoring an open visit's delete — tests inject a
+ * fixed value; defaults to real time. */
+export type SignificanceOpts = { byProxy?: boolean; now?: Date };
 
 /** Significance of editing a visit's times, weighted by the OLD values' sources. */
 export function editSignificance(
@@ -83,11 +85,13 @@ export function editSignificance(
     return { score: Math.round(score), flagged: score >= FLAG_THRESHOLD };
 }
 
-/** A delete always flags — the floor. Score reflects how much recorded time vanished. */
+/**
+ * A delete always flags — the floor. Score reflects how much recorded time
+ * vanished; a still-open visit has no recorded end, so it scores against time
+ * on site so far — deleting the live roster is not "nothing happened yet".
+ */
 export function deleteSignificance(visit: VisitTimes, opts: SignificanceOpts = {}): Significance {
-    const duration = visit.departedAt
-        ? minutesBetween(visit.arrivedAt, visit.departedAt)
-        : 0;
+    const duration = minutesBetween(visit.arrivedAt, visit.departedAt ?? opts.now ?? new Date());
     const weight = Math.max(
         weightOf(visit.arrivedVia, "arrival", visit),
         weightOf(visit.departedVia, "departure", visit),


### PR DESCRIPTION
Fixes #1630.

## Bug
`deleteSignificance` scored an open visit's delete by recorded duration, which
falls back to `0` when `departedAt` is `null`. Every delete always flags
(`flagged: true`), but the *score* — the axis the corrections screen sorts and
scans by — came out lowest for exactly the delete that erases the live
in-building roster.

## Spec reading
§2 of `1256_ATTENDANCE_CORRECTION_SURFACE.md` makes the score the *strength* of
a change; the delete floor only supplies *whether* it flags. Its table says
`delete a LEAD_MARKED or SCANNER visit` → weight "high" → "yes — strong". The
table (and the delete-floor prose) never contemplates an open visit — the old
code resolved that gap as "nothing was lost," which is the one reading the
spec's own logic rules out: a visit still open is unfinished, not zero.

## Fix
Score an open visit's delete against **time on site so far** — `arrivedAt` to
now — using the same `weightOf`/max-weight logic already used for closed
deletes. `now` is injectable via `SignificanceOpts` so unit tests stay exact;
every real call site (`facility/visits` DELETE, `attendance/manual/[id]`
DELETE, `my-programs/conflicts/resolve`, `events/[id]` `manualEditAttendance`)
needed no changes — they already call with only `{ byProxy }`, so they pick up
real-clock scoring for free. Closed-visit scoring is untouched: `departedAt`
still wins the `??` chain, so nothing changes for the visit's normal (closed)
delete path.

## Before / after on the corrections screen
- **Before:** deleting a `SCANNER` visit that's still open scored `0`
  (`Flagged · 0`) — indistinguishable from a trivial delete, and *lower* than
  deleting the identical visit after checkout (`360 × 3 = 1080`, or `×2 = 2160`
  by proxy).
- **After:** deleting that same open visit now scores by elapsed minutes ×
  source weight, same as a closed delete — a 6h-old open `SCANNER` check-in
  scores `1080`, matching the "delete a SCANNER visit — high/strong" row in
  §2's table instead of falling into the unspecified gap.

Out of scope (per the issue): the "both ends machine-closed" case, which is a
separate, lower-priority instance of the same floor-collapsing-to-0 shape and
not part of this fix.

## Tests
- `checkin-app/src/lib/visit/__tests__/significance.test.ts` — added:
  - "an open visit's delete scores elapsed time, not the floor" (SCANNER, 6h
    open → `{ score: 1080, flagged: true }`)
  - "a closed visit's delete score is unaffected by `now`" (confirms closed
    delete scoring is unchanged)
- `checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts` — updated
  the pinned staff-DELETE-of-an-open-visit assertion that issue #1630 flagged
  as `UNRESOLVED`; now asserts `flagged: true` and a score in the elapsed-time
  range instead of the old hardcoded `{ score: 0, flagged: true }`.

Local results:
- `npx tsc --noEmit` — clean
- `npx jest --testPathPatterns significance.test.ts` — 15/15 passed
- `npx eslint` (via lint-staged on commit) — clean, no fixes needed beyond auto-format

🤖 Generated with [Claude Code](https://claude.com/claude-code)