### PR TITLE
feat(kiosk): offline store-and-replay + offline banner (AT8)

### DIFF
--- a/checkin-app/prisma/migrations/20260818140000_raw_badge_log_client_event_id/migration.sql
+++ b/checkin-app/prisma/migrations/20260818140000_raw_badge_log_client_event_id/migration.sql
@@ -1,0 +1,11 @@
+-- Additive, nullable: legacy/web writers keep writing NULL clientEventId
+-- (Postgres NULLs don't collide on a unique index), so nothing else changes.
+-- clientEventId is the kiosk replay idempotency key; reviewReason marks a
+-- replay parked instead of toggled (docs/designs/KIOSK_RESILIENCE.md §2).
+ALTER TABLE "RawBadgeLog" ADD COLUMN "clientEventId" TEXT;
+ALTER TABLE "RawBadgeLog" ADD COLUMN "reviewReason" TEXT;
+
+-- CONCURRENTLY: RawBadgeLog is a live, high-traffic table — a plain unique
+-- index build would hold a lock across it. A migration containing
+-- CREATE INDEX CONCURRENTLY runs outside a transaction automatically.
+CREATE UNIQUE INDEX CONCURRENTLY "RawBadgeLog_clientEventId_key" ON "RawBadgeLog"("clientEventId");

--- a/checkin-app/prisma/migrations/20260818140000_raw_badge_log_client_event_id/migration.sql
+++ b/checkin-app/prisma/migrations/20260818140000_raw_badge_log_client_event_id/migration.sql
@@ -2,10 +2,14 @@
 -- (Postgres NULLs don't collide on a unique index), so nothing else changes.
 -- clientEventId is the kiosk replay idempotency key; reviewReason marks a
 -- replay parked instead of toggled (docs/designs/KIOSK_RESILIENCE.md §2).
-ALTER TABLE "RawBadgeLog" ADD COLUMN "clientEventId" TEXT;
-ALTER TABLE "RawBadgeLog" ADD COLUMN "reviewReason" TEXT;
+-- IF NOT EXISTS / IF EXISTS make this retry-safe: CONCURRENTLY can't run in a
+-- transaction, so a prior attempt killed mid-way can leave columns applied
+-- and/or an invalid index behind for a retry to step on.
+ALTER TABLE "RawBadgeLog" ADD COLUMN IF NOT EXISTS "clientEventId" TEXT;
+ALTER TABLE "RawBadgeLog" ADD COLUMN IF NOT EXISTS "reviewReason" TEXT;
 
 -- CONCURRENTLY: RawBadgeLog is a live, high-traffic table — a plain unique
 -- index build would hold a lock across it. A migration containing
 -- CREATE INDEX CONCURRENTLY runs outside a transaction automatically.
+DROP INDEX IF EXISTS "RawBadgeLog_clientEventId_key";
 CREATE UNIQUE INDEX CONCURRENTLY "RawBadgeLog_clientEventId_key" ON "RawBadgeLog"("clientEventId");

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -1085,6 +1085,10 @@ model RawBadgeLog {
   timestamp     DateTime @default(now())
   /// @sensitivity:personal
   location      String?
+  /// @sensitivity:internal
+  clientEventId String?  @unique // kiosk replay idempotency key; NULL for legacy/web writers
+  /// @sensitivity:internal
+  reviewReason  String?          // set when a stale/out-of-order replay is parked instead of toggled
 
   person Person @relation(fields: [personId], references: [id])
 

--- a/checkin-app/src/app/__tests__/scanReplay.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanReplay.integration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Kiosk replay idempotency against the real DB (docs/designs/KIOSK_RESILIENCE.md
+ * §2): a queued scan carries clientEventId + scannedAt, and replay must dedup,
+ * toggle with the original scan time, and park instead of toggling when stale
+ * or out-of-order.
+ */
+import { POST } from '@/app/api/scan/route';
+import prisma from '@/lib/prisma';
+import { authenticateRequest } from '@/lib/auth';
+import type { Person } from '@/generated/prisma/client';
+
+jest.mock('@/lib/auth', () => ({ authenticateRequest: jest.fn() }));
+jest.mock('@/lib/notifications', () => ({
+    sendCheckinNotifications: jest.fn().mockResolvedValue(undefined),
+    sendNotification: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/lib/logger', () => ({
+    logBackendError: jest.fn(),
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const TAG = 'scan-replay-test';
+
+function scanReq(body: Record<string, unknown>) {
+    return new Request('http://localhost/api/scan', {
+        method: 'POST',
+        body: JSON.stringify(body),
+    }) as unknown as import('next/server').NextRequest;
+}
+
+describe('Scan replay — clientEventId dedup and freshness window (real DB)', () => {
+    let keyholder: Person;
+    let member: Person;
+    const householdIds: number[] = [];
+
+    beforeAll(async () => {
+        (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'kiosk' });
+        keyholder = await prisma.person.create({
+            data: { name: 'Replay Key', email: `key-${TAG}@example.com`, isKeyholder: true, household: { create: { name: 'Test HH' } } },
+        });
+        householdIds.push(keyholder.householdId);
+        member = await prisma.person.create({
+            data: { name: 'Replay Member', email: `member-${TAG}@example.com`, household: { create: { name: 'Test HH' } } },
+        });
+        householdIds.push(member.householdId);
+
+        // Keep the facility open for the whole suite: member check-ins require an
+        // active keyholder, and this is testing replay, not facility-open gating.
+        await prisma.visit.create({ data: { personId: keyholder.id, arrivedAt: new Date(0), arrivedVia: 'SCANNER' } });
+    });
+
+    afterEach(async () => {
+        await prisma.visit.deleteMany({ where: { personId: member.id } });
+        await prisma.rawBadgeLog.deleteMany({ where: { personId: member.id } });
+    });
+
+    afterAll(async () => {
+        await prisma.visit.deleteMany({ where: { personId: { in: [keyholder.id, member.id] } } });
+        await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: [keyholder.id, member.id] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [keyholder.id, member.id] } } });
+        await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
+    });
+
+    it('redelivering the same clientEventId dedups instead of toggling a second time', async () => {
+        const scannedAt = new Date().toISOString();
+        const first = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-dedup', scannedAt }));
+        expect((await first.json()).type).toBe('checkin');
+
+        const retry = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-dedup', scannedAt }));
+        expect(retry.status).toBe(200);
+        expect((await retry.json()).type).toBe('duplicate_ignored');
+
+        const visits = await prisma.visit.findMany({ where: { personId: member.id } });
+        expect(visits).toHaveLength(1);
+    });
+
+    it('a fresh replay toggles using scannedAt as the recorded arrival time', async () => {
+        const scannedAt = new Date(Date.now() - 60_000); // 1 min ago, within W
+        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-fresh', scannedAt: scannedAt.toISOString() }));
+        expect((await res.json()).type).toBe('checkin');
+
+        const visit = await prisma.visit.findFirst({ where: { personId: member.id } });
+        expect(visit?.arrivedAt.getTime()).toBe(scannedAt.getTime());
+    });
+
+    it('a replay older than the freshness window parks instead of toggling', async () => {
+        const scannedAt = new Date(Date.now() - 20 * 60_000); // 20 min ago > 10 min W
+        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-stale', scannedAt: scannedAt.toISOString() }));
+        expect(res.status).toBe(200);
+        expect((await res.json()).type).toBe('parked');
+
+        expect(await prisma.visit.findFirst({ where: { personId: member.id } })).toBeNull();
+        const log = await prisma.rawBadgeLog.findUnique({ where: { clientEventId: 'evt-stale' } });
+        expect(log?.reviewReason).toBe('stale_replay');
+    });
+
+    it('a fresh replay whose scannedAt is older than a later departure parks (out-of-order guard)', async () => {
+        // Live check-in and check-out first, well past the 3s debounce.
+        await POST(scanReq({ participantId: member.id }));
+        await prisma.rawBadgeLog.updateMany({ where: { personId: member.id }, data: { timestamp: new Date(Date.now() - 5000) } });
+        await POST(scanReq({ participantId: member.id }));
+
+        // A queued check-in from BEFORE that departure arrives late — state has
+        // moved past it.
+        const scannedAt = new Date(Date.now() - 4000);
+        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-out-of-order', scannedAt: scannedAt.toISOString() }));
+        expect(res.status).toBe(200);
+        expect((await res.json()).type).toBe('parked');
+
+        const log = await prisma.rawBadgeLog.findUnique({ where: { clientEventId: 'evt-out-of-order' } });
+        expect(log?.reviewReason).toBe('out_of_order');
+    });
+});

--- a/checkin-app/src/app/__tests__/scanReplay.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanReplay.integration.test.ts
@@ -3,9 +3,10 @@
  */
 /**
  * Kiosk replay idempotency against the real DB (docs/designs/KIOSK_RESILIENCE.md
- * §2): a queued scan carries clientEventId + scannedAt, and replay must dedup,
- * toggle with the original scan time, and park instead of toggling when stale
- * or out-of-order.
+ * §2): a queued scan carries clientEventId + scannedAt + `replay: true`, and
+ * replay must dedup, toggle with the original scan time, and park instead of
+ * toggling when stale or out-of-order. The live attempt carries the same
+ * clientEventId (D4 try-first) but no flag, so none of those guards apply to it.
  */
 import { POST } from '@/app/api/scan/route';
 import prisma from '@/lib/prisma';
@@ -65,11 +66,13 @@ describe('Scan replay — clientEventId dedup and freshness window (real DB)', (
     });
 
     it('redelivering the same clientEventId dedups instead of toggling a second time', async () => {
+        // The real sequence: a live attempt whose ack was lost, then the drain's
+        // redelivery of the same event.
         const scannedAt = new Date().toISOString();
         const first = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-dedup', scannedAt }));
         expect((await first.json()).type).toBe('checkin');
 
-        const retry = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-dedup', scannedAt }));
+        const retry = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-dedup', scannedAt, replay: true }));
         expect(retry.status).toBe(200);
         expect((await retry.json()).type).toBe('duplicate_ignored');
 
@@ -79,16 +82,25 @@ describe('Scan replay — clientEventId dedup and freshness window (real DB)', (
 
     it('a fresh replay toggles using scannedAt as the recorded arrival time', async () => {
         const scannedAt = new Date(Date.now() - 60_000); // 1 min ago, within W
-        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-fresh', scannedAt: scannedAt.toISOString() }));
+        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-fresh', scannedAt: scannedAt.toISOString(), replay: true }));
         expect((await res.json()).type).toBe('checkin');
 
         const visit = await prisma.visit.findFirst({ where: { personId: member.id } });
         expect(visit?.arrivedAt.getTime()).toBe(scannedAt.getTime());
     });
 
+    it('a LIVE scan is never parked by the freshness window and arrives at server-now', async () => {
+        const scannedAt = new Date(Date.now() - 20 * 60_000); // stale, but no replay flag
+        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-live-stale', scannedAt: scannedAt.toISOString() }));
+        expect((await res.json()).type).toBe('checkin');
+
+        const visit = await prisma.visit.findFirst({ where: { personId: member.id } });
+        expect(visit?.arrivedAt.getTime()).toBeGreaterThan(Date.now() - 60_000);
+    });
+
     it('a replay older than the freshness window parks instead of toggling', async () => {
         const scannedAt = new Date(Date.now() - 20 * 60_000); // 20 min ago > 10 min W
-        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-stale', scannedAt: scannedAt.toISOString() }));
+        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-stale', scannedAt: scannedAt.toISOString(), replay: true }));
         expect(res.status).toBe(200);
         expect((await res.json()).type).toBe('parked');
 
@@ -110,7 +122,7 @@ describe('Scan replay — clientEventId dedup and freshness window (real DB)', (
         // A queued check-in from BEFORE that departure arrives late — state has
         // moved past it.
         const scannedAt = new Date(Date.now() - 4000);
-        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-out-of-order', scannedAt: scannedAt.toISOString() }));
+        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-out-of-order', scannedAt: scannedAt.toISOString(), replay: true }));
         expect(res.status).toBe(200);
         expect((await res.json()).type).toBe('parked');
 
@@ -137,7 +149,7 @@ describe('Scan replay — clientEventId dedup and freshness window (real DB)', (
         // Replay dated between B's activity and A's departedAt -- state (via A)
         // has moved past it, even though B is the most-recently-arrived visit.
         const scannedAt = new Date(now - 3 * 60_000);
-        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-f7-max-departed', scannedAt: scannedAt.toISOString() }));
+        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-f7-max-departed', scannedAt: scannedAt.toISOString(), replay: true }));
         expect(res.status).toBe(200);
         expect((await res.json()).type).toBe('parked');
 

--- a/checkin-app/src/app/__tests__/scanReplay.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanReplay.integration.test.ts
@@ -98,10 +98,18 @@ describe('Scan replay — clientEventId dedup and freshness window (real DB)', (
     });
 
     it('a fresh replay whose scannedAt is older than a later departure parks (out-of-order guard)', async () => {
-        // Live check-in and check-out first, well past the 3s debounce.
+        // Live check-in and check-out first, well past the 3s debounce. Each
+        // RawBadgeLog row is backdated after being written -- the debounce
+        // pre-read runs against real "now" (§2 D3: "the debounce read at
+        // delivery time"), not scannedAt, so an un-backdated row from either
+        // live scan would otherwise get swallowed as ignored_debounce by the
+        // replay POST below before the out-of-order guard ever sees it. That
+        // collision is real and accepted by the design when it happens live;
+        // this test wants to isolate the guard, not exercise the debounce.
         await POST(scanReq({ participantId: member.id }));
         await prisma.rawBadgeLog.updateMany({ where: { personId: member.id }, data: { timestamp: new Date(Date.now() - 5000) } });
         await POST(scanReq({ participantId: member.id }));
+        await prisma.rawBadgeLog.updateMany({ where: { personId: member.id }, data: { timestamp: new Date(Date.now() - 5000) } });
 
         // A queued check-in from BEFORE that departure arrives late — state has
         // moved past it.
@@ -111,6 +119,33 @@ describe('Scan replay — clientEventId dedup and freshness window (real DB)', (
         expect((await res.json()).type).toBe('parked');
 
         const log = await prisma.rawBadgeLog.findUnique({ where: { clientEventId: 'evt-out-of-order' } });
+        expect(log?.reviewReason).toBe('out_of_order');
+    });
+
+    // F7: a naive "most-recently-arrived visit" pick can miss a departedAt
+    // that belongs to an OLDER-arrived visit -- e.g. a same-day resolution
+    // (D7) writes a departedAt at resolution time on a visit that arrived
+    // earlier than another visit's own arrival. The guard must compare the
+    // true max across all of the participant's visit activity.
+    it('parks on an older-arrived visit\'s newer departedAt, not just the latest-arrived visit (F7)', async () => {
+        const now = Date.now();
+        // Visit A: arrived earliest, but departed most recently (e.g. resolved late).
+        await prisma.visit.create({
+            data: { personId: member.id, arrivedAt: new Date(now - 10 * 60_000), departedAt: new Date(now - 60_000), arrivedVia: 'SCANNER' },
+        });
+        // Visit B: arrived more recently than A, but departed before A's departure.
+        await prisma.visit.create({
+            data: { personId: member.id, arrivedAt: new Date(now - 8 * 60_000), departedAt: new Date(now - 7 * 60_000), arrivedVia: 'SCANNER' },
+        });
+
+        // Replay dated between B's activity and A's departedAt -- state (via A)
+        // has moved past it, even though B is the most-recently-arrived visit.
+        const scannedAt = new Date(now - 3 * 60_000);
+        const res = await POST(scanReq({ participantId: member.id, clientEventId: 'evt-f7-max-departed', scannedAt: scannedAt.toISOString() }));
+        expect(res.status).toBe(200);
+        expect((await res.json()).type).toBe('parked');
+
+        const log = await prisma.rawBadgeLog.findUnique({ where: { clientEventId: 'evt-f7-max-departed' } });
         expect(log?.reviewReason).toBe('out_of_order');
     });
 });

--- a/checkin-app/src/app/__tests__/scanReplay.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanReplay.integration.test.ts
@@ -98,14 +98,10 @@ describe('Scan replay — clientEventId dedup and freshness window (real DB)', (
     });
 
     it('a fresh replay whose scannedAt is older than a later departure parks (out-of-order guard)', async () => {
-        // Live check-in and check-out first, well past the 3s debounce. Each
-        // RawBadgeLog row is backdated after being written -- the debounce
-        // pre-read runs against real "now" (§2 D3: "the debounce read at
-        // delivery time"), not scannedAt, so an un-backdated row from either
-        // live scan would otherwise get swallowed as ignored_debounce by the
-        // replay POST below before the out-of-order guard ever sees it. That
-        // collision is real and accepted by the design when it happens live;
-        // this test wants to isolate the guard, not exercise the debounce.
+        // Live check-in/check-out first, well past the 3s debounce -- each
+        // RawBadgeLog row is backdated after being written since the debounce
+        // pre-read runs against real "now", not scannedAt (§2 D3). This
+        // isolates the out-of-order guard without tripping the debounce.
         await POST(scanReq({ participantId: member.id }));
         await prisma.rawBadgeLog.updateMany({ where: { personId: member.id }, data: { timestamp: new Date(Date.now() - 5000) } });
         await POST(scanReq({ participantId: member.id }));

--- a/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -23,6 +23,7 @@ jest.mock('@/lib/prisma', () => {
         },
         visit: {
             findFirst: jest.fn(),
+            aggregate: jest.fn(),
         },
         systemMetricLog: {
             create: jest.fn().mockResolvedValue({}),
@@ -220,6 +221,7 @@ describe('POST /api/scan', () => {
         it('toggles a fresh replay using scannedAt as the visit time', async () => {
             (prisma.rawBadgeLog.findUnique as jest.Mock).mockResolvedValue(null);
             (prisma.visit.findFirst as jest.Mock).mockResolvedValue(null);
+            (prisma.visit.aggregate as jest.Mock).mockResolvedValue({ _max: { arrivedAt: null, departedAt: null } });
             (processCheckin as jest.Mock).mockResolvedValue(new Response(JSON.stringify({ type: 'checkin' }), { status: 200 }));
 
             const scannedAt = new Date(Date.now() - 60_000).toISOString();
@@ -252,9 +254,11 @@ describe('POST /api/scan', () => {
         it('parks a fresh replay whose scannedAt is older than newer visit activity (out-of-order guard)', async () => {
             (prisma.rawBadgeLog.findUnique as jest.Mock).mockResolvedValue(null);
             const scannedAt = new Date(Date.now() - 5 * 60_000); // within W
-            (prisma.visit.findFirst as jest.Mock).mockResolvedValue({
-                arrivedAt: new Date(Date.now() - 2 * 60_000),
-                departedAt: new Date(Date.now() - 60_000), // newer than scannedAt
+            (prisma.visit.aggregate as jest.Mock).mockResolvedValue({
+                _max: {
+                    arrivedAt: new Date(Date.now() - 2 * 60_000),
+                    departedAt: new Date(Date.now() - 60_000), // newer than scannedAt
+                },
             });
 
             const res = await POST(replayReq({ scannedAt: scannedAt.toISOString() }));

--- a/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -282,5 +282,16 @@ describe('POST /api/scan', () => {
             expect(prisma.rawBadgeLog.findUnique).not.toHaveBeenCalled();
             expect(prisma.rawBadgeLog.create).toHaveBeenCalledWith({ data: { personId: 1, location: 'Main Entrance' } });
         });
+
+        it('an empty-string clientEventId normalizes to null and is treated as a live scan, not a replay', async () => {
+            (prisma.visit.findFirst as jest.Mock).mockResolvedValue(null);
+            (processCheckin as jest.Mock).mockResolvedValue(new Response(JSON.stringify({ type: 'checkin' }), { status: 200 }));
+
+            const res = await POST(replayReq({ clientEventId: '' }));
+            expect(res.status).toBe(200);
+
+            expect(prisma.rawBadgeLog.findUnique).not.toHaveBeenCalled();
+            expect(prisma.rawBadgeLog.create).toHaveBeenCalledWith({ data: { personId: 1, location: 'Main Entrance' } });
+        });
     });
 });

--- a/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -240,6 +240,23 @@ describe('POST /api/scan', () => {
             expect(prisma.rawBadgeLog.create).not.toHaveBeenCalled();
         });
 
+        // Without a usable scannedAt a replay would silently inherit server-now:
+        // the freshness check passes trivially and the out-of-order guard
+        // compares against now, so a stale replay toggles instead of parking.
+        it('rejects replay:true without a scannedAt', async () => {
+            const res = await POST(replayReq({ scannedAt: undefined }));
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toContain('scannedAt');
+            expect(prisma.rawBadgeLog.create).not.toHaveBeenCalled();
+        });
+
+        it('rejects replay:true with an unparseable scannedAt', async () => {
+            const res = await POST(replayReq({ scannedAt: 'not-a-date' }));
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toContain('scannedAt');
+            expect(prisma.rawBadgeLog.create).not.toHaveBeenCalled();
+        });
+
         it('toggles a fresh replay using scannedAt as the visit time', async () => {
             (prisma.rawBadgeLog.findUnique as jest.Mock).mockResolvedValue(null);
             (prisma.visit.findFirst as jest.Mock).mockResolvedValue(null);

--- a/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -5,7 +5,7 @@ import { POST } from '../route';
 import { authenticateRequest } from '@/lib/auth';
 import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import { processCheckin } from '@/lib/scan-service';
+import { processCheckin, processCheckout } from '@/lib/scan-service';
 
 jest.mock('@/lib/auth', () => ({
     authenticateRequest: jest.fn(),
@@ -19,6 +19,7 @@ jest.mock('@/lib/prisma', () => {
         rawBadgeLog: {
             create: jest.fn(),
             findFirst: jest.fn(),
+            findUnique: jest.fn(),
         },
         visit: {
             findFirst: jest.fn(),
@@ -114,7 +115,7 @@ describe('POST /api/scan', () => {
         expect(res.status).toBe(200);
 
         // Scanned, recorded, and checked in AS THE SURVIVOR (id 99), not the badge's own id (1).
-        expect(processCheckin).toHaveBeenCalledWith(survivor, 'session', expect.anything());
+        expect(processCheckin).toHaveBeenCalledWith(survivor, 'session', expect.anything(), expect.any(Date));
         expect(prisma.rawBadgeLog.create).toHaveBeenCalledWith({ data: { personId: 99, location: 'Main Entrance' } });
         expect(logger.info).toHaveBeenCalledWith('Scan forwarded from merged record', {
             badgeId: 1, tombstoneId: 99, survivorId: 99, hops: 1,
@@ -188,5 +189,94 @@ describe('POST /api/scan', () => {
         const json = await res.json();
         expect(json.type).toBe('ignored_debounce');
         expect(json.message).toBe('Scan ignored due to debounce.');
+    });
+
+    // §2 D2/D3 (docs/designs/KIOSK_RESILIENCE.md) — replayed-scan idempotency.
+    describe('replayed scans (clientEventId/scannedAt)', () => {
+        function replayReq(overrides: Record<string, unknown> = {}) {
+            return new Request('http://localhost/api/scan', {
+                method: 'POST',
+                body: JSON.stringify({ participantId: 1, clientEventId: 'evt-1', scannedAt: new Date().toISOString(), ...overrides })
+            }) as unknown as import('next/server').NextRequest;
+        }
+
+        beforeEach(() => {
+            (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'kiosk' });
+            (prisma.person.findUnique as jest.Mock).mockResolvedValue({ id: 1, mergedIntoId: null });
+            (prisma.rawBadgeLog.findFirst as jest.Mock).mockResolvedValue(null);
+        });
+
+        it('acks a redelivered clientEventId as duplicate_ignored without re-toggling', async () => {
+            (prisma.rawBadgeLog.findUnique as jest.Mock).mockResolvedValue({ id: 5, clientEventId: 'evt-1' });
+
+            const res = await POST(replayReq());
+            expect(res.status).toBe(200);
+            const json = await res.json();
+            expect(json.type).toBe('duplicate_ignored');
+            expect(prisma.rawBadgeLog.create).not.toHaveBeenCalled();
+            expect(processCheckin).not.toHaveBeenCalled();
+        });
+
+        it('toggles a fresh replay using scannedAt as the visit time', async () => {
+            (prisma.rawBadgeLog.findUnique as jest.Mock).mockResolvedValue(null);
+            (prisma.visit.findFirst as jest.Mock).mockResolvedValue(null);
+            (processCheckin as jest.Mock).mockResolvedValue(new Response(JSON.stringify({ type: 'checkin' }), { status: 200 }));
+
+            const scannedAt = new Date(Date.now() - 60_000).toISOString();
+            const res = await POST(replayReq({ scannedAt }));
+            expect(res.status).toBe(200);
+
+            expect(prisma.rawBadgeLog.create).toHaveBeenCalledWith({
+                data: { personId: 1, location: 'Main Entrance', clientEventId: 'evt-1', timestamp: new Date(scannedAt) },
+            });
+            expect(processCheckin).toHaveBeenCalledWith({ id: 1, mergedIntoId: null }, 'kiosk', expect.anything(), new Date(scannedAt));
+        });
+
+        it('parks a replay older than the freshness window instead of toggling', async () => {
+            (prisma.rawBadgeLog.findUnique as jest.Mock).mockResolvedValue(null);
+
+            const scannedAt = new Date(Date.now() - 20 * 60_000).toISOString(); // 20 min ago > 10 min W
+            const res = await POST(replayReq({ scannedAt }));
+            expect(res.status).toBe(200);
+            const json = await res.json();
+            expect(json.type).toBe('parked');
+
+            expect(prisma.rawBadgeLog.create).toHaveBeenCalledWith({
+                data: { personId: 1, location: 'Main Entrance', clientEventId: 'evt-1', timestamp: new Date(scannedAt), reviewReason: 'stale_replay' },
+            });
+            expect(prisma.visit.findFirst).not.toHaveBeenCalled();
+            expect(processCheckin).not.toHaveBeenCalled();
+            expect(processCheckout).not.toHaveBeenCalled();
+        });
+
+        it('parks a fresh replay whose scannedAt is older than newer visit activity (out-of-order guard)', async () => {
+            (prisma.rawBadgeLog.findUnique as jest.Mock).mockResolvedValue(null);
+            const scannedAt = new Date(Date.now() - 5 * 60_000); // within W
+            (prisma.visit.findFirst as jest.Mock).mockResolvedValue({
+                arrivedAt: new Date(Date.now() - 2 * 60_000),
+                departedAt: new Date(Date.now() - 60_000), // newer than scannedAt
+            });
+
+            const res = await POST(replayReq({ scannedAt: scannedAt.toISOString() }));
+            expect(res.status).toBe(200);
+            const json = await res.json();
+            expect(json.type).toBe('parked');
+            expect(prisma.rawBadgeLog.create).toHaveBeenCalledWith(
+                expect.objectContaining({ data: expect.objectContaining({ reviewReason: 'out_of_order' }) })
+            );
+            expect(processCheckin).not.toHaveBeenCalled();
+            expect(processCheckout).not.toHaveBeenCalled();
+        });
+
+        it('a same-body legacy scan (no clientEventId) is unaffected — no dedup pre-read, no park branch', async () => {
+            (prisma.visit.findFirst as jest.Mock).mockResolvedValue(null);
+            (processCheckin as jest.Mock).mockResolvedValue(new Response(JSON.stringify({ type: 'checkin' }), { status: 200 }));
+
+            const res = await POST(replayReq({ clientEventId: undefined, scannedAt: undefined }));
+            expect(res.status).toBe(200);
+
+            expect(prisma.rawBadgeLog.findUnique).not.toHaveBeenCalled();
+            expect(prisma.rawBadgeLog.create).toHaveBeenCalledWith({ data: { personId: 1, location: 'Main Entrance' } });
+        });
     });
 });

--- a/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -192,12 +192,14 @@ describe('POST /api/scan', () => {
         expect(json.message).toBe('Scan ignored due to debounce.');
     });
 
-    // §2 D2/D3 (docs/designs/KIOSK_RESILIENCE.md) — replayed-scan idempotency.
+    // §2 D2/D3/D4 (docs/designs/KIOSK_RESILIENCE.md) — replayed-scan idempotency.
+    // `replay: true` marks a redelivery; D4's try-first rule puts clientEventId
+    // on the live attempt too, so the id alone never implies a replay.
     describe('replayed scans (clientEventId/scannedAt)', () => {
         function replayReq(overrides: Record<string, unknown> = {}) {
             return new Request('http://localhost/api/scan', {
                 method: 'POST',
-                body: JSON.stringify({ participantId: 1, clientEventId: 'evt-1', scannedAt: new Date().toISOString(), ...overrides })
+                body: JSON.stringify({ participantId: 1, clientEventId: 'evt-1', scannedAt: new Date().toISOString(), replay: true, ...overrides })
             }) as unknown as import('next/server').NextRequest;
         }
 
@@ -216,6 +218,26 @@ describe('POST /api/scan', () => {
             expect(json.type).toBe('duplicate_ignored');
             expect(prisma.rawBadgeLog.create).not.toHaveBeenCalled();
             expect(processCheckin).not.toHaveBeenCalled();
+        });
+
+        it('dedups on clientEventId regardless of the replay flag (try-first contract)', async () => {
+            (prisma.rawBadgeLog.findUnique as jest.Mock).mockResolvedValue({ id: 5, clientEventId: 'evt-1' });
+
+            const res = await POST(replayReq({ replay: undefined }));
+            expect((await res.json()).type).toBe('duplicate_ignored');
+            expect(prisma.rawBadgeLog.create).not.toHaveBeenCalled();
+        });
+
+        it('rejects a non-boolean replay flag rather than guessing its truthiness', async () => {
+            const res = await POST(replayReq({ replay: 'true' }));
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toContain('replay');
+        });
+
+        it('rejects replay:true without a clientEventId — it could neither dedup nor park', async () => {
+            const res = await POST(replayReq({ clientEventId: undefined }));
+            expect(res.status).toBe(400);
+            expect(prisma.rawBadgeLog.create).not.toHaveBeenCalled();
         });
 
         it('toggles a fresh replay using scannedAt as the visit time', async () => {
@@ -276,7 +298,7 @@ describe('POST /api/scan', () => {
             (prisma.visit.findFirst as jest.Mock).mockResolvedValue(null);
             (processCheckin as jest.Mock).mockResolvedValue(new Response(JSON.stringify({ type: 'checkin' }), { status: 200 }));
 
-            const res = await POST(replayReq({ clientEventId: undefined, scannedAt: undefined }));
+            const res = await POST(replayReq({ clientEventId: undefined, scannedAt: undefined, replay: undefined }));
             expect(res.status).toBe(200);
 
             expect(prisma.rawBadgeLog.findUnique).not.toHaveBeenCalled();
@@ -287,11 +309,69 @@ describe('POST /api/scan', () => {
             (prisma.visit.findFirst as jest.Mock).mockResolvedValue(null);
             (processCheckin as jest.Mock).mockResolvedValue(new Response(JSON.stringify({ type: 'checkin' }), { status: 200 }));
 
-            const res = await POST(replayReq({ clientEventId: '' }));
+            const res = await POST(replayReq({ clientEventId: '', replay: undefined }));
             expect(res.status).toBe(200);
 
             expect(prisma.rawBadgeLog.findUnique).not.toHaveBeenCalled();
             expect(prisma.rawBadgeLog.create).toHaveBeenCalledWith({ data: { personId: 1, location: 'Main Entrance' } });
+        });
+    });
+
+    // The live kiosk scan carries clientEventId (D4 try-first) but no replay
+    // flag: it must dedup, and otherwise behave exactly like a legacy live scan.
+    describe('live scans carrying a clientEventId (no replay flag)', () => {
+        function liveReq(overrides: Record<string, unknown> = {}) {
+            return new Request('http://localhost/api/scan', {
+                method: 'POST',
+                body: JSON.stringify({ participantId: 1, clientEventId: 'evt-live', scannedAt: new Date().toISOString(), ...overrides })
+            }) as unknown as import('next/server').NextRequest;
+        }
+
+        beforeEach(() => {
+            (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'kiosk' });
+            (prisma.person.findUnique as jest.Mock).mockResolvedValue({ id: 1, mergedIntoId: null });
+            (prisma.rawBadgeLog.findFirst as jest.Mock).mockResolvedValue(null);
+            (prisma.rawBadgeLog.findUnique as jest.Mock).mockResolvedValue(null);
+            (prisma.visit.findFirst as jest.Mock).mockResolvedValue(null);
+            (processCheckin as jest.Mock).mockResolvedValue(new Response(JSON.stringify({ type: 'checkin' }), { status: 200 }));
+        });
+
+        it('records the dedup key but stamps server-now, never the kiosk scannedAt', async () => {
+            const res = await POST(liveReq({ scannedAt: new Date(Date.now() - 60_000).toISOString() }));
+            expect(res.status).toBe(200);
+
+            // No `timestamp` override -> the column default (now).
+            expect(prisma.rawBadgeLog.create).toHaveBeenCalledWith({
+                data: { personId: 1, location: 'Main Entrance', clientEventId: 'evt-live' },
+            });
+        });
+
+        it('is never parked by the freshness window, however old its scannedAt', async () => {
+            const res = await POST(liveReq({ scannedAt: new Date(Date.now() - 20 * 60_000).toISOString() }));
+            expect((await res.json()).type).toBe('checkin');
+            expect(prisma.visit.aggregate).not.toHaveBeenCalled();
+            expect(processCheckin).toHaveBeenCalled();
+        });
+
+        it('is never parked by the out-of-order guard, and checks out as live (no replay id)', async () => {
+            (prisma.visit.findFirst as jest.Mock).mockResolvedValue({ id: 7 });
+            (prisma.visit.aggregate as jest.Mock).mockResolvedValue({
+                _max: { arrivedAt: new Date(), departedAt: new Date() },
+            });
+            (processCheckout as jest.Mock).mockResolvedValue(new Response(JSON.stringify({ type: 'checkout' }), { status: 200 }));
+
+            const res = await POST(liveReq());
+            expect((await res.json()).type).toBe('checkout');
+            // Last arg null => processCheckout takes the live warn/confirm path.
+            expect(processCheckout).toHaveBeenCalledWith({ id: 1, mergedIntoId: null }, 7, 'kiosk', expect.anything(), expect.any(Date), null);
+        });
+
+        it('still dedups a clientEventId already recorded server-side', async () => {
+            (prisma.rawBadgeLog.findUnique as jest.Mock).mockResolvedValue({ id: 5, clientEventId: 'evt-live' });
+
+            const res = await POST(liveReq());
+            expect((await res.json()).type).toBe('duplicate_ignored');
+            expect(prisma.rawBadgeLog.create).not.toHaveBeenCalled();
         });
     });
 });

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -17,6 +17,13 @@ const MAX_MERGE_HOPS = 5;
 // kiosk was offline, and a bare toggle can't tell entering from leaving.
 const REPLAY_FRESHNESS_WINDOW_MS = 10 * 60 * 1000;
 
+// F7: the out-of-order guard needs the true latest activity across ALL of a
+// participant's visits, not just the most-recently-arrived one -- a
+// same-day/next-day resolution (D7) can write a departedAt newer than a
+// later visit's own arrival, and comparing arrivedAt alone would miss it.
+const maxDate = (a: Date | null, b: Date | null): Date | null =>
+    !a ? b : !b ? a : (a > b ? a : b);
+
 // High cap: kiosks burst and a whole facility may share one NAT IP. withKiosk
 // reads the raw body, authenticates it (kiosk signature OR session), rejects
 // unauthenticated, and hands us the parsed body + actor. We own authorization.
@@ -166,11 +173,11 @@ export const POST = withKiosk(
                 if (stale) {
                     parkReason = "stale_replay";
                 } else {
-                    const latestVisit = await tx.visit.findFirst({
+                    const activity = await tx.visit.aggregate({
                         where: { personId: participant.id, deletedAt: null },
-                        orderBy: { arrivedAt: "desc" },
+                        _max: { arrivedAt: true, departedAt: true },
                     });
-                    const latestActivityAt = latestVisit ? (latestVisit.departedAt ?? latestVisit.arrivedAt) : null;
+                    const latestActivityAt = maxDate(activity._max.arrivedAt, activity._max.departedAt);
                     if (latestActivityAt && latestActivityAt > eventTime) {
                         parkReason = "out_of_order";
                     }
@@ -205,7 +212,7 @@ export const POST = withKiosk(
             });
 
             if (activeVisit) {
-                return await processCheckout(participant, activeVisit.id, authType, tx, eventTime);
+                return await processCheckout(participant, activeVisit.id, authType, tx, eventTime, clientEventId);
             } else {
                 return await processCheckin(participant, authType, tx, eventTime);
             }

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -29,7 +29,7 @@ const maxDate = (a: Date | null, b: Date | null): Date | null =>
 // unauthenticated, and hands us the parsed body + actor. We own authorization.
 export const POST = withKiosk(
     { rateLimit: { name: "scan", limit: 300 } },
-    async (_req, body: { participantId?: unknown; clientEventId?: unknown; scannedAt?: unknown }, auth) => {
+    async (_req, body: { participantId?: unknown; clientEventId?: unknown; scannedAt?: unknown; replay?: unknown }, auth) => {
     const startTime = Date.now();
 
     try {
@@ -45,8 +45,22 @@ export const POST = withKiosk(
         const clientEventId = (typeof body.clientEventId === 'string' && body.clientEventId) || null;
         const parsedScannedAt = typeof body.scannedAt === 'string' ? new Date(body.scannedAt) : null;
         const scannedAt = parsedScannedAt && !isNaN(parsedScannedAt.getTime()) ? parsedScannedAt : null;
-        const isReplay = clientEventId !== null;
-        const eventTime = scannedAt ?? new Date();
+
+        // Replay-ness is explicit: only the outbox drain sets it. It cannot be
+        // inferred from clientEventId, because D4's try-first rule puts that id
+        // on the LIVE attempt too so a later redelivery dedups.
+        if (body.replay !== undefined && typeof body.replay !== 'boolean') {
+            return apiError("replay must be a boolean.", 400);
+        }
+        const isReplay = body.replay === true;
+        if (isReplay && !clientEventId) {
+            return apiError("A replayed scan requires clientEventId.", 400);
+        }
+
+        // A replay carries its own event time; a live scan is happening now, so
+        // it never inherits the kiosk's clock (D3's window and the debounce both
+        // measure against server now).
+        const eventTime = isReplay && scannedAt ? scannedAt : new Date();
 
         // Web session: check if user can scan this participant
         let pendingHouseholdCheck = false;
@@ -212,7 +226,7 @@ export const POST = withKiosk(
             });
 
             if (activeVisit) {
-                return await processCheckout(participant, activeVisit.id, authType, tx, eventTime, clientEventId);
+                return await processCheckout(participant, activeVisit.id, authType, tx, eventTime, isReplay ? clientEventId : null);
             } else {
                 return await processCheckin(participant, authType, tx, eventTime);
             }

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -1,6 +1,7 @@
+import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
-import { apiError } from "@/lib/api-response";
+import { apiError, apiJson } from "@/lib/api-response";
 import { processCheckin, processCheckout, finalizeFacilityClose } from "@/lib/scan-service";
 import { config } from "@/lib/config";
 import { withKiosk } from "@/lib/kioskAuth";
@@ -11,12 +12,17 @@ import { withKiosk } from "@/lib/kioskAuth";
 // a corrupt/cyclic chain can't loop the lookup forever, and reissue instead.
 const MAX_MERGE_HOPS = 5;
 
+// docs/designs/KIOSK_RESILIENCE.md §2: a replayed scan older than this parks
+// for human review instead of toggling — state may have moved on while the
+// kiosk was offline, and a bare toggle can't tell entering from leaving.
+const REPLAY_FRESHNESS_WINDOW_MS = 10 * 60 * 1000;
+
 // High cap: kiosks burst and a whole facility may share one NAT IP. withKiosk
 // reads the raw body, authenticates it (kiosk signature OR session), rejects
 // unauthenticated, and hands us the parsed body + actor. We own authorization.
 export const POST = withKiosk(
     { rateLimit: { name: "scan", limit: 300 } },
-    async (_req, body: { participantId?: unknown }, auth) => {
+    async (_req, body: { participantId?: unknown; clientEventId?: unknown; scannedAt?: unknown }, auth) => {
     const startTime = Date.now();
 
     try {
@@ -25,6 +31,15 @@ export const POST = withKiosk(
         if (!participantId || typeof participantId !== 'number') {
             return apiError("A valid numeric participantId is required.", 400);
         }
+
+        // Optional replay fields from a queued kiosk scan. Absent → exactly
+        // today's behavior (legacy/web callers). A malformed scannedAt falls
+        // back to now rather than propagating an Invalid Date into the visit.
+        const clientEventId = typeof body.clientEventId === 'string' ? body.clientEventId : null;
+        const parsedScannedAt = typeof body.scannedAt === 'string' ? new Date(body.scannedAt) : null;
+        const scannedAt = parsedScannedAt && !isNaN(parsedScannedAt.getTime()) ? parsedScannedAt : null;
+        const isReplay = clientEventId !== null;
+        const eventTime = scannedAt ?? new Date();
 
         // Web session: check if user can scan this participant
         let pendingHouseholdCheck = false;
@@ -103,12 +118,24 @@ export const POST = withKiosk(
         // and branches correctly. The lock auto-releases on commit/rollback.
         const authType = auth.type;
 
-        const res = await prisma.$transaction(async (tx) => {
+        let res: Response;
+        try {
+        res = await prisma.$transaction(async (tx) => {
             // Per-participant lock. Serializes only same-participant scans;
             // different participants get different lock keys and never block.
             // $executeRaw (not $queryRaw): pg_advisory_xact_lock returns `void`,
             // which $queryRaw cannot deserialize. $executeRaw just runs it.
             await tx.$executeRaw`SELECT pg_advisory_xact_lock(${participant.id})`;
+
+            // A replayed event carries its own idempotency key. Pre-read before
+            // the debounce check — an ack lost after the original attempt
+            // committed must dedup even once the 3s debounce window has passed.
+            if (clientEventId) {
+                const seen = await tx.rawBadgeLog.findUnique({ where: { clientEventId } });
+                if (seen) {
+                    return apiJson({ type: 'duplicate_ignored', message: 'Event already recorded.' });
+                }
+            }
 
             // 4. Double scan debounce check (3 seconds) — now under the lock, so
             // it sees the committed badge event of any racing scan ahead of it.
@@ -130,13 +157,42 @@ export const POST = withKiosk(
                 });
             }
 
-            // 5. Record raw badge event
+            // A replay older than the freshness window, or one that lands behind
+            // visit activity newer than its own scan time, can't be trusted to
+            // toggle — state has moved past it. Park it for a human instead.
+            let parkReason: string | null = null;
+            if (isReplay) {
+                const stale = Date.now() - eventTime.getTime() > REPLAY_FRESHNESS_WINDOW_MS;
+                if (stale) {
+                    parkReason = "stale_replay";
+                } else {
+                    const latestVisit = await tx.visit.findFirst({
+                        where: { personId: participant.id, deletedAt: null },
+                        orderBy: { arrivedAt: "desc" },
+                    });
+                    const latestActivityAt = latestVisit ? (latestVisit.departedAt ?? latestVisit.arrivedAt) : null;
+                    if (latestActivityAt && latestActivityAt > eventTime) {
+                        parkReason = "out_of_order";
+                    }
+                }
+            }
+
+            // 5. Record raw badge event — always, even when parking: the touch
+            // itself is never lost, only its Visit projection is deferred for
+            // review.
             await tx.rawBadgeLog.create({
                 data: {
                     personId: participant.id,
                     location: "Main Entrance",
+                    ...(clientEventId ? { clientEventId } : {}),
+                    ...(isReplay ? { timestamp: eventTime } : {}),
+                    ...(parkReason ? { reviewReason: parkReason } : {}),
                 },
             });
+
+            if (parkReason) {
+                return apiJson({ type: 'parked', message: 'Recorded for review.' });
+            }
 
             // 6. Check-in or check-out
             const activeVisit = await tx.visit.findFirst({
@@ -149,9 +205,9 @@ export const POST = withKiosk(
             });
 
             if (activeVisit) {
-                return await processCheckout(participant, activeVisit.id, authType, tx);
+                return await processCheckout(participant, activeVisit.id, authType, tx, eventTime);
             } else {
-                return await processCheckin(participant, authType, tx);
+                return await processCheckin(participant, authType, tx, eventTime);
             }
         }, {
             // maxWait: time a racing scan waits to acquire a connection / start.
@@ -160,6 +216,15 @@ export const POST = withKiosk(
             maxWait: 5000,
             timeout: 15000,
         });
+        } catch (err) {
+            // Cross-lock race on the same clientEventId (e.g. two replay attempts
+            // of one queued event racing different advisory-lock windows) — the
+            // unique constraint is the backstop the pre-read can't fully close.
+            if (clientEventId && err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+                return apiJson({ type: 'duplicate_ignored', message: 'Event already recorded.' });
+            }
+            throw err;
+        }
 
         // Facility-wide close runs here, AFTER the per-participant transaction
         // commits and the advisory lock is released. Keeping the sweep + email

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -40,8 +40,8 @@ export const POST = withKiosk(
         }
 
         // Optional replay fields from a queued kiosk scan. Absent → exactly
-        // today's behavior (legacy/web callers). A malformed scannedAt falls
-        // back to now rather than propagating an Invalid Date into the visit.
+        // today's behavior (legacy/web callers). An unparseable scannedAt
+        // normalizes to null, which a replay then rejects below.
         const clientEventId = (typeof body.clientEventId === 'string' && body.clientEventId) || null;
         const parsedScannedAt = typeof body.scannedAt === 'string' ? new Date(body.scannedAt) : null;
         const scannedAt = parsedScannedAt && !isNaN(parsedScannedAt.getTime()) ? parsedScannedAt : null;
@@ -53,14 +53,21 @@ export const POST = withKiosk(
             return apiError("replay must be a boolean.", 400);
         }
         const isReplay = body.replay === true;
-        if (isReplay && !clientEventId) {
-            return apiError("A replayed scan requires clientEventId.", 400);
-        }
 
-        // A replay carries its own event time; a live scan is happening now, so
-        // it never inherits the kiosk's clock (D3's window and the debounce both
-        // measure against server now).
-        const eventTime = isReplay && scannedAt ? scannedAt : new Date();
+        // A live scan is happening now and never inherits the kiosk's clock (D3's
+        // window and the debounce both measure against server now). A replay must
+        // carry its own id and event time: falling back to now would make the
+        // freshness check pass trivially and toggle a scan that should park.
+        let eventTime = new Date();
+        if (isReplay) {
+            if (!clientEventId) {
+                return apiError("A replayed scan requires clientEventId.", 400);
+            }
+            if (!scannedAt) {
+                return apiError("A replayed scan requires a valid scannedAt.", 400);
+            }
+            eventTime = scannedAt;
+        }
 
         // Web session: check if user can scan this participant
         let pendingHouseholdCheck = false;

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -42,7 +42,7 @@ export const POST = withKiosk(
         // Optional replay fields from a queued kiosk scan. Absent → exactly
         // today's behavior (legacy/web callers). A malformed scannedAt falls
         // back to now rather than propagating an Invalid Date into the visit.
-        const clientEventId = typeof body.clientEventId === 'string' ? body.clientEventId : null;
+        const clientEventId = (typeof body.clientEventId === 'string' && body.clientEventId) || null;
         const parsedScannedAt = typeof body.scannedAt === 'string' ? new Date(body.scannedAt) : null;
         const scannedAt = parsedScannedAt && !isNaN(parsedScannedAt.getTime()) ? parsedScannedAt : null;
         const isReplay = clientEventId !== null;

--- a/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
+++ b/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
@@ -109,6 +109,33 @@ describe("force close is bound to the warning", () => {
     });
 });
 
+describe("a LIVE scan carrying a clientEventId still warns and confirms", () => {
+    // D4 try-first puts the idempotency key on the live attempt, so the park
+    // must key on the replay flag (null here), never on the id's presence.
+    const present = [{ name: "Someone Inside", email: "inside@example.com" }];
+
+    it("warns and stamps on the first live scan even though the scan has an event id", async () => {
+        const db = fakeDb(present);
+        const res = await processCheckout(keyholder, 42, "kiosk", db, new Date(), null);
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).type).toBe("warning");
+        expect(db.visit.update).toHaveBeenCalledWith({
+            where: { id: 42 },
+            data: { forceCloseWarnedAt: expect.any(Date) },
+        });
+        expect(db.rawBadgeLog.update).not.toHaveBeenCalled();
+    });
+
+    it("force-closes on the confirming live scan that follows the stamp", async () => {
+        const db = fakeDb(present, new Date(Date.now() - 8000));
+        const res = await processCheckout(keyholder, 42, "kiosk", db, new Date(), null);
+
+        expect(res.status).toBe(200);
+        expect((await res.json()).facilityClosed).toBe(true);
+    });
+});
+
 describe("F1: replay must not be able to force-close (§4 phase gate)", () => {
     const present = [{ name: "Someone Inside", email: "inside@example.com" }];
 

--- a/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
+++ b/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
@@ -36,6 +36,9 @@ function fakeDb(
             findUnique: jest.fn().mockResolvedValue({ forceCloseWarnedAt: warnedAt }),
             update: jest.fn().mockResolvedValue({}),
         },
+        rawBadgeLog: {
+            update: jest.fn().mockResolvedValue({}),
+        },
     } as unknown as DbClient;
 }
 
@@ -103,5 +106,37 @@ describe("force close is bound to the warning", () => {
 
         expect(res.status).toBe(400);
         expect((await res.json()).type).toBe("warning");
+    });
+});
+
+describe("F1: replay must not be able to force-close (§4 phase gate)", () => {
+    const present = [{ name: "Someone Inside", email: "inside@example.com" }];
+
+    it("a replayed checkout parks instead of warning/confirming, never touching forceCloseWarnedAt", async () => {
+        const db = fakeDb(present);
+        const res = await processCheckout(keyholder, 42, "kiosk", db, new Date(), "evt-replay-1");
+
+        expect(res.status).toBe(200);
+        expect((await res.json()).type).toBe("parked");
+        expect(db.visit.findUnique).not.toHaveBeenCalled();
+        expect(db.visit.update).not.toHaveBeenCalled();
+        expect(db.rawBadgeLog.update).toHaveBeenCalledWith({
+            where: { clientEventId: "evt-replay-1" },
+            data: { reviewReason: "force_close_review" },
+        });
+    });
+
+    it("two replayed keyholder checkouts do NOT close all open visits -- the second also parks", async () => {
+        const db = fakeDb(present);
+
+        const first = await processCheckout(keyholder, 42, "kiosk", db, new Date(), "evt-replay-1");
+        expect((await first.json()).type).toBe("parked");
+
+        const second = await processCheckout(keyholder, 42, "kiosk", db, new Date(), "evt-replay-2");
+        expect((await second.json()).type).toBe("parked");
+
+        // Neither replay ever stamped or read forceCloseWarnedAt, so nothing
+        // was ever in a position to "confirm" and sweep the room.
+        expect(db.visit.update).not.toHaveBeenCalled();
     });
 });

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -72,7 +72,8 @@ export async function processCheckout(
     activeVisitId: number,
     authType: string,
     db: DbClient = prisma,
-    visitTime: Date = new Date()
+    visitTime: Date = new Date(),
+    clientEventId: string | null = null
 ) {
     let facilityClosed = false;
 
@@ -97,6 +98,20 @@ export async function processCheckout(
             });
 
             if (remainingUsers.length > 0) {
+                if (clientEventId) {
+                    // KIOSK_RESILIENCE.md §4 phase gate: replay must not be able to
+                    // force-close. A queued double-badge can carry a warn+confirm
+                    // pair ~seconds apart that replays unattended; never read or
+                    // write forceCloseWarnedAt for a replay -- park for a human
+                    // instead (D4: a queued confirm's token is from before the
+                    // outage and must expire, not be honored).
+                    await db.rawBadgeLog.update({
+                        where: { clientEventId },
+                        data: { reviewReason: 'force_close_review' },
+                    });
+                    return apiJson({ type: 'parked', message: 'Recorded for review.' });
+                }
+
                 const ownVisit = await db.visit.findUnique({
                     where: { id: activeVisitId },
                     select: { forceCloseWarnedAt: true }

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -99,12 +99,10 @@ export async function processCheckout(
 
             if (remainingUsers.length > 0) {
                 if (clientEventId) {
-                    // KIOSK_RESILIENCE.md §4 phase gate: replay must not be able to
-                    // force-close. A queued double-badge can carry a warn+confirm
-                    // pair ~seconds apart that replays unattended; never read or
-                    // write forceCloseWarnedAt for a replay -- park for a human
-                    // instead (D4: a queued confirm's token is from before the
-                    // outage and must expire, not be honored).
+                    // KIOSK_RESILIENCE.md §4: a replay must not force-close -- a
+                    // queued warn+confirm pair can replay unattended, so we never
+                    // read/write forceCloseWarnedAt for a replay and park it for a
+                    // human instead (its confirm token predates the outage).
                     await db.rawBadgeLog.update({
                         where: { clientEventId },
                         data: { reviewReason: 'force_close_review' },

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -73,7 +73,8 @@ export async function processCheckout(
     authType: string,
     db: DbClient = prisma,
     visitTime: Date = new Date(),
-    clientEventId: string | null = null
+    /** clientEventId of a REPLAYED event (drain-delivered), null for a live scan. */
+    replayEventId: string | null = null
 ) {
     let facilityClosed = false;
 
@@ -98,13 +99,13 @@ export async function processCheckout(
             });
 
             if (remainingUsers.length > 0) {
-                if (clientEventId) {
+                if (replayEventId) {
                     // KIOSK_RESILIENCE.md §4: a replay must not force-close -- a
                     // queued warn+confirm pair can replay unattended, so we never
                     // read/write forceCloseWarnedAt for a replay and park it for a
                     // human instead (its confirm token predates the outage).
                     await db.rawBadgeLog.update({
-                        where: { clientEventId },
+                        where: { clientEventId: replayEventId },
                         data: { reviewReason: 'force_close_review' },
                     });
                     return apiJson({ type: 'parked', message: 'Recorded for review.' });

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -18,7 +18,7 @@ const FORCE_CLOSE_CONFIRM_MS = 60_000;
  * unit tests) `db` defaults to the global prisma client. Fire-and-forget side
  * effects (notifications) intentionally run off the global client either way.
  */
-export async function processCheckin(participant: Person, authType: string, db: DbClient = prisma) {
+export async function processCheckin(participant: Person, authType: string, db: DbClient = prisma, visitTime: Date = new Date()) {
     // Non-keyholders require an open facility (at least 1 isKeyholder present)
     if (!participant.isKeyholder) {
         const activeKeyholders = await db.visit.count({
@@ -34,7 +34,7 @@ export async function processCheckin(participant: Person, authType: string, db: 
         }
     }
 
-    const arrivalTime = new Date();
+    const arrivalTime = visitTime;
     const eventId = await findAssociatedEventAt(participant.id, arrivalTime, db);
 
     const newVisit = await db.visit.create({
@@ -71,7 +71,8 @@ export async function processCheckout(
     participant: Person,
     activeVisitId: number,
     authType: string,
-    db: DbClient = prisma
+    db: DbClient = prisma,
+    visitTime: Date = new Date()
 ) {
     let facilityClosed = false;
 
@@ -144,7 +145,7 @@ export async function processCheckout(
         }
     }
 
-    const finalVisits = await processVisitCheckout(activeVisitId, new Date(), db, "SCANNER");
+    const finalVisits = await processVisitCheckout(activeVisitId, visitTime, db, "SCANNER");
     const updatedVisit = finalVisits.length > 0 ? finalVisits[finalVisits.length - 1] : null;
 
     // Fire-and-forget: send check-out notifications (mirrors processCheckin)

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -264,6 +264,8 @@ export const classifications = {
         personId: 'internal',
         timestamp: 'personal',
         location: 'personal',
+        clientEventId: 'internal',
+        reviewReason: 'internal',
     },
     Visit: {
         id: 'public',

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -8,3 +8,9 @@ __pycache__/
 *.pyo
 venv/
 .venv/
+
+# Offline scan queue (client-generated, per-kiosk)
+outbox.db
+outbox.db-wal
+outbox.db-shm
+outbox.db.corrupt.*

--- a/client/client.py
+++ b/client/client.py
@@ -22,6 +22,8 @@ from http.server import HTTPServer, BaseHTTPRequestHandler, ThreadingHTTPServer
 from nacl.signing import SigningKey
 import requests
 
+from outbox import Outbox, classify_response, replay_drain, new_event_id, now_iso
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -87,22 +89,35 @@ class BackendClient:
         h["Content-Type"] = "application/json"
         return h
 
-    def post_scan(self, participant_id):
+    def post_scan(self, participant_id, client_event_id=None, scanned_at=None):
         path = "/api/scan"
+        payload = {"participantId": participant_id}
         try:
-            body = json.dumps({"participantId": int(participant_id)})
+            payload["participantId"] = int(participant_id)
         except ValueError:
-            body = json.dumps({"participantId": participant_id})
-            
+            pass
+        if client_event_id:
+            payload["clientEventId"] = client_event_id
+        if scanned_at:
+            payload["scannedAt"] = scanned_at
+        body = json.dumps(payload)
+
         headers = self._headers("POST", path, body)
         try:
             r = self.session.post(
                 self.base_url + path, headers=headers, data=body, timeout=10
             )
-            return r.json(), r.status_code
         except Exception as e:
             log.error(f"Failed to post scan: {e}")
-            return {"error": str(e)}, 0
+            return {"error": str(e)}, 0, None
+
+        retry_after = r.headers.get("Retry-After")
+        try:
+            return r.json(), r.status_code, retry_after
+        except ValueError:
+            # Non-JSON body (e.g. the waker's 503 HTML on a cold-wake scan) --
+            # warming, not failure. Never lose the scan on a parse error.
+            return {"error": "non-JSON response", "type": "warming"}, r.status_code, retry_after
 
     def get_attendance(self):
         if not self.attendance_path:
@@ -194,7 +209,7 @@ class KioskHandler(BaseHTTPRequestHandler):
   * {{ margin: 0; padding: 0; box-sizing: border-box; }}
   body, html {{ width: 100%; height: 100%; overflow: hidden; background: #000; font-family: sans-serif; }}
   iframe {{ width: 100%; height: 100%; border: none; }}
-  
+
   #blackout {{
     position: absolute;
     top: 0;
@@ -243,6 +258,11 @@ class KioskHandler(BaseHTTPRequestHandler):
     color: #fff;
     white-space: pre-wrap;
     animation: fadeout 12s forwards;
+  }}
+  .banner-saved {{
+    background: rgba(37,99,235,0.95);
+    border: 2px solid #60a5fa;
+    color: #fff;
   }}
   @keyframes fadeout {{
     0% {{ opacity: 1; }}
@@ -387,17 +407,17 @@ class KioskHandler(BaseHTTPRequestHandler):
 
     def _proxy_request(self, method):
         url = self.backend.base_url + self.path
-        
+
         body_bytes = b""
         length = int(self.headers.get("Content-Length", 0))
         if length > 0:
             body_bytes = self.rfile.read(length)
-            
+
         req_headers = {}
         for k, v in self.headers.items():
             if k.lower() not in ['host', 'connection', 'accept-encoding']:
                 req_headers[k] = v
-                
+
         # Inject Key Signing Headers onto the API requests transparently!
         # Sign with pathname only (no query string) — backend verifies against pathname
         from urllib.parse import urlparse
@@ -409,10 +429,10 @@ class KioskHandler(BaseHTTPRequestHandler):
                 body_str = body_bytes.decode('utf-8')
             except UnicodeDecodeError:
                 pass
-                
+
         sig_headers = sign_request(self.backend.signing_key, method, sign_path, body_str)
         req_headers.update(sig_headers)
-        
+
         try:
             # Use requests.request (stateless) so cookies flow directly between browser and backend
             resp = requests.request(
@@ -424,7 +444,7 @@ class KioskHandler(BaseHTTPRequestHandler):
                 stream=True,
                 timeout=30
             )
-            
+
             try:
                 self.send_response(resp.status_code)
                 for k, v in resp.headers.items():
@@ -441,7 +461,7 @@ class KioskHandler(BaseHTTPRequestHandler):
             except (BrokenPipeError, ConnectionResetError):
                 # Browser closed the connection, normal for HMR or page reloads
                 pass
-                    
+
         except Exception as e:
             if not isinstance(e, (BrokenPipeError, ConnectionResetError)):
                 log.error(f"Proxy error for {self.path}: {e}")
@@ -458,7 +478,7 @@ class KioskHandler(BaseHTTPRequestHandler):
 # ---------------------------------------------------------------------------
 # USB scanner listener
 # ---------------------------------------------------------------------------
-def usb_scanner_listener(backend, state, device_path):
+def usb_scanner_listener(backend, state, outbox, device_path):
     try:
         import evdev
     except ImportError:
@@ -496,7 +516,7 @@ def usb_scanner_listener(backend, state, device_path):
             else:
                 log.error(f"No device found matching: {device_path}")
                 return
-        
+
         dev.grab()
         log.info(f"Listening on: {dev.name} ({dev.path})")
     except Exception as e:
@@ -515,12 +535,12 @@ def usb_scanner_listener(backend, state, device_path):
             if buffer.strip():
                 participant_id = buffer.strip()
                 log.info(f"Scanned ID: {participant_id}")
-                handle_scan(backend, state, participant_id)
+                handle_scan(backend, state, outbox, participant_id)
             buffer = ""
         elif key_event.scancode in KEY_MAP:
             buffer += KEY_MAP[key_event.scancode]
 
-def stdin_scanner_listener(backend, state):
+def stdin_scanner_listener(backend, state, outbox):
     log.info("USB device not configured — reading scans from stdin")
     while True:
         try:
@@ -528,13 +548,11 @@ def stdin_scanner_listener(backend, state):
             participant_id = line.strip()
             if participant_id:
                 log.info(f"Stdin scan: {participant_id}")
-                handle_scan(backend, state, participant_id)
+                handle_scan(backend, state, outbox, participant_id)
         except EOFError:
             break
 
-def handle_scan(backend, state, participant_id):
-    body, status = backend.post_scan(participant_id)
-
+def _scan_result_banner_html(body, status):
     # Build banner HTML for the wrapper page.
     # All values below originate from the backend response (participant names,
     # emails, messages) and are ultimately assigned to the wrapper page via
@@ -543,36 +561,62 @@ def handle_scan(backend, state, participant_id):
     # the kiosk browser — which can issue signed, kiosk-authenticated requests
     # through the local proxy. Escape before the newline->`<br>` substitution so
     # injected markup cannot survive.
-    banner_html = ""
     if status >= 400 or "error" in body:
         if body.get("type") == "warning":
             warn = html.escape(body.get("error", "Warning")).replace("\n", "<br>")
-            banner_html = f'<div class="banner banner-warning">⚠️ {warn}</div>'
-        else:
-            err = html.escape(body.get("error", "Unknown error"))
-            banner_html = f'<div class="banner banner-error">✗ Scan failed: {err}</div>'
-    else:
-        stype = body.get("type", "")
-        email = html.escape(str(body.get("participant", {}).get("email", "?")))
-        msg = html.escape(body.get("message", ""))
-        label = "CHECKED IN" if stype == "checkin" else "CHECKED OUT"
-        if msg and msg != "Checked in successfully" and msg != "Checked out successfully":
-            banner_html = f'<div class="banner banner-ok">✓ {email} — {msg}</div>'
-        else:
-            banner_html = f'<div class="banner banner-ok">✓ {email} — {label}</div>'
+            return f'<div class="banner banner-warning">⚠️ {warn}</div>'
+        err = html.escape(body.get("error", "Unknown error"))
+        return f'<div class="banner banner-error">✗ Scan failed: {err}</div>'
 
-    # Phase 1: Push banner immediately (no attendance data yet)
-    state.push_event({"html": banner_html})
+    stype = body.get("type", "")
+    email = html.escape(str(body.get("participant", {}).get("email", "?")))
+    msg = html.escape(body.get("message", ""))
+    label = "CHECKED IN" if stype == "checkin" else "CHECKED OUT"
+    if msg and msg != "Checked in successfully" and msg != "Checked out successfully":
+        return f'<div class="banner banner-ok">✓ {email} — {msg}</div>'
+    return f'<div class="banner banner-ok">✓ {email} — {label}</div>'
 
-    if status < 400 and "error" not in body:
+def _saved_banner_html(queued):
+    # A queued scan reads as done and safe to walk away from -- distinct
+    # from the red "not saved" state.
+    return f'<div class="banner banner-saved">✓ Saved — will sync ({queued} waiting)</div>'
+
+def handle_scan(backend, state, outbox, participant_id):
+    client_event_id = new_event_id()
+    scanned_at = now_iso()
+
+    # A fresh scan must not jump its own predecessor -- if this participant
+    # already has a pending queued event, enqueue behind it instead of
+    # attempting live delivery out of order.
+    if outbox.has_pending_for_participant(participant_id):
+        outbox.enqueue(client_event_id, participant_id, scanned_at)
+        state.push_event({"html": _saved_banner_html(outbox.pending_count())})
+        log.info(f"Queued (predecessor pending): participant {participant_id}")
+        return
+
+    body, status, retry_after = backend.post_scan(participant_id, client_event_id, scanned_at)
+    outcome = classify_response(status, body)
+
+    if outcome == "retry":
+        # Try live first; only persist to the outbox if it wasn't confirmed.
+        outbox.enqueue(client_event_id, participant_id, scanned_at)
+        state.push_event({"html": _saved_banner_html(outbox.pending_count())})
+        log.warning(f"Scan queued (server unreachable/warming): participant {participant_id}")
+        return
+
+    # ack or dead: server responded definitively at scan time -- render the
+    # existing immediate banner, unchanged behavior for the online path.
+    state.push_event({"html": _scan_result_banner_html(body, status)})
+
+    if outcome == "ack":
         ptype = body.get("type", "?")
         email = body.get("participant", {}).get("email", "?")
         log.info(f"Scan result: {ptype.upper()} — {email}")
     else:
-        log.warning(f"Scan error: {body.get('error', body)}")
+        log.warning(f"Scan error (dead-letter, not queued): {body.get('error', body)}")
 
-    # Phase 2: Fetch fresh attendance and push update for the iframe
-    if backend.attendance_path and status < 400:
+    # Fetch fresh attendance and push update for the iframe
+    if backend.attendance_path and outcome == "ack":
         att_data, att_status = backend.get_attendance()
         if att_status == 200:
             event_payload = {"html": ""}
@@ -606,7 +650,7 @@ def attendance_poller(backend, state, interval=30):
 def version_poller(backend, state, interval=60):
     """Background thread that checks for client and server version updates."""
     import subprocess
-    
+
     # Get initial server version
     initial_server_version = None
     for _ in range(6):
@@ -616,10 +660,10 @@ def version_poller(backend, state, interval=60):
             log.info(f"Initial server version: {initial_server_version}")
             break
         time.sleep(5)
-    
+
     while True:
         time.sleep(interval)
-        
+
         # 1. Check Server Version Update
         if initial_server_version:
             sv, status = backend.get_server_version()
@@ -627,14 +671,14 @@ def version_poller(backend, state, interval=60):
                 log.info(f"Server version changed from {initial_server_version} to {sv}. Requesting reload.")
                 state.push_event({"reload": True})
                 initial_server_version = sv  # Update to prevent spam
-        
+
         # 2. Check Client Version Update
         try:
             subprocess.run(["git", "fetch", "origin", "main"], capture_output=True, timeout=15)
 
             local_head = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
             remote_head = subprocess.check_output(["git", "rev-parse", "origin/main"], text=True).strip()
-            
+
             if local_head and remote_head and local_head != remote_head:
                 log.info(f"Client version update available ({local_head} -> {remote_head}). Restarting client.")
                 os._exit(0)
@@ -665,6 +709,8 @@ def main():
 
     backend = BackendClient(backend_url, signing_key, attendance_path or None)
     state = AttendanceState()
+    outbox = Outbox(config.get("outbox_path", "outbox.db"))
+    log.info(f"Outbox:  {outbox.path} ({outbox.pending_count()} pending on start)")
 
     # Fetch initial attendance state (only if attendance_path is configured)
     if attendance_path:
@@ -684,10 +730,17 @@ def main():
     vpoller = threading.Thread(target=version_poller, args=(backend, state), daemon=True)
     vpoller.start()
 
+    # Start the outbox replay thread: drains queued scans in order,
+    # re-signing and resubmitting each one, once the backend is reachable.
+    drain = threading.Thread(
+        target=replay_drain, args=(outbox, backend.post_scan, state.push_event), daemon=True
+    )
+    drain.start()
+
     if usb_device:
-        scanner = threading.Thread(target=usb_scanner_listener, args=(backend, state, usb_device), daemon=True)
+        scanner = threading.Thread(target=usb_scanner_listener, args=(backend, state, outbox, usb_device), daemon=True)
     else:
-        scanner = threading.Thread(target=stdin_scanner_listener, args=(backend, state), daemon=True)
+        scanner = threading.Thread(target=stdin_scanner_listener, args=(backend, state, outbox), daemon=True)
     scanner.start()
 
     KioskHandler.state = state

--- a/client/client.py
+++ b/client/client.py
@@ -617,7 +617,8 @@ def handle_scan(backend, state, outbox, participant_id):
     # attempting live delivery out of order.
     if outbox.has_pending_for_participant(participant_id):
         outbox.enqueue(client_event_id, participant_id, scanned_at)
-        state.push_event({"html": _saved_banner_html(outbox.pending_count())})
+        queued = outbox.pending_count()
+        state.push_event({"html": _saved_banner_html(queued), "queued": queued})
         log.info(f"Queued (predecessor pending): participant {participant_id}")
         return
 
@@ -627,7 +628,8 @@ def handle_scan(backend, state, outbox, participant_id):
     if outcome == "retry":
         # Try live first; only persist to the outbox if it wasn't confirmed.
         outbox.enqueue(client_event_id, participant_id, scanned_at)
-        state.push_event({"html": _saved_banner_html(outbox.pending_count())})
+        queued = outbox.pending_count()
+        state.push_event({"html": _saved_banner_html(queued), "queued": queued})
         log.warning(f"Scan queued (server unreachable/warming): participant {participant_id}")
         return
 

--- a/client/client.py
+++ b/client/client.py
@@ -39,6 +39,7 @@ log = logging.getLogger("kiosk")
 # The backend page serving the kiosk display; `mode=kiosk` selects its kiosk
 # layout. Overridable per-Pi via config.json.
 DEFAULT_KIOSK_PATH = "/attendance/current?mode=kiosk"
+DEFAULT_OUTBOX_PATH = "outbox.db"
 
 def load_config(path="config.json"):
     if not os.path.exists(path):
@@ -209,7 +210,7 @@ class KioskHandler(BaseHTTPRequestHandler):
   * {{ margin: 0; padding: 0; box-sizing: border-box; }}
   body, html {{ width: 100%; height: 100%; overflow: hidden; background: #000; font-family: sans-serif; }}
   iframe {{ width: 100%; height: 100%; border: none; }}
-
+  
   #blackout {{
     position: absolute;
     top: 0;
@@ -264,6 +265,19 @@ class KioskHandler(BaseHTTPRequestHandler):
     border: 2px solid #60a5fa;
     color: #fff;
   }}
+  #queue-badge {{
+    position: absolute;
+    bottom: 12px;
+    right: 12px;
+    z-index: 9998;
+    background: rgba(37,99,235,0.9);
+    color: #fff;
+    padding: 6px 14px;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: bold;
+    display: none;
+  }}
   @keyframes fadeout {{
     0% {{ opacity: 1; }}
     80% {{ opacity: 1; }}
@@ -307,6 +321,17 @@ class KioskHandler(BaseHTTPRequestHandler):
     }}
   }}
 
+  // D5: a live queued-count on the SSE stream so staff watch the backlog drain.
+  function updateQueueBadge(n) {{
+    const b = document.getElementById("queue-badge");
+    if (n > 0) {{
+      b.textContent = n + " queued";
+      b.style.display = "block";
+    }} else {{
+      b.style.display = "none";
+    }}
+  }}
+
   function connectSSE() {{
     const source = new EventSource("/events");
 
@@ -327,6 +352,7 @@ class KioskHandler(BaseHTTPRequestHandler):
         return;
       }}
       handleData(data, false);
+      if (typeof data.queued === "number") updateQueueBadge(data.queued);
       const html = data.html || "";
       if (html) {{
         const container = document.getElementById("flash-container");
@@ -359,6 +385,7 @@ class KioskHandler(BaseHTTPRequestHandler):
 <body onload="connectSSE()">
   <div id="blackout"></div>
   <div id="flash-container"></div>
+  <div id="queue-badge"></div>
   <iframe src="{self.kiosk_path}"></iframe>
 </body>
 </html>"""
@@ -407,17 +434,17 @@ class KioskHandler(BaseHTTPRequestHandler):
 
     def _proxy_request(self, method):
         url = self.backend.base_url + self.path
-
+        
         body_bytes = b""
         length = int(self.headers.get("Content-Length", 0))
         if length > 0:
             body_bytes = self.rfile.read(length)
-
+            
         req_headers = {}
         for k, v in self.headers.items():
             if k.lower() not in ['host', 'connection', 'accept-encoding']:
                 req_headers[k] = v
-
+                
         # Inject Key Signing Headers onto the API requests transparently!
         # Sign with pathname only (no query string) — backend verifies against pathname
         from urllib.parse import urlparse
@@ -429,10 +456,10 @@ class KioskHandler(BaseHTTPRequestHandler):
                 body_str = body_bytes.decode('utf-8')
             except UnicodeDecodeError:
                 pass
-
+                
         sig_headers = sign_request(self.backend.signing_key, method, sign_path, body_str)
         req_headers.update(sig_headers)
-
+        
         try:
             # Use requests.request (stateless) so cookies flow directly between browser and backend
             resp = requests.request(
@@ -444,7 +471,7 @@ class KioskHandler(BaseHTTPRequestHandler):
                 stream=True,
                 timeout=30
             )
-
+            
             try:
                 self.send_response(resp.status_code)
                 for k, v in resp.headers.items():
@@ -461,7 +488,7 @@ class KioskHandler(BaseHTTPRequestHandler):
             except (BrokenPipeError, ConnectionResetError):
                 # Browser closed the connection, normal for HMR or page reloads
                 pass
-
+                    
         except Exception as e:
             if not isinstance(e, (BrokenPipeError, ConnectionResetError)):
                 log.error(f"Proxy error for {self.path}: {e}")
@@ -613,7 +640,7 @@ def handle_scan(backend, state, outbox, participant_id):
         email = body.get("participant", {}).get("email", "?")
         log.info(f"Scan result: {ptype.upper()} — {email}")
     else:
-        log.warning(f"Scan error (dead-letter, not queued): {body.get('error', body)}")
+        log.warning(f"Scan rejected, not queued: {body.get('error', body)}")
 
     # Fetch fresh attendance and push update for the iframe
     if backend.attendance_path and outcome == "ack":
@@ -650,7 +677,7 @@ def attendance_poller(backend, state, interval=30):
 def version_poller(backend, state, interval=60):
     """Background thread that checks for client and server version updates."""
     import subprocess
-
+    
     # Get initial server version
     initial_server_version = None
     for _ in range(6):
@@ -660,10 +687,10 @@ def version_poller(backend, state, interval=60):
             log.info(f"Initial server version: {initial_server_version}")
             break
         time.sleep(5)
-
+    
     while True:
         time.sleep(interval)
-
+        
         # 1. Check Server Version Update
         if initial_server_version:
             sv, status = backend.get_server_version()
@@ -671,14 +698,14 @@ def version_poller(backend, state, interval=60):
                 log.info(f"Server version changed from {initial_server_version} to {sv}. Requesting reload.")
                 state.push_event({"reload": True})
                 initial_server_version = sv  # Update to prevent spam
-
+        
         # 2. Check Client Version Update
         try:
             subprocess.run(["git", "fetch", "origin", "main"], capture_output=True, timeout=15)
 
             local_head = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
             remote_head = subprocess.check_output(["git", "rev-parse", "origin/main"], text=True).strip()
-
+            
             if local_head and remote_head and local_head != remote_head:
                 log.info(f"Client version update available ({local_head} -> {remote_head}). Restarting client.")
                 os._exit(0)
@@ -709,7 +736,7 @@ def main():
 
     backend = BackendClient(backend_url, signing_key, attendance_path or None)
     state = AttendanceState()
-    outbox = Outbox(config.get("outbox_path", "outbox.db"))
+    outbox = Outbox(config.get("outbox_path", DEFAULT_OUTBOX_PATH))
     log.info(f"Outbox:  {outbox.path} ({outbox.pending_count()} pending on start)")
 
     # Fetch initial attendance state (only if attendance_path is configured)

--- a/client/client.py
+++ b/client/client.py
@@ -90,7 +90,7 @@ class BackendClient:
         h["Content-Type"] = "application/json"
         return h
 
-    def post_scan(self, participant_id, client_event_id=None, scanned_at=None):
+    def post_scan(self, participant_id, client_event_id=None, scanned_at=None, replay=False):
         path = "/api/scan"
         payload = {"participantId": participant_id}
         try:
@@ -101,6 +101,11 @@ class BackendClient:
             payload["clientEventId"] = client_event_id
         if scanned_at:
             payload["scannedAt"] = scanned_at
+        if replay:
+            # Only the outbox drain sets this. The live attempt carries the same
+            # clientEventId (D4 try-first) but is NOT a replay, so the server
+            # cannot infer replay-ness from the id.
+            payload["replay"] = True
         body = json.dumps(payload)
 
         headers = self._headers("POST", path, body)

--- a/client/outbox.py
+++ b/client/outbox.py
@@ -219,7 +219,12 @@ def replay_drain(outbox, send_fn, push_fn=None, sleep_fn=time.sleep, in_closed_w
             continue
 
         client_event_id, participant_id, scanned_at, attempts = rows[0]
-        body, status, retry_after = send_fn(participant_id, client_event_id, scanned_at)
+        # replay=True is what tells the server this is a redelivery: the live
+        # attempt already sent this clientEventId (D4 try-first), so only the
+        # drain may trip the replay-only guards.
+        body, status, retry_after = send_fn(
+            participant_id, client_event_id, scanned_at, replay=True
+        )
         outcome = classify_response(status, body)
 
         if outcome == "ack":

--- a/client/outbox.py
+++ b/client/outbox.py
@@ -164,11 +164,10 @@ class Outbox:
 def classify_response(status, body):
     """Maps a scan response to one of three outcomes: ack (delete), retry
     (keep, backoff), dead (terminal, stop retrying)."""
-    # F2: check this FIRST, regardless of status. post_scan normalizes any
-    # non-JSON body (waker HTML, a captive portal's login page, ...) to this
-    # sentinel while preserving whatever status the intermediary sent -- often
-    # 200, not 400. Gating on status==400 let a 200 non-JSON body ack a scan
-    # that was never actually recorded server-side.
+    # F2: check first, regardless of status -- post_scan normalizes a
+    # non-JSON body (waker HTML, captive portal login, ...) to this sentinel,
+    # preserving the intermediary's real status (often 200, not 400), so
+    # gating on status==400 alone would falsely ack an unrecorded scan.
     if isinstance(body, dict) and body.get("type") == "warming":
         return "retry"
     if status == 0:

--- a/client/outbox.py
+++ b/client/outbox.py
@@ -24,10 +24,9 @@ DRAIN_PACE_SECONDS = 1.0
 # evicted to enforce this -- it is a log-only warning, not a hard cap.
 WARN_QUEUE_SIZE = 50_000
 
-# docs/designs/KIOSK_RESILIENCE.md D4: the drain must not send during the
+# docs/designs/KIOSK_RESILIENCE.md D4/Q17: the drain never sends during the
 # closed window -- a queued POST is non-GET and wakes the curfewed service.
-# Exact hours are server-fetched per Q6, not wired to the client yet;
-# placeholder local-time window pending confirmation (flagged on the PR).
+# The window is 23:00-06:00 local.
 CLOSED_WINDOW_START_HOUR = 23  # local time, inclusive
 CLOSED_WINDOW_END_HOUR = 6     # local time, exclusive
 

--- a/client/outbox.py
+++ b/client/outbox.py
@@ -1,0 +1,225 @@
+"""Durable offline scan queue: SQLite outbox + a single FIFO-by-time replay
+thread. Kept separate from client.py so it can be imported without touching
+client.py's other background threads."""
+
+import logging
+import os
+import random
+import sqlite3
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+
+log = logging.getLogger("kiosk")
+
+# Start at the waker's Retry-After (~30s), exponential to a ~5 min cap.
+MIN_BACKOFF_SECONDS = 30
+MAX_BACKOFF_SECONDS = 300
+# Drain pace capped at ~1 event/sec so a backlog leaves the shared 300/min
+# scan rate limit mostly to live scans.
+DRAIN_PACE_SECONDS = 1.0
+# Guard rail against a pathological stuck state. Un-acked rows are never
+# evicted to enforce this -- it is a log-only warning, not a hard cap.
+WARN_QUEUE_SIZE = 50_000
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def new_event_id():
+    return str(uuid.uuid4())
+
+
+class Outbox:
+    """One SQLite file, one table. WAL + synchronous=FULL for
+    crash-consistency across the kiosk.sh respawn loop and power cuts."""
+
+    def __init__(self, path="outbox.db"):
+        self.path = path
+        self._lock = threading.RLock()
+        self._conn = self._open(path)
+
+    def _open(self, path):
+        conn = sqlite3.connect(path, check_same_thread=False)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=FULL")
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS outbox (
+                    client_event_id TEXT PRIMARY KEY,
+                    participant_id  TEXT NOT NULL,
+                    scanned_at      TEXT NOT NULL,
+                    attempts        INTEGER NOT NULL DEFAULT 0,
+                    last_status     INTEGER,
+                    state           TEXT NOT NULL DEFAULT 'pending',
+                    created_at      TEXT NOT NULL
+                )"""
+            )
+            conn.commit()
+            return conn
+        except sqlite3.DatabaseError as e:
+            # Scanning must never block on a sick queue: move the corrupt
+            # file aside and start fresh.
+            conn.close()
+            corrupt_path = f"{path}.corrupt.{int(time.time())}"
+            log.error(f"Outbox {path} unreadable ({e}); moving aside to {corrupt_path}")
+            try:
+                os.replace(path, corrupt_path)
+            except OSError:
+                pass
+            conn = sqlite3.connect(path, check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=FULL")
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS outbox (
+                    client_event_id TEXT PRIMARY KEY,
+                    participant_id  TEXT NOT NULL,
+                    scanned_at      TEXT NOT NULL,
+                    attempts        INTEGER NOT NULL DEFAULT 0,
+                    last_status     INTEGER,
+                    state           TEXT NOT NULL DEFAULT 'pending',
+                    created_at      TEXT NOT NULL
+                )"""
+            )
+            conn.commit()
+            return conn
+
+    def enqueue(self, client_event_id, participant_id, scanned_at):
+        """Idempotent: a retried enqueue of the same event is a no-op."""
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR IGNORE INTO outbox "
+                "(client_event_id, participant_id, scanned_at, created_at) VALUES (?,?,?,?)",
+                (client_event_id, str(participant_id), scanned_at, now_iso()),
+            )
+            self._conn.commit()
+            n = self.pending_count()
+            if n > WARN_QUEUE_SIZE:
+                log.warning(f"Outbox has {n} pending rows -- unusually large backlog")
+
+    def has_pending_for_participant(self, participant_id):
+        """A fresh scan must not jump its own predecessor in FIFO order."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT 1 FROM outbox WHERE participant_id=? AND state='pending' LIMIT 1",
+                (str(participant_id),),
+            ).fetchone()
+            return row is not None
+
+    def pending_count(self):
+        with self._lock:
+            return self._conn.execute(
+                "SELECT COUNT(*) FROM outbox WHERE state='pending'"
+            ).fetchone()[0]
+
+    def pending_rows(self):
+        """Global FIFO by scanned_at -- trivially preserves per-person order.
+        Survives restart: rows persist in the WAL file untouched."""
+        with self._lock:
+            return self._conn.execute(
+                "SELECT client_event_id, participant_id, scanned_at, attempts "
+                "FROM outbox WHERE state='pending' ORDER BY scanned_at ASC"
+            ).fetchall()
+
+    def ack(self, client_event_id):
+        """Server confirmed (2xx, or a dedup/duplicate_ignored response)."""
+        with self._lock:
+            self._conn.execute("DELETE FROM outbox WHERE client_event_id=?", (client_event_id,))
+            self._conn.commit()
+
+    def bump_attempt(self, client_event_id, status):
+        with self._lock:
+            self._conn.execute(
+                "UPDATE outbox SET attempts = attempts + 1, last_status=? WHERE client_event_id=?",
+                (status, client_event_id),
+            )
+            self._conn.commit()
+
+    def mark_dead(self, client_event_id, status):
+        """Terminal failure: stop retrying so it stops burning rate limit
+        and blocking FIFO. ponytail: dead rows stay local only --
+        transmitting them to a server-side DLQ is a later epic slice."""
+        with self._lock:
+            self._conn.execute(
+                "UPDATE outbox SET state='dead', last_status=? WHERE client_event_id=?",
+                (status, client_event_id),
+            )
+            self._conn.commit()
+
+    def dead_count(self):
+        with self._lock:
+            return self._conn.execute(
+                "SELECT COUNT(*) FROM outbox WHERE state='dead'"
+            ).fetchone()[0]
+
+
+def classify_response(status, body):
+    """Maps a scan response to one of three outcomes: ack (delete), retry
+    (keep, backoff), dead (terminal, stop retrying)."""
+    if status == 0:
+        return "retry"  # network error / timeout -- safe, idempotent retry
+    if status in (200, 201):
+        # checkin | checkout | duplicate_ignored | ignored_debounce | parked
+        return "ack"
+    if status == 401:
+        return "retry"  # clock skew / key mismatch -- re-signing can recover
+    if status == 429:
+        return "retry"
+    if status == 400 and isinstance(body, dict) and body.get("type") == "warning":
+        return "ack"  # force-close caution; the touch WAS recorded server-side
+    if status == 400 and isinstance(body, dict) and body.get("type") == "warming":
+        return "retry"  # non-JSON/waker body normalized to this by post_scan
+    if status in (400, 404, 409):
+        return "dead"
+    if status == 503:
+        return "retry"  # warming, not failure
+    if 500 <= status < 600:
+        return "retry"  # handler threw, transaction rolled back, idempotent
+    # Unrecognized status: fail safe -- never silently drop a scan.
+    return "retry"
+
+
+def _backoff_seconds(retry_after_header, current_backoff):
+    try:
+        base = float(retry_after_header) if retry_after_header else current_backoff
+    except (TypeError, ValueError):
+        base = current_backoff
+    base = max(MIN_BACKOFF_SECONDS, min(base, MAX_BACKOFF_SECONDS))
+    jitter = base * random.uniform(-0.1, 0.1)
+    return max(1.0, base + jitter)
+
+
+def replay_drain(outbox, send_fn, push_fn=None, poll_interval=1.0, sleep_fn=time.sleep):
+    """Single drain thread: pulls pending rows in scanned_at order,
+    resubmits each one (send_fn re-signs per call), and applies the
+    ack/retry/dead outcome. Runs forever; call in a background thread."""
+    backoff = MIN_BACKOFF_SECONDS
+    while True:
+        rows = outbox.pending_rows()
+        if not rows:
+            backoff = MIN_BACKOFF_SECONDS
+            sleep_fn(poll_interval)
+            continue
+
+        client_event_id, participant_id, scanned_at, attempts = rows[0]
+        body, status, retry_after = send_fn(participant_id, client_event_id, scanned_at)
+        outcome = classify_response(status, body)
+
+        if outcome == "ack":
+            outbox.ack(client_event_id)
+            backoff = MIN_BACKOFF_SECONDS
+            if push_fn:
+                push_fn({"html": "", "queued": outbox.pending_count()})
+            sleep_fn(DRAIN_PACE_SECONDS)
+        elif outcome == "dead":
+            outbox.mark_dead(client_event_id, status)
+            log.warning(f"Outbox event {client_event_id} dead-lettered (status={status})")
+            backoff = MIN_BACKOFF_SECONDS
+            sleep_fn(DRAIN_PACE_SECONDS)
+        else:
+            outbox.bump_attempt(client_event_id, status)
+            wait = _backoff_seconds(retry_after, backoff)
+            backoff = min(backoff * 2, MAX_BACKOFF_SECONDS)
+            sleep_fn(wait)

--- a/client/outbox.py
+++ b/client/outbox.py
@@ -16,12 +16,27 @@ log = logging.getLogger("kiosk")
 # Start at the waker's Retry-After (~30s), exponential to a ~5 min cap.
 MIN_BACKOFF_SECONDS = 30
 MAX_BACKOFF_SECONDS = 300
-# Drain pace capped at ~1 event/sec so a backlog leaves the shared 300/min
-# scan rate limit mostly to live scans.
+# Also the idle-poll interval and the pace between processed events (ack/dead)
+# -- one knob, not two, since both cap the drain loop's cycle time. ~1
+# event/sec leaves the shared 300/min scan rate limit mostly to live scans.
 DRAIN_PACE_SECONDS = 1.0
 # Guard rail against a pathological stuck state. Un-acked rows are never
 # evicted to enforce this -- it is a log-only warning, not a hard cap.
 WARN_QUEUE_SIZE = 50_000
+
+# docs/designs/KIOSK_RESILIENCE.md D4: the drain must not send during the
+# closed window -- a queued POST is non-GET and wakes the curfewed service.
+# Exact hours are server-fetched per Q6, not wired to the client yet;
+# placeholder local-time window pending confirmation (flagged on the PR).
+CLOSED_WINDOW_START_HOUR = 23  # local time, inclusive
+CLOSED_WINDOW_END_HOUR = 6     # local time, exclusive
+
+
+def in_closed_window(now=None):
+    hour = (now or datetime.now()).hour
+    if CLOSED_WINDOW_START_HOUR <= CLOSED_WINDOW_END_HOUR:
+        return CLOSED_WINDOW_START_HOUR <= hour < CLOSED_WINDOW_END_HOUR
+    return hour >= CLOSED_WINDOW_START_HOUR or hour < CLOSED_WINDOW_END_HOUR
 
 
 def now_iso():
@@ -41,50 +56,41 @@ class Outbox:
         self._lock = threading.RLock()
         self._conn = self._open(path)
 
+    _SCHEMA_SQL = """CREATE TABLE IF NOT EXISTS outbox (
+        client_event_id TEXT PRIMARY KEY,
+        participant_id  TEXT NOT NULL,
+        scanned_at      TEXT NOT NULL,
+        attempts        INTEGER NOT NULL DEFAULT 0,
+        last_status     INTEGER,
+        state           TEXT NOT NULL DEFAULT 'pending',
+        created_at      TEXT NOT NULL
+    )"""
+
     def _open(self, path):
-        conn = sqlite3.connect(path, check_same_thread=False)
-        try:
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute("PRAGMA synchronous=FULL")
-            conn.execute(
-                """CREATE TABLE IF NOT EXISTS outbox (
-                    client_event_id TEXT PRIMARY KEY,
-                    participant_id  TEXT NOT NULL,
-                    scanned_at      TEXT NOT NULL,
-                    attempts        INTEGER NOT NULL DEFAULT 0,
-                    last_status     INTEGER,
-                    state           TEXT NOT NULL DEFAULT 'pending',
-                    created_at      TEXT NOT NULL
-                )"""
-            )
-            conn.commit()
+        def connect_and_init():
+            conn = sqlite3.connect(path, check_same_thread=False)
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.execute("PRAGMA synchronous=FULL")
+                conn.execute(self._SCHEMA_SQL)
+                conn.commit()
+            except sqlite3.DatabaseError:
+                conn.close()
+                raise
             return conn
+
+        try:
+            return connect_and_init()
         except sqlite3.DatabaseError as e:
             # Scanning must never block on a sick queue: move the corrupt
             # file aside and start fresh.
-            conn.close()
             corrupt_path = f"{path}.corrupt.{int(time.time())}"
             log.error(f"Outbox {path} unreadable ({e}); moving aside to {corrupt_path}")
             try:
                 os.replace(path, corrupt_path)
             except OSError:
                 pass
-            conn = sqlite3.connect(path, check_same_thread=False)
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute("PRAGMA synchronous=FULL")
-            conn.execute(
-                """CREATE TABLE IF NOT EXISTS outbox (
-                    client_event_id TEXT PRIMARY KEY,
-                    participant_id  TEXT NOT NULL,
-                    scanned_at      TEXT NOT NULL,
-                    attempts        INTEGER NOT NULL DEFAULT 0,
-                    last_status     INTEGER,
-                    state           TEXT NOT NULL DEFAULT 'pending',
-                    created_at      TEXT NOT NULL
-                )"""
-            )
-            conn.commit()
-            return conn
+            return connect_and_init()
 
     def enqueue(self, client_event_id, participant_id, scanned_at):
         """Idempotent: a retried enqueue of the same event is a no-op."""
@@ -158,6 +164,13 @@ class Outbox:
 def classify_response(status, body):
     """Maps a scan response to one of three outcomes: ack (delete), retry
     (keep, backoff), dead (terminal, stop retrying)."""
+    # F2: check this FIRST, regardless of status. post_scan normalizes any
+    # non-JSON body (waker HTML, a captive portal's login page, ...) to this
+    # sentinel while preserving whatever status the intermediary sent -- often
+    # 200, not 400. Gating on status==400 let a 200 non-JSON body ack a scan
+    # that was never actually recorded server-side.
+    if isinstance(body, dict) and body.get("type") == "warming":
+        return "retry"
     if status == 0:
         return "retry"  # network error / timeout -- safe, idempotent retry
     if status in (200, 201):
@@ -169,8 +182,6 @@ def classify_response(status, body):
         return "retry"
     if status == 400 and isinstance(body, dict) and body.get("type") == "warning":
         return "ack"  # force-close caution; the touch WAS recorded server-side
-    if status == 400 and isinstance(body, dict) and body.get("type") == "warming":
-        return "retry"  # non-JSON/waker body normalized to this by post_scan
     if status in (400, 404, 409):
         return "dead"
     if status == 503:
@@ -191,16 +202,22 @@ def _backoff_seconds(retry_after_header, current_backoff):
     return max(1.0, base + jitter)
 
 
-def replay_drain(outbox, send_fn, push_fn=None, poll_interval=1.0, sleep_fn=time.sleep):
+def replay_drain(outbox, send_fn, push_fn=None, sleep_fn=time.sleep, in_closed_window_fn=in_closed_window):
     """Single drain thread: pulls pending rows in scanned_at order,
     resubmits each one (send_fn re-signs per call), and applies the
     ack/retry/dead outcome. Runs forever; call in a background thread."""
     backoff = MIN_BACKOFF_SECONDS
     while True:
+        # D4: never send during the closed window -- a queued POST is
+        # non-GET and would wake the curfewed service.
+        if in_closed_window_fn():
+            sleep_fn(DRAIN_PACE_SECONDS)
+            continue
+
         rows = outbox.pending_rows()
         if not rows:
             backoff = MIN_BACKOFF_SECONDS
-            sleep_fn(poll_interval)
+            sleep_fn(DRAIN_PACE_SECONDS)
             continue
 
         client_event_id, participant_id, scanned_at, attempts = rows[0]

--- a/client/test_client.py
+++ b/client/test_client.py
@@ -2,6 +2,10 @@ import inspect
 import json
 import os
 import unittest
+from unittest.mock import MagicMock
+
+from nacl.signing import SigningKey
+
 from client import BackendClient, DEFAULT_KIOSK_PATH, main
 
 class TestBackendClient(unittest.TestCase):
@@ -14,6 +18,28 @@ class TestBackendClient(unittest.TestCase):
         self.assertTrue(hasattr(client, "post_scan"), "BackendClient is missing post_scan method")
         self.assertTrue(hasattr(client, "get_attendance"), "BackendClient is missing get_attendance method")
         self.assertTrue(hasattr(client, "_headers"), "BackendClient is missing _headers method")
+
+class TestPostScanReplayFlag(unittest.TestCase):
+    """The live attempt carries clientEventId (D4 try-first) but no replay
+    flag -- the server's replay-only guards must not fire on it."""
+
+    def _payload(self, **kwargs):
+        client = BackendClient("http://fake", SigningKey(b"\x00" * 32))
+        client.session = MagicMock()
+        client.session.post.return_value = MagicMock(
+            status_code=200, headers={}, json=lambda: {}
+        )
+        client.post_scan(7, "evt-1", "2026-08-18T10:00:00+00:00", **kwargs)
+        return json.loads(client.session.post.call_args.kwargs["data"])
+
+    def test_live_send_carries_the_event_id_but_no_replay_flag(self):
+        payload = self._payload()
+        self.assertEqual(payload["clientEventId"], "evt-1")
+        self.assertNotIn("replay", payload)
+
+    def test_replay_send_sets_the_flag(self):
+        self.assertIs(self._payload(replay=True)["replay"], True)
+
 
 class TestProxyBindsLocalhostOnly(unittest.TestCase):
     def test_server_binds_127_0_0_1_not_0_0_0_0(self):

--- a/client/test_outbox.py
+++ b/client/test_outbox.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock
 
-from outbox import Outbox, classify_response, replay_drain, new_event_id, now_iso
+from outbox import Outbox, classify_response, replay_drain, new_event_id, now_iso, in_closed_window
 from client import handle_scan, _saved_banner_html
 
 
@@ -115,8 +115,29 @@ class TestClassifyResponse(unittest.TestCase):
             (500, {}),
             (502, {}),
             (400, {"type": "warming"}),
+            (200, {"type": "warming"}),  # F2: a captive portal's 200 HTML, normalized by post_scan
         ]:
             self.assertEqual(classify_response(status, body), "retry", (status, body))
+
+    def test_warming_sentinel_wins_regardless_of_status(self):
+        # F2: post_scan normalizes any non-JSON body (waker HTML, a captive
+        # portal's login page, ...) to {"type": "warming"} while preserving
+        # whatever status the intermediary sent -- often 200, not 400. A
+        # status-gated warming check would let a 200 non-JSON body ack a scan
+        # that was never actually recorded server-side.
+        for status in (200, 201, 502, 404):
+            self.assertEqual(
+                classify_response(status, {"type": "warming"}), "retry", status
+            )
+
+
+class TestInClosedWindow(unittest.TestCase):
+    def test_wraps_across_midnight(self):
+        from datetime import datetime
+        self.assertTrue(in_closed_window(datetime(2026, 8, 18, 23, 30)))
+        self.assertTrue(in_closed_window(datetime(2026, 8, 18, 2, 0)))
+        self.assertFalse(in_closed_window(datetime(2026, 8, 18, 6, 0)))  # end hour is exclusive
+        self.assertFalse(in_closed_window(datetime(2026, 8, 18, 12, 0)))
 
 
 class TestReplayDrain(unittest.TestCase):
@@ -166,6 +187,31 @@ class TestReplayDrain(unittest.TestCase):
         ])
         self.assertEqual(len(ob.pending_rows()), 1)
         self.assertEqual(ob.pending_rows()[0][3], 1)  # attempts bumped
+
+    def test_does_not_send_during_the_closed_window(self):
+        # F3 / D4: a queued POST is non-GET and would wake the curfewed
+        # service -- the drain must sleep through the closed window instead
+        # of sending.
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            ob.enqueue("evt-1", "1", now_iso())
+
+            send_fn = MagicMock()
+            sleeps = {"n": 0}
+
+            def fake_sleep(secs):
+                sleeps["n"] += 1
+                if sleeps["n"] >= 3:
+                    raise _StopLoop()
+
+            with self.assertRaises(_StopLoop):
+                replay_drain(
+                    ob, send_fn, push_fn=None, sleep_fn=fake_sleep,
+                    in_closed_window_fn=lambda: True,
+                )
+
+            send_fn.assert_not_called()
+            self.assertEqual(ob.pending_count(), 1)
 
     def test_same_client_event_id_reused_across_retries_until_acked(self):
         # The idempotency key must not change between attempts -- a retried

--- a/client/test_outbox.py
+++ b/client/test_outbox.py
@@ -150,7 +150,7 @@ class TestReplayDrain(unittest.TestCase):
 
             calls = {"n": 0}
 
-            def send_fn(participant_id, client_event_id, scanned_at):
+            def send_fn(participant_id, client_event_id, scanned_at, replay=False):
                 idx = calls["n"]
                 calls["n"] += 1
                 return responses[idx]
@@ -223,7 +223,7 @@ class TestReplayDrain(unittest.TestCase):
 
             seen_ids = []
 
-            def send_fn(participant_id, client_event_id, scanned_at):
+            def send_fn(participant_id, client_event_id, scanned_at, replay=False):
                 seen_ids.append(client_event_id)
                 if len(seen_ids) < 3:
                     return ({}, 503, None)
@@ -238,6 +238,30 @@ class TestReplayDrain(unittest.TestCase):
 
             self.assertEqual(seen_ids, ["evt-fixed", "evt-fixed", "evt-fixed"])
             self.assertEqual(ob.pending_rows(), [])
+
+
+    def test_drain_marks_every_send_as_a_replay(self):
+        # The server's replay-only guards (freshness, out-of-order, force-close
+        # parking) key on this flag, not on clientEventId -- the live attempt
+        # already sent that id.
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            ob.enqueue("evt-1", "1", now_iso())
+
+            seen = []
+
+            def send_fn(participant_id, client_event_id, scanned_at, replay=False):
+                seen.append(replay)
+                return ({"type": "checkin"}, 200, None)
+
+            def fake_sleep(secs):
+                if seen:
+                    raise _StopLoop()
+
+            with self.assertRaises(_StopLoop):
+                replay_drain(ob, send_fn, push_fn=None, sleep_fn=fake_sleep)
+
+            self.assertEqual(seen, [True])
 
 
 class TestHandleScanQueuesOnFailure(unittest.TestCase):
@@ -273,6 +297,18 @@ class TestHandleScanQueuesOnFailure(unittest.TestCase):
 
             self.assertEqual(ob.pending_count(), 0)
             self.assertIn("banner-ok", state.events[-1]["html"])
+
+    def test_live_scan_is_not_sent_as_a_replay(self):
+        # A live kiosk scan must reach the server unflagged, or the server
+        # parks the force-close instead of warning at the door.
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            backend = self._backend(({"type": "checkin", "participant": {}}, 200, None))
+
+            handle_scan(backend, FakeState(), ob, "9")
+
+            self.assertNotIn("replay", backend.post_scan.call_args.kwargs)
+            self.assertEqual(len(backend.post_scan.call_args.args), 3)
 
     def test_dead_letter_response_is_not_queued(self):
         with tempfile.TemporaryDirectory() as d:

--- a/client/test_outbox.py
+++ b/client/test_outbox.py
@@ -297,6 +297,17 @@ class TestHandleScanQueuesOnFailure(unittest.TestCase):
             self.assertEqual(ob.pending_count(), 2)
             self.assertEqual(backend.post_scan.call_count, 1)
             self.assertIn("2 waiting", state.events[-1]["html"])
+            self.assertEqual(state.events[-1]["queued"], 2)
+
+    def test_enqueue_pushes_queued_count_for_the_badge_not_just_on_drain(self):
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            backend = self._backend(({"error": "Connection refused"}, 0, None))
+            state = FakeState()
+
+            handle_scan(backend, state, ob, "9")
+
+            self.assertEqual(state.events[-1]["queued"], 1)
 
 
 class TestSavedBanner(unittest.TestCase):

--- a/client/test_outbox.py
+++ b/client/test_outbox.py
@@ -1,0 +1,263 @@
+"""Tests for the offline scan queue: durability across restart, ordered
+replay, no-double-submit under the idempotency rules, and the queued/offline
+banner (#1257)."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from outbox import Outbox, classify_response, replay_drain, new_event_id, now_iso
+from client import handle_scan, _saved_banner_html
+
+
+class _StopLoop(Exception):
+    """Sentinel to escape replay_drain's `while True` in tests."""
+
+
+class FakeState:
+    def __init__(self):
+        self.events = []
+
+    def push_event(self, data):
+        self.events.append(data)
+
+
+class TestOutboxDurability(unittest.TestCase):
+    def test_pending_rows_survive_process_restart(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "outbox.db")
+            ob1 = Outbox(path)
+            ob1.enqueue("evt-1", "42", "2026-08-18T10:00:00+00:00")
+
+            # Simulate a restart: a fresh Outbox instance over the same file.
+            ob2 = Outbox(path)
+            rows = ob2.pending_rows()
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0][0], "evt-1")
+
+    def test_corrupt_file_moved_aside_and_queue_still_usable(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "outbox.db")
+            with open(path, "wb") as f:
+                f.write(b"not a sqlite file at all, definitely corrupt\x00\x01")
+
+            ob = Outbox(path)  # must not raise, must not block scanning
+            ob.enqueue("evt-1", "1", now_iso())
+            self.assertEqual(ob.pending_count(), 1)
+
+            corrupt_files = [f for f in os.listdir(d) if ".corrupt." in f]
+            self.assertEqual(len(corrupt_files), 1)
+
+
+class TestOutboxOrderingAndDedup(unittest.TestCase):
+    def test_pending_rows_ordered_by_scanned_at(self):
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            ob.enqueue("evt-b", "1", "2026-08-18T10:05:00+00:00")
+            ob.enqueue("evt-a", "2", "2026-08-18T10:00:00+00:00")
+            ob.enqueue("evt-c", "3", "2026-08-18T10:10:00+00:00")
+
+            ids = [r[0] for r in ob.pending_rows()]
+            self.assertEqual(ids, ["evt-a", "evt-b", "evt-c"])
+
+    def test_enqueue_same_event_id_twice_is_a_noop(self):
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            ob.enqueue("evt-1", "1", now_iso())
+            ob.enqueue("evt-1", "1", now_iso())
+            self.assertEqual(ob.pending_count(), 1)
+
+    def test_has_pending_for_participant(self):
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            self.assertFalse(ob.has_pending_for_participant("7"))
+            ob.enqueue("evt-1", "7", now_iso())
+            self.assertTrue(ob.has_pending_for_participant("7"))
+            ob.ack("evt-1")
+            self.assertFalse(ob.has_pending_for_participant("7"))
+
+    def test_ack_removes_dead_marks_and_keeps(self):
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            ob.enqueue("evt-1", "1", now_iso())
+            ob.enqueue("evt-2", "2", now_iso())
+
+            ob.ack("evt-1")
+            ob.mark_dead("evt-2", 404)
+
+            self.assertEqual(ob.pending_rows(), [])
+            self.assertEqual(ob.dead_count(), 1)
+
+
+class TestClassifyResponse(unittest.TestCase):
+    def test_ack_cases(self):
+        for status, body in [
+            (200, {"type": "checkin"}),
+            (200, {"type": "checkout"}),
+            (200, {"type": "duplicate_ignored"}),
+            (200, {"type": "ignored_debounce"}),
+            (200, {"type": "parked"}),
+            (400, {"type": "warning", "error": "force close caution"}),
+        ]:
+            self.assertEqual(classify_response(status, body), "ack", (status, body))
+
+    def test_dead_cases(self):
+        for status in (400, 404, 409):
+            self.assertEqual(classify_response(status, {"error": "nope"}), "dead")
+
+    def test_retry_cases(self):
+        for status, body in [
+            (0, {"error": "timeout"}),
+            (503, {}),
+            (429, {}),
+            (401, {}),
+            (500, {}),
+            (502, {}),
+            (400, {"type": "warming"}),
+        ]:
+            self.assertEqual(classify_response(status, body), "retry", (status, body))
+
+
+class TestReplayDrain(unittest.TestCase):
+    def _run(self, responses):
+        """responses: list of (body, status, retry_after) yielded in order by send_fn."""
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            for i in range(len(responses)):
+                ob.enqueue(f"evt-{i}", str(i), f"2026-08-18T10:0{i}:00+00:00")
+
+            calls = {"n": 0}
+
+            def send_fn(participant_id, client_event_id, scanned_at):
+                idx = calls["n"]
+                calls["n"] += 1
+                return responses[idx]
+
+            sleeps = []
+
+            def fake_sleep(secs):
+                sleeps.append(secs)
+                if calls["n"] >= len(responses):
+                    raise _StopLoop()
+
+            with self.assertRaises(_StopLoop):
+                replay_drain(ob, send_fn, push_fn=None, sleep_fn=fake_sleep)
+            return ob
+
+    def test_acked_events_are_removed_in_order(self):
+        ob = self._run([
+            ({"type": "checkin"}, 200, None),
+            ({"type": "checkout"}, 200, None),
+        ])
+        self.assertEqual(ob.pending_rows(), [])
+
+    def test_dead_event_is_marked_and_does_not_block_the_next_one(self):
+        ob = self._run([
+            ({"error": "unknown participant"}, 404, None),
+            ({"type": "checkin"}, 200, None),
+        ])
+        self.assertEqual(ob.dead_count(), 1)
+        self.assertEqual(ob.pending_rows(), [])
+
+    def test_retry_keeps_the_event_pending(self):
+        ob = self._run([
+            ({}, 503, "30"),
+        ])
+        self.assertEqual(len(ob.pending_rows()), 1)
+        self.assertEqual(ob.pending_rows()[0][3], 1)  # attempts bumped
+
+    def test_same_client_event_id_reused_across_retries_until_acked(self):
+        # The idempotency key must not change between attempts -- a retried
+        # send after a warming/network failure is a redelivery of the same
+        # event, not a new one, or server-side dedup can't do its job.
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            ob.enqueue("evt-fixed", "1", now_iso())
+
+            seen_ids = []
+
+            def send_fn(participant_id, client_event_id, scanned_at):
+                seen_ids.append(client_event_id)
+                if len(seen_ids) < 3:
+                    return ({}, 503, None)
+                return ({"type": "duplicate_ignored"}, 200, None)
+
+            def fake_sleep(secs):
+                if len(seen_ids) >= 3:
+                    raise _StopLoop()
+
+            with self.assertRaises(_StopLoop):
+                replay_drain(ob, send_fn, push_fn=None, sleep_fn=fake_sleep)
+
+            self.assertEqual(seen_ids, ["evt-fixed", "evt-fixed", "evt-fixed"])
+            self.assertEqual(ob.pending_rows(), [])
+
+
+class TestHandleScanQueuesOnFailure(unittest.TestCase):
+    def _backend(self, post_scan_return, attendance_path=None):
+        backend = MagicMock()
+        backend.post_scan.return_value = post_scan_return
+        backend.attendance_path = attendance_path
+        return backend
+
+    def test_network_failure_queues_and_shows_saved_banner(self):
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            backend = self._backend(({"error": "Connection refused"}, 0, None))
+            state = FakeState()
+
+            handle_scan(backend, state, ob, "9")
+
+            self.assertEqual(ob.pending_count(), 1)
+            self.assertIn("Saved", state.events[-1]["html"])
+            self.assertIn("1 waiting", state.events[-1]["html"])
+
+    def test_successful_scan_is_not_queued(self):
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            backend = self._backend((
+                {"type": "checkin", "participant": {"email": "a@b.com"}, "message": "Checked in successfully"},
+                200,
+                None,
+            ))
+            state = FakeState()
+
+            handle_scan(backend, state, ob, "9")
+
+            self.assertEqual(ob.pending_count(), 0)
+            self.assertIn("banner-ok", state.events[-1]["html"])
+
+    def test_dead_letter_response_is_not_queued(self):
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            backend = self._backend(({"error": "unknown participant"}, 404, None))
+            state = FakeState()
+
+            handle_scan(backend, state, ob, "9")
+
+            self.assertEqual(ob.pending_count(), 0)
+            self.assertIn("banner-error", state.events[-1]["html"])
+
+    def test_second_scan_for_same_pending_participant_enqueues_behind_first(self):
+        with tempfile.TemporaryDirectory() as d:
+            ob = Outbox(os.path.join(d, "outbox.db"))
+            backend = self._backend(({"error": "down"}, 0, None))
+            state = FakeState()
+
+            handle_scan(backend, state, ob, "9")  # queues evt-1
+            handle_scan(backend, state, ob, "9")  # must not attempt live delivery
+
+            self.assertEqual(ob.pending_count(), 2)
+            self.assertEqual(backend.post_scan.call_count, 1)
+            self.assertIn("2 waiting", state.events[-1]["html"])
+
+
+class TestSavedBanner(unittest.TestCase):
+    def test_banner_text_includes_queue_count(self):
+        self.assertIn("3 waiting", _saved_banner_html(3))
+        self.assertIn("banner-saved", _saved_banner_html(0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/designs/KIOSK_RESILIENCE.md
+++ b/docs/designs/KIOSK_RESILIENCE.md
@@ -823,6 +823,8 @@ implementation, not a re-open. Questions 23–27 (v3 audit) are still open.
     **Decided:** exempt only **kiosk-proxied** traffic (`signedRequest`).
     During the closed window the **proxy swallows** the attendance poll.
     Wedge detection is valid in **open hours only**.
+    **Amended 2026-08-18 (jee7s):** the closed window is **23:00–06:00
+    local** — decided, not a placeholder.
 
 18. **Late-replay parent notification.**
     **Decided:** occurred-at time is **always** in the message. If delivery
@@ -846,6 +848,9 @@ implementation, not a re-open. Questions 23–27 (v3 audit) are still open.
 22. **When the Stage-2 substrate lands.**
     **Decided:** **with Phase 1.** Queue and substrate are one cut. C is
     born on the log. No Phase 1.5.
+    **Amended 2026-08-18 (jee7s):** the queue slice ships first (#1667); the
+    §6 substrate follows as its own slice, and parked/dead rows become
+    reviewable via D7 when it lands.
 
 *Questions 23–27 arrive with v3, from the #1529 Class-B audit (§7).*
 

--- a/docs/designs/KIOSK_RESILIENCE.md
+++ b/docs/designs/KIOSK_RESILIENCE.md
@@ -379,13 +379,17 @@ POST /api/scan                       Auth unchanged (withKiosk; re-sign every at
 Body (new fields optional):
   { participantId: number,
     clientEventId?: string,          // UUID, stable across retries of one scan
-    scannedAt?:     string }         // ISO8601, instant the badge was read
+    scannedAt?:     string,          // ISO8601, instant the badge was read
+    replay?:        boolean }        // true ONLY on an outbox-drain redelivery
 
 Server:
   legacy body {participantId}        → exactly today's behavior (timestamp=now, no dedup key)
   clientEventId present → in the advisory-lock tx, pre-read RawBadgeLog by clientEventId:
     found  → 200 {type:"duplicate_ignored"}                    (idempotent replay, no toggle)
-    absent → write RawBadgeLog{clientEventId, timestamp: scannedAt ?? now}:
+    absent, replay !== true (LIVE) → write RawBadgeLog{clientEventId, timestamp: now};
+                             today's live behavior unchanged, including the
+                             last-keyholder warn/confirm → 200 {type:"checkin"|"checkout"}
+    absent, replay === true → write RawBadgeLog{clientEventId, timestamp: scannedAt ?? now}:
       (now - scannedAt) <= W → normal toggle, event-assoc uses scannedAt
                                → 200 {type:"checkin"|"checkout"}
                                out-of-order guard (D3): participant has visit
@@ -393,7 +397,20 @@ Server:
       else                   → set reviewReason, DO NOT toggle → 200 {type:"parked"}
   unique-violation on the insert (cross-lock race, e.g. mid-replay merge)
                                      → 200 {type:"duplicate_ignored"}
+  malformed replay (non-boolean, or true without clientEventId) → 400
 ```
+
+**Amendment (2026-08-18) — replay-ness is explicit, not inferred.** D4's
+try-first rule puts `clientEventId` on the **live** attempt, so
+"`clientEventId` present" cannot mean "this is a replay": inferring it parks
+every live last-keyholder force-close and applies the replay-only guards to
+live scans. The body therefore carries `replay: true`, set **only** by
+`client/outbox.py`'s drain. Dedup (pre-read + the `@unique` backstop) stays
+keyed on `clientEventId` regardless of the flag — that is the try-first
+contract. Everything replay-only (freshness window W, out-of-order guard,
+`timestamp` backdated to `scannedAt`, force-close parking) gates on the flag.
+A live scan is happening now, so it stamps server-now and never inherits the
+kiosk's clock.
 
 ### Schema delta
 


### PR DESCRIPTION
Fixes #1257

## What / why

The kiosk drops a scan today whenever the backend is unreachable — most
visibly the guaranteed-lost cold-wake scan (`post_scan` calls `r.json()` on
the waker's `503` HTML and throws), but also any genuine WiFi/Aurora outage.
This is the first implementation slice of the kiosk resilience epic (#1347,
design ratified in #1662): scans captured while offline are durably queued
on the kiosk and replayed in order once connectivity returns, with a
distinct "queued" banner so staff know the touch was recorded.

## §2 sections implemented (docs/designs/KIOSK_RESILIENCE.md)

- **D1 — Queue storage.** SQLite (`client/outbox.py`), one file, one table,
  WAL + `synchronous=FULL`. A corrupt outbox file is moved aside and a fresh
  one opened on start — scanning never blocks on a sick queue.
- **D2 — Event identity + server dedup.** The client generates a
  `clientEventId` (UUID) and captures `scannedAt` at scan time, reusing both
  across every retry — including the **live** first attempt (D4 try-first),
  so an attempt whose response was lost dedups when the drain redelivers it.
  Server-side: `RawBadgeLog.clientEventId` is a nullable
  `@unique` column (additive, retry-safe migration, `CREATE INDEX
  CONCURRENTLY`); a redelivered event is pre-read inside the advisory-lock
  transaction and acked as `duplicate_ignored` without re-toggling. A
  `P2002` on the insert (cross-lock race) is caught and mapped the same way.
  Dedup is keyed on `clientEventId` **regardless of** whether the request is
  a replay; replay-ness itself is a separate, explicit signal (below).
- **Replay marking — `replay: true` (design delta, see "Design delta"
  below).** Because the id rides the live attempt, a replay is identified by
  an explicit boolean that **only** `client/outbox.py`'s drain sets. All
  replay-only behavior gates on it: the freshness window, the out-of-order
  guard, backdating `RawBadgeLog.timestamp` to `scannedAt`, and force-close
  parking. A live scan — with or without a `clientEventId` — behaves exactly
  as it does on `main`, plus dedup: server-now timestamp, debounce against
  real now, and a fully working last-keyholder warn/confirm.
- **D3 — Stale-replay handling.** A replay within the 10-minute freshness
  window toggles normally, using `scannedAt` as the visit time. An
  out-of-order guard parks instead of toggling if the participant has visit
  activity newer than the replayed event — compared as the max of
  `arrivedAt`/`departedAt` across *all* of the participant's visits, not
  just the most-recently-arrived one. Beyond the window, or when the
  out-of-order guard trips, the touch is still recorded on `RawBadgeLog`
  (`reviewReason` set) but the Visit projection is skipped — invariant 1's
  "never lose the touch" without guessing at direction. A replayed
  last-keyholder checkout with others still present never reads or writes
  `forceCloseWarnedAt`; it parks too (`reviewReason: force_close_review`)
  rather than risk force-closing the building unattended. All of this is
  scoped to flagged replays — none of it touches a live scan.
- **D4 — Replay transport.** A single FIFO-by-time drain thread
  (`replay_drain`) pulls pending rows in `scanned_at` order, resubmits each
  one (re-signed per attempt, since `post_scan` builds a fresh signature
  every call), and classifies the response into ack / retry (with backoff,
  respecting `Retry-After`) / dead — the warming sentinel is checked before
  status, so a non-JSON 200 (e.g. a captive portal) can't ack a scan that
  was never recorded server-side. The drain sleeps through the closed
  window instead of sending, since a queued POST is non-GET and would wake
  the curfewed service. A fresh scan for a participant with an
  already-pending event enqueues behind it rather than attempting live
  delivery out of order.
- **D5 — Offline banner.** A distinct blue "Saved" banner
  (`✓ Saved — will sync (N waiting)`) replaces the red failure banner when a
  scan is queued instead of confirmed, and a small "N queued" corner badge
  on the kiosk wrapper tracks the live backlog off the same SSE payload.
- **D6 (client-side only).** Terminal failures (400/404/409) are marked
  `dead` locally so they stop retrying and stop blocking FIFO; un-acked rows
  are never evicted. Transmitting dead rows to a server-side DLQ is not part
  of this slice (see Not in scope).

## §0 invariants touched, and how honored

- **Invariant 1 (never lose a scan).** The outbox is durable (SQLite/WAL)
  and survives the `kiosk.sh` respawn loop and power cuts. Server-side, even
  a parked replay still writes `RawBadgeLog` — the touch is never dropped,
  only its Visit projection is deferred.
- **Invariant 2 (infra failure is normal).** The kiosk keeps accepting scans
  and queuing them for the duration of an outage; the drain thread retries
  with backoff indefinitely rather than giving up.
- **Invariant 4 (always acknowledge the person).** A queued scan gets an
  immediate "Saved" acknowledgement, not silence or a spinner.
- **Invariant 5 (trust the displayed direction).** `scannedAt` travels with
  the event and is what the server toggles against (within the freshness
  window) — the server never re-infers direction from live state at replay
  time.

## Revision — adversarial cross-review fixes (2026-08-18)

A cross-review against this design turned up 11 findings; the confirmed
ones are fixed here (file:line detail in the review, not restated):

- **F1 (blocker).** Replay could force-close the building: a replayed
  keyholder double-badge could stamp `forceCloseWarnedAt` on one queued
  event and confirm it on the next (seconds apart in the drain), sweeping
  everyone out unattended. `processCheckout` now takes the replay's
  `clientEventId`; when present and the checkout would otherwise hit the
  last-keyholder-with-others-present branch, it never reads or writes
  `forceCloseWarnedAt` — it parks (`reviewReason: force_close_review`)
  instead, per §4's phase gate ("replay must not be able to force-close")
  and D4 ("a queued confirm... must be treated as expired, not honored").
  Regression test: two replayed keyholder checkouts, neither closes the
  facility. **Superseded in part:** keying that park on `clientEventId`
  caught live scans too — see the follow-up revision below.
- **F2 (blocker).** `classify_response` checked `status in (200,201)` →
  ack *before* the warming-sentinel check (which was gated on
  `status==400`). `post_scan` normalizes any non-JSON body — including a
  captive portal's 200 HTML — to `{"type":"warming"}` while preserving the
  real status, so a 200 non-JSON body deleted a queued row that was never
  actually recorded server-side. The warming check now runs first,
  unconditional on status.
- **F3.** The drain now sleeps through the closed window per D4 (a queued
  POST is non-GET and would wake the curfewed service) instead of sending.
  The window is **23:00–06:00 local** — ratified 2026-08-18 and recorded on
  §5 Q17; the constants are no longer a placeholder. Server-fetched hours
  (Q6) remain a later refinement, not a gate on this slice.
- **F7.** The out-of-order guard picked the participant's
  most-recently-arrived visit and compared its own `departedAt`/`arrivedAt`.
  A resolved visit (D7: "the Visit is written at `scannedAt`, never
  resolution time") can carry a `departedAt` newer than a *different*,
  later-arrived visit's own arrival — the old code would miss that and let
  a stale replay toggle. Fixed to compare the max of `arrivedAt` and
  `departedAt` across all of the participant's visits. New integration test
  with two real visits proves the fix (the old code would pass it through
  instead of parking it).
- **F8.** The `clientEventId`/`reviewReason` migration is now retry-safe:
  `ADD COLUMN IF NOT EXISTS` on both columns, `DROP INDEX IF EXISTS` before
  `CREATE UNIQUE INDEX CONCURRENTLY` (kept, as prescribed by the design).
- **F11.** Dropped whitespace-only hunks in `client.py`'s `_serve_wrapper`,
  `_proxy_request`, and `version_poller` — verified via `git merge-tree
  --write-tree` against `fix/1616-selfupdate-loop-guard` (#1665) that this
  was the sole source of conflict; the merge is now clean.
- **Simplifications:** collapsed `Outbox._open`'s duplicated
  corruption-recovery block into one retry path; collapsed
  `poll_interval`/`DRAIN_PACE_SECONDS` into one constant (both capped the
  same drain-loop cycle time); `outbox_path`'s default is now a named
  constant (`DEFAULT_OUTBOX_PATH`) instead of a bare string literal;
  D5 says the queued count should ride the SSE stream so staff can watch it
  — it was pushed but never read by the wrapper JS, so the wrapper now
  actually renders it (small corner badge) rather than deleting the field;
  fixed a log line in `handle_scan` that labeled a plain live rejection
  "dead-letter" (the event was never enqueued at all on that path).
- Also fixed a pre-existing CI failure on the out-of-order-guard
  integration test unrelated to the above: its live check-out
  `RawBadgeLog` row wasn't backdated past the 3s debounce window before the
  replay POST, so the debounce (which reads real "now", not `scannedAt` —
  an accepted collision documented in §2 D3) swallowed the replay as
  `ignored_debounce` before the guard ever ran. The test now backdates both
  live rows, matching the design rather than the previous (accidental)
  code/test agreement.

## Revision — live scans are no longer treated as replays (2026-08-18, `3767ac3e`)

Reported on review and confirmed. `/api/scan` derived
`isReplay = clientEventId !== null`, but D4's try-first rule puts
`clientEventId` on the **live** first attempt (`handle_scan`), so *every*
live kiosk scan was classified as a replay. The visible consequence: a live
last-keyholder checkout with others present hit F1's park branch — no
warning, no confirm, `RawBadgeLog` parked `force_close_review`, and a `200
{type:"parked"}` the kiosk banner renders as a successful checkout
(invariant 5: the displayed direction lies). The building could not be
force-closed from an online kiosk. The freshness window, out-of-order guard,
and `timestamp`-backdating also applied to live scans.

Fix — separate the two signals that were conflated:

- **Client.** `post_scan(..., replay=False)` adds `"replay": true` to the
  body; only `replay_drain` passes `replay=True`. `handle_scan`'s live
  attempt sends `clientEventId` + `scannedAt` and no flag. There is no
  client-side live retry path — an unconfirmed live attempt is enqueued and
  every later attempt comes from the drain, so the flag is exactly "this is
  a redelivery".
- **Server.** `isReplay` comes from the flag (validated boolean, default
  false; a non-boolean, or `replay: true` without a `clientEventId`, is a
  400 rather than a guess). Dedup — the `clientEventId` pre-read inside the
  advisory lock plus the `P2002` backstop — is unchanged and still runs for
  live scans, which is what makes try-first safe. Replay-only behaviors gate
  on `isReplay` alone; `processCheckout`'s last param is now
  `replayEventId` (the replay's id, or `null` for a live scan), so the
  force-close park cannot fire on a live scan by construction.
- A live scan now stamps **server-now** rather than the kiosk's `scannedAt`;
  it is happening now, and the debounce already compares against server now.

**Design delta.** `docs/designs/KIOSK_RESILIENCE.md` §2 defines no
first-vs-redelivery marker — D2 assumes the server-side pre-read identifies a
redelivery, which only holds once the event was recorded, and the §2 contract
gates the replay behaviors on "`clientEventId` present". The `replay` field
is therefore an addition; the §2 contract block and a dated amendment
paragraph are updated in this commit to match.

Test matrix: live scan with a `clientEventId` warns on the first
last-keyholder checkout and force-closes on the confirming second; flagged
replays still park on both (the F1 pins, re-routed through the flag);
redelivery of an already-recorded event returns `duplicate_ignored` with or
without the flag; freshness/out-of-order tests now require the flag, with new
cases proving a live scan carrying an old `scannedAt` checks in instead of
parking; Python covers both directions (drain sends the flag, `handle_scan`
does not, and the wire payload is asserted).

## Explicitly NOT in this slice (other epic #1347 slices)

- Health state-machine / recovery ladder (§3) — Chromium/wifi/reboot
  recovery, heartbeat, waker-aware banner.
- Reconciliation substrate (§6) — the Stage-2 event log, closed-facility
  advisory-open + deferred projection C, the M0–M3 machines. **Decided
  2026-08-18:** Q22 is amended — the queue ships as this smaller slice and
  the substrate follows as its own slice.
- Server-side DLQ transmission (`dead: true` on `/api/scan`) and the
  `system-status/unsynced-scans` review panel (D7) — dead/parked rows exist
  on `RawBadgeLog` now (`reviewReason`) but nothing surfaces or resolves
  them yet.
- The full §5.23 explicit-confirm-token redesign — still untouched; this
  revision only closes the specific replay-force-close hazard (F1) by
  parking instead of ever confirming, it does not build the token/state
  machine §5.23 calls for.
- Replay metrics, protocol versioning negotiation, batch endpoint — all
  named as build defaults / later phases in the design.
- Server-fetched open hours (Q6) — the drain uses the ratified 23:00–06:00
  local window; wiring the client to the server's hours is a later slice.

## Boundary with #1665 (open, `fix/1616-selfupdate-loop-guard`)

No overlap in substance, but the original version of this PR had
whitespace-only diffs (trailing-space strips) inside `version_poller`,
`_proxy_request`, and `_serve_wrapper` that were enough to produce a merge
conflict against #1665's `version_poller` rewrite despite touching no
shared logic. Those whitespace-only hunks are reverted in the revision
commit (F11 above). Verified clean with:
`git merge-tree --write-tree <this-branch> origin/fix/1616-selfupdate-loop-guard`
— exit 0, single resulting tree, no conflict markers.

## Testing

- **Local (`client/`, `python -m unittest discover -v` from `client/` with
  `requirements.txt` installed): 33/33 pass**, including the new replay-flag
  cases (drain marks every send `replay=True`; `handle_scan`'s live attempt
  sends no flag; the `post_scan` wire payload is asserted both ways), F2
  (warming-sentinel-regardless-of-status), F3 (closed-window drain, hour-
  wrap), and existing coverage (durability across restart, corrupt-file
  recovery, FIFO ordering, dedup no-ops, retry idempotency-key reuse,
  classify_response's full table, replay_drain branching, saved-banner
  behavior).
- **Local (`checkin-app/`):** `npx tsc --noEmit` clean. Targeted jest
  (`--testPathPatterns` on `scanRoute.test.ts` and
  `scanServiceKeyholderWarning.test.ts`, the two touched unit-test files):
  30/30 pass, including F1 (flagged replay never force-closes), F7
  (out-of-order guard aggregate), the live-scan-with-`clientEventId` cases
  (warn + confirm, server-now timestamp, never parked), and the
  `replay`-flag validation cases.
- **CI-only (unchanged from before):**
  `checkin-app/src/app/__tests__/scanReplay.integration.test.ts` exercises
  dedup/freshness/out-of-order behavior against a real DB — no local DB in
  this environment to run it directly. Its replay cases now carry
  `replay: true`; the dedup case models the real sequence (live attempt,
  then drain redelivery of the same id), and a new case pins that a live
  scan with a 20-minute-old `scannedAt` checks in at server-now rather than
  parking.

## Rulings — decided 2026-08-18 (jee7s)

The three items raised on the open-questions comment are decided:

1. **Q22 amended — this smaller slice ships.** The queue + replay path lands
   on its own; the §6 reconciliation substrate follows as its own slice, and
   parked/dead rows become reviewable via D7 when it lands. Amendment
   recorded on §5 Q22.
2. **Deploy-before-merge approved** — runbook below.
3. **Closed window ratified at 23:00–06:00 local.** Recorded on §5 Q17;
   `outbox.py`'s constants now state the rule instead of hedging.

Still open, not a gate on this slice: kiosk-clock coupling in the 3s debounce
(item iii on that comment) — `scannedAt` is trusted at sub-second granularity
while the debounce compares against server "now". §2 D3 accepts the mixed
behavior today; changing it is a design-level call.

### Deploy runbook

1. Deploy the server build from this branch to prod (schema migration +
   `/api/scan` changes).
2. Verify `/api/scan` accepts both a legacy body and a `clientEventId` body.
3. Merge this PR — kiosks auto-pull `origin/main` and self-restart on
   respawn (`version_poller`), so the client follows the server, never
   leads it.
4. Confirm a kiosk drains its outbox after the update (queued count returns
   to 0; the "N queued" badge clears).

## Review notes (adversarial re-verification, 2026-08-18)

Three small polish items from a follow-up review, applied here:

- **Empty-string `clientEventId`.** `/api/scan`'s route parsed a body
  `clientEventId: ""` into `isReplay = true` (`!== null`) while
  `processCheckout`'s `if (clientEventId)` treated the same value as falsy —
  mixed semantics that could reach the force-close warn path on a request
  that was nominally a replay. Normalized to `null` at parse time (one
  guard, all downstream reads now agree). New route test pins `"" →` live
  scan, not replay.
- **Badge on enqueue.** The "N queued" corner badge (D5) only moved during
  drain; a scan that queued because a predecessor was already pending, or
  because the live POST failed, didn't push a `queued` count until the next
  drain tick or attendance poll. Both `handle_scan` enqueue paths now push
  the current `pending_count()` alongside the saved-banner event, same
  payload shape the drain already uses.
- **Comment trims.** Three comments ran long against house style (~4 lines);
  trimmed in `scan-service.ts` (F1 force-close-park guard),
  `outbox.py::classify_response` (F2 warming-sentinel-first rationale), and
  `scanReplay.integration.test.ts` (the out-of-order-guard test's debounce
  backdating note). No behavior change; the trimmed detail was restated
  above in F1/F2 and in "Also fixed a pre-existing CI failure...", so
  nothing is lost, just de-duplicated off the inline comment.
- **Flagged, not fixed here:** a drain ack calls `setBlackout(false)` to
  wake a blacked-out kiosk screen on any activity, but nothing re-arms the
  blackout timer until the next `counts` push (attendance poll or live
  scan) — a kiosk that wakes purely off a drain ack during a quiet period
  can sit lit until the next poll. Pre-existing behavior, not introduced by
  this PR; belongs with the §3 health state-machine slice (already listed
  above as out of scope here), not patched piecemeal in this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





## Rebase onto main — supervision ladder composed, S1 fixed (2026-08-20, `0904ebe9`)

#1664 and #1670 merged while this PR sat approved, flipping it CONFLICTING.
Merged `origin/main` in; three conflicts, all keep-both, nothing from main
reverted:

- **`scan-service.ts`** — #1670's departure supervision interrupt composed with
  this branch's `visitTime` / `replayEventId`. `processCheckout` gained no
  supervision parameters on main, so the merged signature is simply
  `(participant, activeVisitId, authType, db, visitTime, replayEventId)`.
- **`client.py`** — main inlined the amber supervising-adults banner in
  `handle_scan`; this branch had already extracted the markup into
  `_scan_result_banner_html` so the drain could share it. Main's warning branch
  moved into the helper.
- **`test_client.py`** — main's `scan_banner` helper faked a backend to reach
  `handle_scan`, whose signature now takes an outbox; it calls the extracted
  helper directly instead. The three supervision-banner cases are unchanged.

`schema.prisma` (Visit `supervisionWarnedAt` + RawBadgeLog
`clientEventId`/`reviewReason`), the generated classifications, and
`route.ts` all merged without conflict.

### S1 — a replayed departure no longer runs the supervision ladder

Item 3 on the [rebase work-list](https://github.com/innovationtreehouse/checkin/pull/1667#issuecomment-5334299274),
now LIVE-relevant because #1670 is on main. The ladder's confirm rung answers
`400 {type:"warning"}` and records **nothing** but a `supervisionWarnedAt`
stamp, while `classify_response` maps that shape to **`ack`** — true of the
force-close warning, false of this one. A replayed departure that would drop the
room below two supervising adults was therefore deleted from the outbox with the
visit still open and unattended, and nobody is standing at the reader hours
later to re-badge. Silent on both ends.

The gate is `!replayEventId` on the interrupt block — the same signal and the
same shape as the force-close guard a few lines above. A replayed departure is
hours-old bookkeeping: no room to warn about, no one to confirm, and the visit
must close. Live departures are untouched; main's rungs, stamps and youth gate
all still run.

Three cases added to `scanServiceSupervisionInterrupt.test.ts` (main's own
harness): a replayed departure that would leave one supervising adult departs at
its `scannedAt` with no 400 and no stamp, the same with none remaining, and the
live path still demands its confirm. Removing the gate fails the first two.

### Also fixed — a clock-dependent hang in this PR's own tests

`TestReplayDrain` called `replay_drain` without pinning `in_closed_window_fn`,
so three cases spun forever on the real clock whenever the suite ran inside the
ratified 23:00–06:00 closed window (F3). A nightly CI run would have **hung the
job**, not failed it. The injection seam already existed and one case already
used it; the other three now do too.

### Deferred to the post-#1669 rebase — NOT in this pass

Items 1 and 2 of the work-list both depend on #1669's token model, which is
approved but not yet merged, so neither can be implemented against anything real
yet:

1. **Narrowing the `force_close_review` park to token-less replays.** The park
   still fires for every replayed last-keyholder checkout. Once #1669 mints a
   `forceCloseToken` per warning, the condition becomes "replayed **and** no
   matching token", so a pre-outage confirm still closes — the #1347 ruling.
2. **The outbox `forceCloseToken` column.** `client/outbox.py`'s schema has no
   token column, so without it every queued confirm replays token-less and hits
   the park from (1) anyway. (1) is decorative until (2) lands with it.

Both land together in the follow-up rebase after #1669 merges. Work-list item 4
(re-run CI post-rebase) is satisfied by this push.

### Verification

No conflict markers; `npx tsc --noEmit` clean; `npx jest --testPathPatterns
"scanRoute|scanService|supervision"` → **61/61** across 4 suites; Python suite
from `client/` (`python3 -m unittest discover`) → **44/44**. Net diff vs
`origin/main` is this PR's feature plus the S1 gate.
