### PR TITLE
fix(facility): backfill staff walk-in visits to LEAD_MARKED (#1632)

### DIFF
--- a/checkin-app/prisma/migrations/20260818120000_staff_entry_lead_marked_backfill/migration.sql
+++ b/checkin-app/prisma/migrations/20260818120000_staff_entry_lead_marked_backfill/migration.sql
@@ -1,0 +1,15 @@
+-- #1632: backfill staff walk-in visits (insert route's CREATE audit rows
+-- tagged newData.type='staff_entry') from arrivedVia/departedVia=WEB to
+-- LEAD_MARKED, matching the post-#1558 rule. Idempotent: only touches rows
+-- still on WEB. Rationale/consequence: PR body.
+UPDATE "Visit"
+SET "arrivedVia" = CASE WHEN "arrivedVia" = 'WEB' THEN 'LEAD_MARKED' ELSE "arrivedVia" END::"VisitSource",
+    "departedVia" = CASE WHEN "departedVia" = 'WEB' THEN 'LEAD_MARKED' ELSE "departedVia" END::"VisitSource"
+WHERE "id" IN (
+    SELECT "affectedEntityId"
+    FROM "AuditLog"
+    WHERE "tableName" = 'Visit'
+      AND "action" = 'CREATE'
+      AND "newData"->>'type' = 'staff_entry'
+)
+AND ("arrivedVia" = 'WEB' OR "departedVia" = 'WEB');

--- a/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminVisitsAPI.integration.test.ts
@@ -439,14 +439,14 @@ describe('Admin Visits API Integration Tests', () => {
             expect(res.status).toBe(403);
         });
 
