### PR TITLE
fix(attendance): manual correction keeps arrivedVia source (#1631)

### DIFF
--- a/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/facilityTrendsAPI.integration.test.ts
@@ -9,14 +9,16 @@
  * path: bucketing visits by period, the volunteer/participant split (by program
  * enrollment — ProgramParticipant, NOT age), structured (event-associated) vs
  * unstructured hours, the `arrivedVia=LEAD_MARKED` exclusion (synthetic "marked
- * present" visits, plus its pre-split `SYSTEM` spelling) and the two cases it must
- * not swallow — an untagged arrival, and a real visit whose time staff corrected
- * (driven through the PATCH route, since a hand-built fixture cannot catch a wrong
- * stamp) — the `programId` filter, and the invalid-period 400.
+ * present" visits, plus its pre-split `SYSTEM` spelling) and the cases it must
+ * not swallow — an untagged arrival, a real visit whose time staff corrected via
+ * the staff route, and a member's self-correction (#1631) — plus the `programId`
+ * filter and the invalid-period 400. Corrections are driven through the real
+ * PATCH routes, since a hand-built fixture cannot catch a wrong stamp.
  */
 
 import { GET } from '@/app/api/facility/trends/route';
 import { PATCH } from '@/app/api/facility/visits/route';
+import { PATCH as MANUAL_PATCH } from '@/app/api/attendance/manual/[id]/route';
 import prisma from '@/lib/prisma';
 import { getServerSession } from 'next-auth/next';
 import { getAppSettings } from '@/lib/appSettings';
@@ -261,6 +263,93 @@ describe('Facility trends API', () => {
         // Still counted, now at the corrected 1h. Restamping the arrival
         // LEAD_MARKED would make these 0 — the visit would vanish from the trend
         // for having been fixed.
+        const after = await (await callAs({ id: adminId, isSysadmin: true }, `?period=month&programId=${program.id}`)).json();
+        expect(after.totals.uniqueVolunteers).toBe(1);
+        expect(after.totals.totalVolunteerHours).toBe(1);
+        expect(after.totals.structuredHours).toBe(1);
+
+        await prisma.auditLog.deleteMany({ where: { tableName: 'Visit', affectedEntityId: visit.id } });
+        await prisma.visit.delete({ where: { id: visit.id } });
+        await prisma.event.delete({ where: { id: event.id } });
+        await prisma.program.delete({ where: { id: program.id } });
+    });
+
+    // #1631 pin: PATCH /api/attendance/manual/[id] (member self-correction) must
+    // not restamp arrivedVia WEB. Before the fix, correcting the arrival time of
+    // a LEAD_MARKED (staff-asserted) visit promoted it past the trends filter —
+    // it started counting as measured hours the moment its time was fixed.
+    it('keeps a self-corrected LEAD_MARKED visit excluded from trends hours', async () => {
+        const program = await prisma.program.create({ data: { name: `SelfCorrectedLM ${TAG}` } });
+        const event = await prisma.event.create({
+            data: { programId: program.id, name: `SelfCorrectedLM event ${TAG}`, startAt: arrival(2), endAt: departure(2, 3) },
+        });
+        const now = Date.now();
+        const visit = await prisma.visit.create({
+            data: {
+                personId: volunteerId,
+                arrivedAt: new Date(now - 4 * 3600000),
+                departedAt: new Date(now - 2 * 3600000),
+                arrivedVia: 'LEAD_MARKED',
+                departedVia: 'LEAD_MARKED',
+                associatedEventId: event.id,
+            },
+        });
+        visitIds.push(visit.id);
+
+        const before = await (await callAs({ id: adminId, isSysadmin: true }, `?period=month&programId=${program.id}`)).json();
+        expect(before.totals.totalVolunteerHours).toBe(0);
+
+        // The member corrects their own arrival — a household lead is not needed here.
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: volunteerId } });
+        const patch = await MANUAL_PATCH(new Request(`http://localhost:4000/api/attendance/manual/${visit.id}`, {
+            method: 'PATCH',
+            body: JSON.stringify({ arrivedAt: new Date(now - 3 * 3600000).toISOString() }),
+        }) as unknown as import('next/server').NextRequest, { params: Promise.resolve({ id: String(visit.id) }) } as never);
+        expect(patch.status).toBe(200);
+        const patched = await prisma.visit.findUnique({ where: { id: visit.id } });
+        expect(patched?.arrivedVia).toBe('LEAD_MARKED'); // not restamped WEB
+
+        // Still 0 — restamping WEB would have promoted this into 1h of counted hours.
+        const after = await (await callAs({ id: adminId, isSysadmin: true }, `?period=month&programId=${program.id}`)).json();
+        expect(after.totals.uniqueVolunteers).toBe(0);
+        expect(after.totals.totalVolunteerHours).toBe(0);
+        expect(after.totals.structuredHours).toBe(0);
+
+        await prisma.auditLog.deleteMany({ where: { tableName: 'Visit', affectedEntityId: visit.id } });
+        await prisma.visit.delete({ where: { id: visit.id } });
+        await prisma.event.delete({ where: { id: event.id } });
+        await prisma.program.delete({ where: { id: program.id } });
+    });
+
+    // Control for the same fix: a WEB/SCANNER visit's self-correction is
+    // otherwise unchanged — it still applies and still counts, same as before.
+    it('keeps a self-corrected SCANNER visit counted after the manual PATCH route', async () => {
+        const program = await prisma.program.create({ data: { name: `SelfCorrectedScanner ${TAG}` } });
+        const event = await prisma.event.create({
+            data: { programId: program.id, name: `SelfCorrectedScanner event ${TAG}`, startAt: arrival(2), endAt: departure(2, 3) },
+        });
+        const now = Date.now();
+        const visit = await prisma.visit.create({
+            data: {
+                personId: volunteerId,
+                arrivedAt: new Date(now - 4 * 3600000),
+                departedAt: new Date(now - 2 * 3600000),
+                arrivedVia: 'SCANNER',
+                departedVia: 'SCANNER',
+                associatedEventId: event.id,
+            },
+        });
+        visitIds.push(visit.id);
+
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: volunteerId } });
+        const patch = await MANUAL_PATCH(new Request(`http://localhost:4000/api/attendance/manual/${visit.id}`, {
+            method: 'PATCH',
+            body: JSON.stringify({ arrivedAt: new Date(now - 3 * 3600000).toISOString() }),
+        }) as unknown as import('next/server').NextRequest, { params: Promise.resolve({ id: String(visit.id) }) } as never);
+        expect(patch.status).toBe(200);
+        const patched = await prisma.visit.findUnique({ where: { id: visit.id } });
+        expect(patched?.arrivedVia).toBe('SCANNER'); // not restamped WEB either — just no longer restamped at all
+
         const after = await (await callAs({ id: adminId, isSysadmin: true }, `?period=month&programId=${program.id}`)).json();
         expect(after.totals.uniqueVolunteers).toBe(1);
         expect(after.totals.totalVolunteerHours).toBe(1);

--- a/checkin-app/src/app/api/attendance/manual/[id]/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/attendance/manual/[id]/__tests__/route.test.ts
@@ -133,8 +133,11 @@ describe("PATCH /api/attendance/manual/[id]", () => {
         const res = await PATCH(req("PATCH", { arrivedAt: "2026-07-20T14:05:00Z" }), ctx as never);
 
         expect(res.status).toBe(200);
+        // #1631: arrivedVia is never restamped on correction — trends' exclusion
+        // filter reads it, so overwriting a LEAD_MARKED source would promote the
+        // visit into counted hours.
         expect(tx.visit.update).toHaveBeenCalledWith(expect.objectContaining({
-            data: { arrivedAt: new Date("2026-07-20T14:05:00Z"), arrivedVia: "WEB" },
+            data: { arrivedAt: new Date("2026-07-20T14:05:00Z") },
         }));
         const audit = auditCreate.mock.calls[0][0].data;
         expect(audit).toMatchObject({
@@ -144,6 +147,35 @@ describe("PATCH /api/attendance/manual/[id]", () => {
         expect(audit.newData.type).toBe("self_correction");
         expect(audit.newData.significance.flagged).toBe(false);
         expect(emailBoardMembers).not.toHaveBeenCalled();
+    });
+
+    // #1631 pin: a LEAD_MARKED (staff-asserted) arrival must keep that source
+    // through a correction, or trends' `notIn ["LEAD_MARKED", "SYSTEM"]` filter
+    // starts counting it as measured hours.
+    it("keeps a LEAD_MARKED arrival's source on correction (does not restamp WEB)", async () => {
+        const leadMarked = { ...baseVisit, arrivedVia: "LEAD_MARKED", departedVia: "LEAD_MARKED" };
+        visitFindUnique.mockResolvedValue(leadMarked);
+        // A real update returns the row's untouched columns as-is, not a static
+        // fixture's default — the mock has to reflect that to catch this bug.
+        tx.visit.update.mockImplementation(async (args: { data: Record<string, unknown> }) => ({ ...leadMarked, ...args.data }));
+        const res = await PATCH(req("PATCH", { arrivedAt: "2026-07-20T14:05:00Z" }), ctx as never);
+
+        expect(res.status).toBe(200);
+        expect(tx.visit.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: { arrivedAt: new Date("2026-07-20T14:05:00Z") }, // no arrivedVia key at all
+        }));
+        const { visit } = await res.json();
+        expect(visit.arrivedVia).toBe("LEAD_MARKED");
+    });
+
+    it("still restamps departedVia to WEB on a departure correction (no trends reader for it)", async () => {
+        visitFindUnique.mockResolvedValue({ ...baseVisit, arrivedVia: "LEAD_MARKED", departedVia: "LEAD_MARKED" });
+        const res = await PATCH(req("PATCH", { departedAt: "2026-07-20T16:30:00Z" }), ctx as never);
+
+        expect(res.status).toBe(200);
+        expect(tx.visit.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: { departedAt: new Date("2026-07-20T16:30:00Z"), departedVia: "WEB" },
+        }));
     });
 
     it("flags a big move of a measured (SCANNER) arrival to the board", async () => {

--- a/checkin-app/src/app/api/attendance/manual/[id]/route.ts
+++ b/checkin-app/src/app/api/attendance/manual/[id]/route.ts
@@ -110,11 +110,16 @@ export const PATCH = handler<{ id: string }>('PATCH /api/attendance/manual/[id]'
                 select: { id: true },
             });
             if (!live) return null;
-            // An edited value is a self-report now, whatever captured it before.
+            // arrivedVia is left as-is: trends' exclusion filter (facility/trends
+            // route) reads only arrivedVia, so restamping it WEB here promoted a
+            // LEAD_MARKED (staff-asserted, not measured) arrival into counted
+            // hours the moment its time was corrected (#1631). departedVia has no
+            // such reader, so it still becomes WEB — an edited departure is a
+            // self-report now, whatever captured it before.
             return tx.visit.update({
                 where: { id: visitId },
                 data: {
-                    ...(arrivedAt ? { arrivedAt: nextArrived, arrivedVia: "WEB" } : {}),
+                    ...(arrivedAt ? { arrivedAt: nextArrived } : {}),
                     ...(departedAt && !closingOpenVisit ? { departedAt: nextDeparted, departedVia: "WEB" } : {}),
                 },
             });


### PR DESCRIPTION
Fixes #1631.

## The shrunk ruling

> **v1.2 scope, shrunk.**
>
> Staff `PATCH /api/facility/visits` already leaves `arrivedVia` alone — the filed promotion does not reproduce there.
>
> This issue is only: `PATCH /api/attendance/manual/[id]` must not restamp `arrivedVia: "WEB"` on a correction. A `LEAD_MARKED` (or `SCANNER`) arrival stays that source so trends do not start counting it.
>
> Not in scope: splitting `VisitSource` (#1624).
>
> 🤖 Posted by Grok on behalf of @jee7s

## Why the fix is confined to this route

`PATCH /api/facility/visits` (staff correction) was checked and already leaves `arrivedVia` untouched — verified by reading the route, not touched here. `PATCH /api/attendance/manual/[id]` (member self-correction / household-lead correction) was the one route still doing `data: { arrivedAt: nextArrived, arrivedVia: "WEB" }` on every arrival edit, unconditionally overwriting whatever source was on the row.

## Trends-promotion mechanics

`facility/trends`'s exclusion filter (`route.ts` ~L79-82) reads **only** `arrivedVia`:

```ts
OR: [
    { arrivedVia: null },
    { arrivedVia: { notIn: ["LEAD_MARKED", "SYSTEM"] } },
],
```

A `LEAD_MARKED` arrival (a roster mark / staff-asserted presence — see the `docs/rules/attendance-checkin.md` rule added by #1666: "staff-asserted presence is not facility hours") is deliberately excluded. Before this fix, the moment a member or their household lead corrected that visit's arrival time through this route, the unconditional `arrivedVia: "WEB"` stamp promoted it past the filter and it silently started counting as measured facility hours — exactly the mechanism the parent issue (#1624's sibling) described, now confirmed to live specifically in this route.

Fix: drop the `arrivedVia` key from the update entirely when only `arrivedAt` is being corrected, so the existing source (`LEAD_MARKED`, `SCANNER`, `WEB`, etc.) survives untouched.

**`departedVia` is deliberately left restamping to `WEB`.** I checked whether the same promotion mechanism applies there: the trends filter above reads `arrivedVia` only, never `departedVia`, and no other exclusion/counting path in the codebase reads it either (`significance.ts` reads the *old* pre-update visit, `attendanceConflicts.ts` only displays it, audit logging only reads old values). So restamping `departedVia` to `WEB` on a departure correction cannot promote anything — it's inert with respect to this bug, and mirroring the fix there would be an unrequested, unjustified behavior change. Left as-is.

**Audit/significance unaffected.** `editSignificance`/`deleteSignificance` (`lib/visit/significance.ts`) are called with the visit's state *before* the update, so they already weighted corrections by the true prior source — the restamp never fed into that calculation. The audit log's `oldData` also reads pre-update values. Nothing here changes.

## Tests

- Unit (`api/attendance/manual/[id]/__tests__/route.test.ts`): updated the existing "applies a small edit" pin to assert no `arrivedVia` key is written; added a case pinning that a `LEAD_MARKED` arrival keeps that source through a correction (response body included), and a case confirming `departedVia` still restamps to `WEB` on a departure correction.
- Integration (`app/__tests__/facilityTrendsAPI.integration.test.ts`, CI-only, drives the real `PATCH` route per the file's existing pattern): added a case pinning that correcting a `LEAD_MARKED` visit's arrival through the self-correction route leaves it excluded from trends totals (0h, before and after), and a control case showing a `SCANNER` visit's self-correction is otherwise unchanged — still applies and still counts.

Ran locally: `tsc --noEmit` clean, lint clean, and the full non-integration unit suite for the touched files (27 tests) passes. Integration tests require Docker Postgres and run in CI only, per this repo's convention.

## Out of scope

Splitting `VisitSource` (#1624) — the "one column, two facts" root cause the original issue named — is explicitly not addressed here, per the shrunk ruling. This PR is the narrow stopgap: it stops the one live promotion path without touching the `VisitSource` model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)