-        it('creates a closed WEB visit for another person and audits actor + subject', async () => {
+        it('creates a closed LEAD_MARKED visit for another person and audits actor + subject', async () => {
             (getServerSession as jest.Mock).mockResolvedValue({ user: { id: testAdminId, isSysadmin: true } });
             const res = await post({ personId: testUserId, arrivedAt: arrived.toISOString(), departedAt: departed.toISOString() });
 
             expect(res.status).toBe(201);
             const { visit } = await res.json();
             const stored = await prisma.visit.findUnique({ where: { id: visit.id } });
-            expect(stored).toMatchObject({ personId: testUserId, arrivedVia: 'WEB', departedVia: 'WEB' });
+            expect(stored).toMatchObject({ personId: testUserId, arrivedVia: 'LEAD_MARKED', departedVia: 'LEAD_MARKED' });
             expect(stored?.departedAt).toBeInstanceOf(Date);
 
             const audit = await prisma.auditLog.findFirst({

--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -12,11 +12,14 @@
  * present" visits, plus its pre-split `SYSTEM` spelling) and the two cases it must
  * not swallow — an untagged arrival, and a real visit whose time staff corrected
  * (driven through the PATCH route, since a hand-built fixture cannot catch a wrong
- * stamp) — the `programId` filter, and the invalid-period 400.
+ * stamp) — the `programId` filter, a real staff walk-in insert (#1632: the
+ * route the LEAD_MARKED backfill's row-set is keyed on) staying excluded, and
+ * the invalid-period 400.
  */
 
 import { GET } from '@/app/api/facility/trends/route';
 import { PATCH } from '@/app/api/facility/visits/route';
+import { POST as INSERT_POST } from '@/app/api/facility/visits/insert/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import { getAppSettings } from '@/lib/appSettings';
@@ -268,6 +271,52 @@ describe('Facility trends API', () => {
 
         await prisma.auditLog.deleteMany({ where: { tableName: 'Visit', affectedEntityId: visit.id } });
         await prisma.visit.delete({ where: { id: visit.id } });
+        await prisma.event.delete({ where: { id: event.id } });
+        await prisma.program.delete({ where: { id: program.id } });
+    });
+
+    // #1632: the staff walk-in insert route now stamps LEAD_MARKED, which is
+    // exactly what the historical backfill rewrites old WEB rows to. Driven
+    // through the real route (not a hand-built fixture) so a regression that
+    // reverts the route back to WEB fails this, not just a unit test on the
+    // route in isolation.
+    it('excludes a real staff walk-in insert from trends hours', async () => {
+        const program = await prisma.program.create({ data: { name: `StaffEntry ${TAG}` } });
+        const insertArrival = new Date(Date.now() - 4 * 3600000);
+        const insertDeparture = new Date(Date.now() - 2 * 3600000);
+        const event = await prisma.event.create({
+            data: {
+                programId: program.id,
+                name: `StaffEntry event ${TAG}`,
+                startAt: new Date(insertArrival.getTime() - 3600000),
+                endAt: new Date(insertDeparture.getTime() + 3600000),
+            },
+        });
+        await prisma.programVolunteer.create({ data: { programId: program.id, personId: volunteerId } });
+
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+        const insertRes = await INSERT_POST(new Request('http://localhost:4000/api/facility/visits/insert', {
+            method: 'POST',
+            body: JSON.stringify({
+                personId: volunteerId,
+                arrivedAt: insertArrival.toISOString(),
+                departedAt: insertDeparture.toISOString(),
+            }),
+        }) as unknown as import('next/server').NextRequest);
+        expect(insertRes.status).toBe(201);
+        const { visit } = await insertRes.json();
+        visitIds.push(visit.id);
+        expect(visit.arrivedVia).toBe('LEAD_MARKED');
+
+        const res = await callAs({ id: adminId, isSysadmin: true }, `?period=month&programId=${program.id}`);
+        const data = await res.json();
+        // Excluded entirely — not just demoted out of structured hours.
+        expect(data.totals.uniqueVolunteers).toBe(0);
+        expect(data.totals.totalVolunteerHours).toBe(0);
+        expect(data.totals.structuredHours).toBe(0);
+
+        await prisma.programVolunteer.deleteMany({ where: { programId: program.id } });
+        await prisma.auditLog.deleteMany({ where: { tableName: 'Visit', affectedEntityId: visit.id } });
         await prisma.event.delete({ where: { id: event.id } });
         await prisma.program.delete({ where: { id: program.id } });
     });

--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -13,12 +13,13 @@
  * not swallow — an untagged arrival, and a real visit whose time staff corrected
  * (driven through the PATCH route, since a hand-built fixture cannot catch a wrong
  * stamp) — the `programId` filter, a real staff walk-in insert (#1632: the
- * route the LEAD_MARKED backfill's row-set is keyed on) staying excluded, and
- * the invalid-period 400.
+ * route the LEAD_MARKED backfill's row-set is keyed on) staying excluded and,
+ * when that same walk-in is deleted, scoring at the LEAD_MARKED source weight
+ * rather than the WEB weight it replaced — and the invalid-period 400.
  */
 
 import { GET } from '@/app/api/facility/trends/route';
-import { PATCH } from '@/app/api/facility/visits/route';
+import { PATCH, DELETE as VISITS_DELETE } from '@/app/api/facility/visits/route';
 import { POST as INSERT_POST } from '@/app/api/facility/visits/insert/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
@@ -314,6 +315,25 @@ describe('Facility trends API', () => {
         expect(data.totals.uniqueVolunteers).toBe(0);
         expect(data.totals.totalVolunteerHours).toBe(0);
         expect(data.totals.structuredHours).toBe(0);
+
+        // F13 pin: deleting this walk-in through the real DELETE route must weigh
+        // it at the LEAD_MARKED source weight (2), not the WEB weight (1) it
+        // replaced — that source-weight bump is the backfill's whole premise.
+        // 120 minutes * weight 2 * byProxy(admin acting for volunteerId) 2 = 480,
+        // double the 240 a WEB-weighted score would give the same edit.
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: adminId, isSysadmin: true } });
+        const deleteRes = await VISITS_DELETE(new Request('http://localhost:4000/api/facility/visits', {
+            method: 'DELETE',
+            body: JSON.stringify({ visitId: visit.id }),
+        }) as unknown as import('next/server').NextRequest);
+        expect(deleteRes.status).toBe(200);
+
+        const deleteAudit = await prisma.auditLog.findFirst({
+            where: { actorId: adminId, action: 'DELETE', tableName: 'Visit', affectedEntityId: visit.id },
+            orderBy: { id: 'desc' },
+        });
+        expect((deleteAudit?.newData as { significance?: { score: number; flagged: boolean } })?.significance)
+            .toEqual({ score: 480, flagged: true });
 
         await prisma.programVolunteer.deleteMany({ where: { programId: program.id } });
         await prisma.auditLog.deleteMany({ where: { tableName: 'Visit', affectedEntityId: visit.id } });

--- a/checkin-app/src/app/api/facility/visits/insert/route.ts
+++ b/checkin-app/src/app/api/facility/visits/insert/route.ts
@@ -64,8 +64,12 @@ export const POST = withAuth(
                         personId: subjectId,
                         arrivedAt: ar.value,
                         departedAt: dr.value,
-                        arrivedVia: "WEB",
-                        departedVia: "WEB",
+                        // Staff-asserted, not measured — LEAD_MARKED, matching the
+                        // events-roster mark and the #1632 backfill of prior rows
+                        // that were wrongly stamped WEB. Excluded from
+                        // facility/trends (see that route's filter).
+                        arrivedVia: "LEAD_MARKED",
+                        departedVia: "LEAD_MARKED",
                         associatedEventId: eventId,
                     },
                 });

--- a/docs/rules/attendance-checkin.md
+++ b/docs/rules/attendance-checkin.md
@@ -173,6 +173,13 @@ Things the app takes as true because they are handled outside it.
   left. Putting someone on the list of who is in the building now follows from a
   badge at the kiosk, never from staff saying so.  [Decision — deliberate limit]
 
+- Staff-asserted presence is not facility hours: a visit recorded for somebody
+  else, or a roster mark, states the window it was asserted for rather than a
+  measured stay, so the trends leave it out. A walk-in that a roster mark adopts
+  keeps its badged times and still counts. The 2026-08 backfill brought
+  historical staff entries into line with this, so hours for past periods dropped
+  retroactively.  [Decision]
+
 - Facility hours split by program enrollment, not age: anyone present and not
   enrolled counts on the volunteer side.  [Decision]
 

--- a/docs/rules/attendance-checkin.md
+++ b/docs/rules/attendance-checkin.md
@@ -176,9 +176,7 @@ Things the app takes as true because they are handled outside it.
 - Staff-asserted presence is not facility hours: a visit recorded for somebody
   else, or a roster mark, states the window it was asserted for rather than a
   measured stay, so the trends leave it out. A walk-in that a roster mark adopts
-  keeps its badged times and still counts. The 2026-08 backfill brought
-  historical staff entries into line with this, so hours for past periods dropped
-  retroactively.  [Decision]
+  keeps its badged times and still counts.  [Decision]
 
 - Facility hours split by program enrollment, not age: anyone present and not
   enrolled counts on the volunteer side.  [Decision]


### PR DESCRIPTION
Fixes #1632.

## Decision

`jee7s` decided on the issue (2026-08-18): **backfill**. Rewrite the historical staff walk-in rows to `arrivedVia`/`departedVia: LEAD_MARKED`. Understood consequence: previously reported facility-hours for past periods drop retroactively and no longer reconcile with anything already reported from those numbers.

## Route change — and why it's landing in this PR, not #1624

The insert route did **not** already stamp `LEAD_MARKED` for every new staff walk-in. #1558 deliberately left `facility/visits/insert` on `WEB` — its own PR body says so outright: "Item A (`facility/visits/insert` stamps `WEB`) is untouched — you folded it into #1624 yourself" — deferring that route change to #1624, which is still open. (An earlier commit on the #1558 branch, `a2e6a586`, did make this exact insert→`LEAD_MARKED` change; it was removed by a reset to `6249f2d1` before merge, precisely to defer it.)

This PR's second commit moves the route to `LEAD_MARKED` anyway. That's forced by the backfill's own coherence, not by any rule #1558 already established: leave the insert route on `WEB` and the very next staff walk-in recreates the discontinuity the backfill just erased. It is a real, if narrow, re-opening of what #1558 explicitly deferred — flagged for explicit sign-off in the PR comment rather than folded in silently.

## Row-set logic

`checkin-app/src/app/api/facility/visits/insert/route.ts:82` — the only route that writes staff walk-ins — pairs every `Visit` CREATE with an `AuditLog` row tagged `newData.type: "staff_entry"`. That tag is the exact, and only, discriminator:

```sql
WHERE "id" IN (
    SELECT "affectedEntityId"
    FROM "AuditLog"
    WHERE "tableName" = 'Visit'
      AND "action" = 'CREATE'
      AND "newData"->>'type' = 'staff_entry'
)
AND ("arrivedVia" = 'WEB' OR "departedVia" = 'WEB')
```

Verified against the two other candidate writers to confirm neither leaks into this set:
- `attendance/manual/route.ts:166` (member self-entry, incl. household-lead-for-member) writes `newData.type: "manual_entry"` — a different string, untouched.
- `attendance/manual/[id]/route.ts` (self-correction) writes `type: "self_correction"` — also untouched.

`facility/trends`'s `route.ts:79-82` excludes `arrivedVia IN ('LEAD_MARKED', 'SYSTEM')` from hours — confirmed the backfill target value is exactly what the exclusion filter checks.

## Idempotency

The `WHERE ... AND ("arrivedVia" = 'WEB' OR "departedVia" = 'WEB')` guard means a re-run of this migration, or a re-apply against an environment where it already landed, touches zero rows the second time — every row in the identified set that still carries `WEB` gets rewritten once, and nothing else matches after that.

## Migration ordering

Data-only `UPDATE`, no schema change — pure backfill, so it ships expand-only per `DEPLOY_MIGRATION_ORDER_OF_OPERATIONS.md` rule 1 (nothing destructive, nothing another release depends on). Single statement, so no `BEGIN`/`COMMIT` wrap needed (matches the repo's own convention — e.g. `20260724120000_purge_adult_dob`, also a single-statement `UPDATE` backfill, ships unwrapped; multi-statement backfills like `20260803000100_visit_source_split_backfill` are the ones wrapped).

No prior data migration in this repo writes an `AuditLog` entry for its own rewrite (checked every `migration.sql` under `checkin-app/prisma/migrations/` — the only `AuditLog`-touching migrations are DDL against the table itself). Following that precedent, this migration does not synthesize an audit trail for the backfill either.

## Test coverage

Added `excludes a real staff walk-in insert from trends hours` to `checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts`, alongside the existing `LEAD_MARKED`/`SYSTEM` exclusion cases. It drives the actual `POST /api/facility/visits/insert` route (not a hand-built fixture) and then asserts the visit is invisible to `facility/trends` — pins the route's current `LEAD_MARKED` stamp end-to-end, which is also the exact behavior the backfill is bringing historical rows in line with.

The same test now also deletes that walk-in through the real `DELETE /api/facility/visits` route and asserts the recorded `significance` score reflects the `LEAD_MARKED` source weight (2) rather than the `WEB` weight (1) it replaced — 480 vs. the 240 a WEB-weighted read of the identical edit would give, `byProxy` doubling included. Pins that the route change this PR makes actually feeds `significance`, not just `facility/trends`.

Local: `npx tsc --noEmit` clean, `eslint --max-warnings 0` clean on the changed test file. The integration suite needs Docker/Postgres, unavailable in this sandbox — CI runs it (`migration-safety.yml` also applies the new migration against a populated DB).

## Known gap — now closed by #1668 (was: not fixed here)

**Update (2026-08-20):** #1668 landed on main and closed this gap. The section below is kept for the record; no action is left for this PR.

The gap as originally described: `attendance/manual/[id]/route.ts:117` unconditionally restamped `arrivedVia: "WEB"` whenever a member (or household lead) self-corrected their own visit's arrival — the same per-field-provenance failure #1631 already tracks for the staff PATCH route (an existence-claim source overwritten by an unconditional field write), just the mirror direction. Before this backfill, that could only misfire on roster-marked (`LEAD_MARKED`) visits; after it, every staff walk-in is `LEAD_MARKED` too, so a member nudging their own walk-in's arrival would have flipped it from trends-excluded to counted, over a much larger population.

#1668 dropped that restamp: `arrivedVia` is now left as-is on a manual correction (`departedVia` still becomes `WEB`, since trends' exclusion filter reads only `arrivedVia`). It also added two pins to `facilityTrendsAPI.integration.test.ts` — a self-corrected `LEAD_MARKED` visit stays excluded from trends hours, and a self-corrected `SCANNER` visit still counts as the control. Merged into this branch at `94fba256`.

Consequence for this PR: the backfill no longer widens any exposure. It enlarges the `LEAD_MARKED` population, and that population is exactly what #1668 now protects from member self-correction — the two changes are complementary. No test in this PR depended on the old restamp behavior (the #1632 test drives the insert and DELETE routes only, never the manual PATCH), and the docs rule added here describes the trends exclusion itself, not the restamp. #1624/#1631 remain open for the staff-PATCH mirror of the same per-field-provenance issue.

## Docs

`docs/rules/attendance-checkin.md` now carries the standing rule (added on review request, provenance trimmed per the register standard §3.8 in 9af8a9ad): staff-asserted presence is not facility hours, with the adopted-walk-in carve-out, tagged [Decision]. The backfill's retroactive-drop consequence stays recorded here and on issue #1632, not in the register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




