### PR TITLE
feat(kiosk): explicit force-close confirm — 15s countdown + token (#1347 slice)

### DIFF
--- a/checkin-app/prisma/migrations/20260818150000_visit_force_close_token/migration.sql
+++ b/checkin-app/prisma/migrations/20260818150000_visit_force_close_token/migration.sql
@@ -1,0 +1,4 @@
+-- Expand-only: one nullable column. The previous release never names it in a
+-- SELECT, so its reads are unaffected (rule 1). IF NOT EXISTS keeps the file
+-- retry-safe if the deploy is re-run after a partial failure.
+ALTER TABLE "Visit" ADD COLUMN IF NOT EXISTS "forceCloseToken" TEXT;

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -1116,10 +1116,15 @@ model Visit {
   deletedById       Int?
 
   /// When the kiosk last showed this keyholder the "others are still here"
-  /// force-close warning. A force close only proceeds if the scan follows a
-  /// fresh stamp, so an ordinary double-tap cannot close the building.
+  /// force-close warning. Audit stamp only — the confirm is the token below.
   /// @sensitivity:internal
   forceCloseWarnedAt DateTime?
+
+  /// Confirm token minted with that warning and returned to the kiosk. Only a
+  /// scan echoing it force-closes, so an ordinary double-tap cannot; validity
+  /// is by issuance, not elapsed time, so a confirm queued through an outage
+  /// still closes when it lands (§5.23a). @sensitivity:internal
+  forceCloseToken   String?
 
   person Person @relation(fields: [personId], references: [id])
   event  Event?      @relation(fields: [associatedEventId], references: [id])

--- a/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
+++ b/checkin-app/src/app/__tests__/scanCausalChain.integration.test.ts
@@ -31,10 +31,10 @@ jest.mock('@/lib/logger', () => ({
 const TAG = 'scan-causal-test';
 const flush = () => new Promise(r => setImmediate(r));
 
-function scanReq(participantId: number) {
+function scanReq(participantId: number, forceCloseToken?: string) {
     return new Request('http://localhost/api/scan', {
         method: 'POST',
-        body: JSON.stringify({ participantId }),
+        body: JSON.stringify({ participantId, ...(forceCloseToken ? { forceCloseToken } : {}) }),
     }) as unknown as import('next/server').NextRequest;
 }
 
@@ -95,14 +95,16 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
         expect(open).toBe(0);
     });
 
-    it('force-closes (departing everyone) when the scan follows a fresh warning, then sends post-event emails', async () => {
+    it('force-closes (departing everyone) when the scan echoes the confirm token, then sends post-event emails', async () => {
         const kVisit = await prisma.visit.create({
-            // The warning was shown 5s ago (within the 60s window) → confirmed.
-            data: { personId: isKeyholder.id, arrivedAt: new Date(), forceCloseWarnedAt: new Date(Date.now() - 5000) },
+            data: {
+                personId: isKeyholder.id, arrivedAt: new Date(),
+                forceCloseWarnedAt: new Date(Date.now() - 5000), forceCloseToken: 'confirm-me',
+            },
         });
         await prisma.visit.create({ data: { personId: normal.id, arrivedAt: new Date() } });
 
-        const res = await processCheckout(isKeyholder, kVisit.id, 'kiosk');
+        const res = await processCheckout(isKeyholder, kVisit.id, 'kiosk', undefined, 'confirm-me');
         const json = await res.json();
         expect(json.facilityClosed).toBe(true);
 
@@ -121,7 +123,7 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
         const beforeClose = Date.now();
 
         const kVisit = await prisma.visit.create({
-            data: { personId: isKeyholder.id, arrivedAt: new Date(), forceCloseWarnedAt: new Date(Date.now() - 5000) },
+            data: { personId: isKeyholder.id, arrivedAt: new Date(), forceCloseToken: 'confirm-me' },
         });
         const staleVisit = await prisma.visit.create({ data: { personId: normal.id, arrivedAt: stale } });
         // Open AND tombstoned — the one-open-visit index only covers live rows.
@@ -129,7 +131,7 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
             data: { personId: normal.id, arrivedAt: stale, deletedAt: new Date() },
         });
 
-        const res = await processCheckout(isKeyholder, kVisit.id, 'kiosk');
+        const res = await processCheckout(isKeyholder, kVisit.id, 'kiosk', undefined, 'confirm-me');
         expect((await res.json()).facilityClosed).toBe(true);
 
         const capped = await prisma.visit.findUnique({ where: { id: staleVisit.id } });
@@ -165,8 +167,28 @@ describe('Scan causal chain — last isKeyholder closes facility', () => {
         expect(open).toBe(2);
         expect(processPostEventEmails).not.toHaveBeenCalled();
 
-        // The warning is now stamped, so the next scan may confirm.
+        // The warning minted a token; only a scan echoing it may confirm.
         const stamped = await prisma.visit.findUnique({ where: { id: kVisit.id } });
         expect(stamped?.forceCloseWarnedAt).toBeInstanceOf(Date);
+        expect(stamped?.forceCloseToken).toEqual(json.forceCloseToken);
+    });
+
+    it('confirms through the route inside the debounce window — the token is the confirm, not the gap', async () => {
+        await prisma.visit.create({ data: { personId: isKeyholder.id, arrivedAt: new Date() } });
+        await prisma.visit.create({ data: { personId: normal.id, arrivedAt: new Date() } });
+
+        const warnRes = await POST(scanReq(isKeyholder.id));
+        expect(warnRes.status).toBe(400);
+        const warn = await warnRes.json();
+
+        // Badge again immediately: inside the 3s debounce, which would swallow an
+        // untokened scan. The confirm carries the token, so it lands.
+        const closeRes = await POST(scanReq(isKeyholder.id, warn.forceCloseToken));
+        expect((await closeRes.json()).facilityClosed).toBe(true);
+
+        const open = await prisma.visit.count({
+            where: { personId: { in: [isKeyholder.id, normal.id] }, departedAt: null },
+        });
+        expect(open).toBe(0);
     });
 });

--- a/checkin-app/src/app/api/attendance/manual/[id]/__tests__/route.test.ts
+++ b/checkin-app/src/app/api/attendance/manual/[id]/__tests__/route.test.ts
@@ -65,7 +65,7 @@ const HOUSEHOLD_ID = 2;
 const baseVisit = {
     id: 42, personId: OWN_ID, deletedAt: null, deletedById: null, associatedEventId: null,
     arrivedAt: new Date("2026-07-20T14:00:00Z"), departedAt: new Date("2026-07-20T16:00:00Z"),
-    arrivedVia: "WEB", departedVia: "WEB", forceCloseWarnedAt: null,
+    arrivedVia: "WEB", departedVia: "WEB", forceCloseWarnedAt: null, forceCloseToken: null,
 };
 
 function req(method: string, body?: unknown): NextRequest {
@@ -322,7 +322,7 @@ describe("household-lead correction of a member's visit", () => {
 
         expect(visit.arrivedAt).toBe("2026-07-20T14:05:00.000Z");
         expect(visit.departedAt).toBe(baseVisit.departedAt.toISOString());
-        for (const internal of ["deletedAt", "deletedById", "forceCloseWarnedAt"]) {
+        for (const internal of ["deletedAt", "deletedById", "forceCloseWarnedAt", "forceCloseToken"]) {
             expect(visit).not.toHaveProperty(internal);
         }
     });

--- a/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -5,7 +5,7 @@ import { POST } from '../route';
 import { authenticateRequest } from '@/lib/auth';
 import prisma from '@/lib/prisma';
 import { logger } from '@/lib/logger';
-import { processCheckin } from '@/lib/scan-service';
+import { processCheckin, processCheckout } from '@/lib/scan-service';
 
 jest.mock('@/lib/auth', () => ({
     authenticateRequest: jest.fn(),
@@ -22,6 +22,7 @@ jest.mock('@/lib/prisma', () => {
         },
         visit: {
             findFirst: jest.fn(),
+            count: jest.fn().mockResolvedValue(0),
         },
         systemMetricLog: {
             create: jest.fn().mockResolvedValue({}),
@@ -188,5 +189,47 @@ describe('POST /api/scan', () => {
         const json = await res.json();
         expect(json.type).toBe('ignored_debounce');
         expect(json.message).toBe('Scan ignored due to debounce.');
+    });
+
+    describe('force-close confirm token', () => {
+        const scanReq = (body: Record<string, unknown>) => new Request('http://localhost/api/scan', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        }) as unknown as import('next/server').NextRequest;
+
+        beforeEach(() => {
+            (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'session', user: { id: '1' } });
+            (prisma.person.findUnique as jest.Mock).mockResolvedValue({ id: 1, mergedIntoId: null });
+            // Inside the 3s debounce window — only a live token gets past it.
+            (prisma.rawBadgeLog.findFirst as jest.Mock).mockResolvedValue({ timestamp: new Date() });
+            (prisma.visit.findFirst as jest.Mock).mockResolvedValue({ id: 7 });
+            (processCheckout as jest.Mock).mockResolvedValue(
+                new Response(JSON.stringify({ type: 'checkout', facilityClosed: true }), { status: 200 }));
+        });
+
+        it('lets a scan matching a live token through the debounce and forwards it', async () => {
+            (prisma.visit.count as jest.Mock).mockResolvedValue(1); // token matches an open visit
+
+            const res = await POST(scanReq({ participantId: 1, forceCloseToken: 'tok-1' }));
+
+            expect((await res.json()).facilityClosed).toBe(true);
+            expect(processCheckout).toHaveBeenCalledWith({ id: 1, mergedIntoId: null }, 7, 'session', expect.anything(), 'tok-1');
+        });
+
+        it('debounces a spent or unknown token, so a stray second read cannot re-toggle', async () => {
+            (prisma.visit.count as jest.Mock).mockResolvedValue(0); // nothing holds this token
+
+            const res = await POST(scanReq({ participantId: 1, forceCloseToken: 'tok-1' }));
+
+            expect((await res.json()).type).toBe('ignored_debounce');
+            expect(processCheckout).not.toHaveBeenCalled();
+        });
+
+        it('treats a non-string token as no token at all', async () => {
+            const res = await POST(scanReq({ participantId: 1, forceCloseToken: 42 }));
+
+            expect((await res.json()).type).toBe('ignored_debounce');
+            expect(prisma.visit.count).not.toHaveBeenCalled();
+        });
     });
 });

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -16,7 +16,7 @@ const MAX_MERGE_HOPS = 5;
 // unauthenticated, and hands us the parsed body + actor. We own authorization.
 export const POST = withKiosk(
     { rateLimit: { name: "scan", limit: 300 } },
-    async (_req, body: { participantId?: unknown }, auth) => {
+    async (_req, body: { participantId?: unknown; forceCloseToken?: unknown }, auth) => {
     const startTime = Date.now();
 
     try {
@@ -25,6 +25,14 @@ export const POST = withKiosk(
         if (!participantId || typeof participantId !== 'number') {
             return apiError("A valid numeric participantId is required.", 400);
         }
+
+        // Optional force-close confirm token, echoed from the warning response.
+        // Anything that isn't a non-empty string is simply "no token" — it can
+        // only ever grant the confirm, never deny an ordinary scan.
+        const confirmToken =
+            typeof body.forceCloseToken === 'string' && body.forceCloseToken.length > 0
+                ? body.forceCloseToken
+                : null;
 
         // Web session: check if user can scan this participant
         let pendingHouseholdCheck = false;
@@ -110,10 +118,22 @@ export const POST = withKiosk(
             // which $queryRaw cannot deserialize. $executeRaw just runs it.
             await tx.$executeRaw`SELECT pg_advisory_xact_lock(${participant.id})`;
 
+            // A scan echoing a live confirm token IS the force-close confirm, so
+            // the debounce must not swallow it (§5.16). Single-use: the confirm
+            // spends the token, so a stray second read debounces as usual.
+            const isConfirm = confirmToken !== null && (await tx.visit.count({
+                where: {
+                    personId: participant.id,
+                    departedAt: null,
+                    deletedAt: null,
+                    forceCloseToken: confirmToken,
+                },
+            })) > 0;
+
             // 4. Double scan debounce check (3 seconds) — now under the lock, so
             // it sees the committed badge event of any racing scan ahead of it.
             const threeSecondsAgo = new Date(Date.now() - 3000);
-            const recentScan = await tx.rawBadgeLog.findFirst({
+            const recentScan = isConfirm ? null : await tx.rawBadgeLog.findFirst({
                 where: {
                     personId: participant.id,
                     timestamp: {
@@ -149,7 +169,7 @@ export const POST = withKiosk(
             });
 
             if (activeVisit) {
-                return await processCheckout(participant, activeVisit.id, authType, tx);
+                return await processCheckout(participant, activeVisit.id, authType, tx, confirmToken);
             } else {
                 return await processCheckin(participant, authType, tx);
             }

--- a/checkin-app/src/app/page.tsx
+++ b/checkin-app/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession, signIn } from "next-auth/react";
 import {
@@ -37,6 +37,10 @@ export default function Home() {
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
   const [isCheckedIn, setIsCheckedIn] = useState<boolean | null>(null);
+
+  // Force-close confirm token from the last "others are still here" warning.
+  // Echoed on the next click to confirm; dropped when its countdown lapses.
+  const forceCloseToken = useRef<string | null>(null);
 
   const [isLastKeyholder, setIsLastKeyholder] = useState(false);
   const [isTwoDeepViolation, setIsTwoDeepViolation] = useState(false);
@@ -111,16 +115,25 @@ export default function Home() {
     setMessage("");
     try {
       const participantId = session.user?.id;
+      const token = forceCloseToken.current;
+      forceCloseToken.current = null; // single use, whether or not it confirms
       const res = await fetch('/api/scan', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantId })
+        body: JSON.stringify({ participantId, ...(token ? { forceCloseToken: token } : {}) })
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok) {
         setMessage(`${data.type === 'checkin' ? 'Successfully checked in!' : 'Successfully checked out!'}`);
         await checkAttendanceStatus(); // Re-fetch the status securely
       } else {
+        if (data.type === 'warning' && data.forceCloseToken) {
+          forceCloseToken.current = data.forceCloseToken;
+          const seconds = Number(data.confirmSeconds) || 15;
+          setTimeout(() => {
+            if (forceCloseToken.current === data.forceCloseToken) forceCloseToken.current = null;
+          }, seconds * 1000);
+        }
         setMessage(`Error: ${data.error || 'Failed to update attendance'}`);
       }
     } catch {

--- a/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
+++ b/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
@@ -99,6 +99,11 @@ describe("force close is bound to the confirm token", () => {
 
         expect(res.status).toBe(200);
         expect((await res.json()).facilityClosed).toBe(true);
+        // Spent, not left behind on the now-departed visit.
+        expect(db.visit.update).toHaveBeenCalledWith({
+            where: { id: 42 },
+            data: { forceCloseWarnedAt: null, forceCloseToken: null },
+        });
     });
 
     it("honors a token minted before an outage — no elapsed-time gate (§5.23a)", async () => {

--- a/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
+++ b/checkin-app/src/lib/__tests__/scanServiceKeyholderWarning.test.ts
@@ -4,12 +4,12 @@
  * never the full address (#329).
  *
  * The force close itself is bound to that warning: it proceeds only for a scan
- * that follows a fresh `Visit.forceCloseWarnedAt` stamp, never for two badge
- * events that merely happen to be close together (B2 of #1529).
+ * echoing the confirm token minted with it, never for two badge events that
+ * merely happen to be close together (B2 of #1529, §5.23).
  */
 import type { Person } from "@/generated/prisma/client";
 import type { DbClient } from "@/lib/db-client";
-import { processCheckout } from "@/lib/scan-service";
+import { processCheckout, FORCE_CLOSE_CONFIRM_SECONDS } from "@/lib/scan-service";
 
 jest.mock("@/lib/prisma", () => ({ __esModule: true, default: {} }));
 jest.mock("@/lib/notifications", () => ({
@@ -25,7 +25,7 @@ const keyholder = { id: 1, isKeyholder: true } as Person;
 /** Tx-shaped fake (no `$transaction`, so isRootClient() is false). */
 function fakeDb(
     remaining: Array<{ name: string | null; email: string | null }>,
-    warnedAt: Date | null = null
+    storedToken: string | null = null
 ): DbClient {
     return {
         visit: {
@@ -33,7 +33,7 @@ function fakeDb(
             findMany: jest.fn().mockResolvedValue(
                 remaining.map((person, i) => ({ id: 100 + i, person }))
             ),
-            findUnique: jest.fn().mockResolvedValue({ forceCloseWarnedAt: warnedAt }),
+            findUnique: jest.fn().mockResolvedValue({ forceCloseToken: storedToken }),
             update: jest.fn().mockResolvedValue({}),
         },
     } as unknown as DbClient;
@@ -74,32 +74,54 @@ it("omits a person with neither name nor email rather than rendering an empty sl
     expect(body.error).not.toMatch(/, ,|:\n, /);
 });
 
-describe("force close is bound to the warning", () => {
+describe("force close is bound to the confirm token", () => {
     const present = [{ name: "Someone Inside", email: "inside@example.com" }];
 
-    it("warns and stamps the visit when no warning has been shown yet", async () => {
+    it("warns, mints a token, and hands it back with the countdown length", async () => {
         const db = fakeDb(present);
         const res = await processCheckout(keyholder, 42, "kiosk", db);
+        const body = await res.json();
 
         expect(res.status).toBe(400);
-        expect((await res.json()).facilityClosed).toBeUndefined();
+        expect(body.facilityClosed).toBeUndefined();
+        expect(body.forceCloseToken).toEqual(expect.any(String));
+        expect(body.confirmSeconds).toBe(FORCE_CLOSE_CONFIRM_SECONDS);
+        expect(body.error).toContain(`within ${FORCE_CLOSE_CONFIRM_SECONDS} seconds`);
         expect(db.visit.update).toHaveBeenCalledWith({
             where: { id: 42 },
-            data: { forceCloseWarnedAt: expect.any(Date) },
+            data: { forceCloseWarnedAt: expect.any(Date), forceCloseToken: body.forceCloseToken },
         });
     });
 
-    it("closes the facility when the scan follows a fresh warning stamp", async () => {
-        const db = fakeDb(present, new Date(Date.now() - 8000));
-        const res = await processCheckout(keyholder, 42, "kiosk", db);
+    it("closes the facility when the scan echoes the minted token", async () => {
+        const db = fakeDb(present, "token-abc");
+        const res = await processCheckout(keyholder, 42, "kiosk", db, "token-abc");
 
         expect(res.status).toBe(200);
         expect((await res.json()).facilityClosed).toBe(true);
     });
 
-    it("warns again when the stamp has expired", async () => {
-        const db = fakeDb(present, new Date(Date.now() - 5 * 60_000));
+    it("honors a token minted before an outage — no elapsed-time gate (§5.23a)", async () => {
+        // The visit was warned days ago; only the token match decides.
+        const db = fakeDb(present, "token-from-tuesday");
+        const res = await processCheckout(keyholder, 42, "kiosk", db, "token-from-tuesday");
+
+        expect((await res.json()).facilityClosed).toBe(true);
+    });
+
+    it("re-warns with a NEW token when the scan carries no token", async () => {
+        const db = fakeDb(present, "token-abc");
         const res = await processCheckout(keyholder, 42, "kiosk", db);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.type).toBe("warning");
+        expect(body.forceCloseToken).not.toBe("token-abc");
+    });
+
+    it("re-warns rather than closing when the token does not match", async () => {
+        const db = fakeDb(present, "token-abc");
+        const res = await processCheckout(keyholder, 42, "kiosk", db, "token-guessed");
 
         expect(res.status).toBe(400);
         expect((await res.json()).type).toBe("warning");

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -5,10 +5,12 @@ import { apiError, apiJson } from "@/lib/api-response";
 import type { Person } from "@/generated/prisma/client";
 import { type DbClient, isRootClient } from "@/lib/db-client";
 import { MAX_VISIT_MS } from "@/lib/visitTimes";
+import { randomUUID } from "node:crypto";
 
-/** How long a displayed force-close warning stays confirmable. The scan route's
- *  3s debounce eats the front of it, so the kiosk copy says "3 to 60 seconds". */
-const FORCE_CLOSE_CONFIRM_MS = 60_000;
+/** Seconds the kiosk counts down after showing the force-close warning. The
+ *  countdown is display; the confirm is the token, which has no elapsed-time
+ *  gate — see the confirm check in processCheckout. */
+export const FORCE_CLOSE_CONFIRM_SECONDS = 15;
 
 /**
  * Process a check-in for a participant who has no active visit.
@@ -71,7 +73,8 @@ export async function processCheckout(
     participant: Person,
     activeVisitId: number,
     authType: string,
-    db: DbClient = prisma
+    db: DbClient = prisma,
+    confirmToken: string | null = null
 ) {
     let facilityClosed = false;
 
@@ -98,19 +101,21 @@ export async function processCheckout(
             if (remainingUsers.length > 0) {
                 const ownVisit = await db.visit.findUnique({
                     where: { id: activeVisitId },
-                    select: { forceCloseWarnedAt: true }
+                    select: { forceCloseToken: true }
                 });
-                const warnedAt = ownVisit?.forceCloseWarnedAt;
+                // The confirm is the token this scan echoes, not the gap between
+                // badges and not the wall clock: the countdown runs on the kiosk,
+                // so a confirm queued through an outage still closes on arrival.
                 const confirmForceClose =
-                    warnedAt != null && Date.now() - warnedAt.getTime() <= FORCE_CLOSE_CONFIRM_MS;
+                    confirmToken != null && ownVisit?.forceCloseToken === confirmToken;
 
                 if (!confirmForceClose) {
-                    // Stamp the warning on this visit; only a scan that follows the
-                    // stamp may force-close, so the confirmation is bound to the
-                    // warning having been shown rather than to badge adjacency.
+                    // Mint a fresh token with the warning; the old one dies here, so
+                    // an unconfirmed countdown cannot be redeemed later.
+                    const token = randomUUID();
                     await db.visit.update({
                         where: { id: activeVisitId },
-                        data: { forceCloseWarnedAt: new Date() }
+                        data: { forceCloseWarnedAt: new Date(), forceCloseToken: token }
                     });
 
                     // Never render the raw address (tier `pii`) on the kiosk screen (#329):
@@ -121,8 +126,10 @@ export async function processCheckout(
                         .filter(Boolean)
                         .join(", ");
                     return apiJson({
-                        error: `Warning! You are the last isKeyholder, but others are here:\n${names}\n\nBadge again in 3 to 60 seconds to confirm you've checked them and close the facility.`,
-                        type: "warning" as const
+                        error: `Warning! You are the last isKeyholder, but others are here:\n${names}\n\nBadge again within ${FORCE_CLOSE_CONFIRM_SECONDS} seconds to confirm you've checked them and close the facility.`,
+                        type: "warning" as const,
+                        forceCloseToken: token,
+                        confirmSeconds: FORCE_CLOSE_CONFIRM_SECONDS
                     }, 400);
                 }
             }

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -136,6 +136,15 @@ export async function processCheckout(
 
             facilityClosed = true;
 
+            // The token is spent. Clear it before the visit departs so no
+            // redeemable force-close state survives on a closed row — every
+            // lookup filters `departedAt: null` today, but one that forgets to
+            // shouldn't find a live-looking token.
+            await db.visit.update({
+                where: { id: activeVisitId },
+                data: { forceCloseWarnedAt: null, forceCloseToken: null }
+            });
+
             // The facility-wide sweep takes row locks on EVERY open visit, and
             // the email kick fires its own DB queries. Neither may run inside the
             // scan route's per-participant advisory-lock transaction: it would

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -276,6 +276,7 @@ export const classifications = {
         deletedAt: 'internal',
         deletedById: 'internal',
         forceCloseWarnedAt: 'internal',
+        forceCloseToken: 'internal',
     },
     AuditLog: {
         id: 'internal',

--- a/client/client.py
+++ b/client/client.py
@@ -87,13 +87,17 @@ class BackendClient:
         h["Content-Type"] = "application/json"
         return h
 
-    def post_scan(self, participant_id):
+    def post_scan(self, participant_id, force_close_token=None):
         path = "/api/scan"
+        payload = {}
         try:
-            body = json.dumps({"participantId": int(participant_id)})
+            payload["participantId"] = int(participant_id)
         except ValueError:
-            body = json.dumps({"participantId": participant_id})
-            
+            payload["participantId"] = participant_id
+        if force_close_token:
+            payload["forceCloseToken"] = force_close_token
+        body = json.dumps(payload)
+
         headers = self._headers("POST", path, body)
         try:
             r = self.session.post(
@@ -138,6 +142,24 @@ class AttendanceState:
         self.lock = threading.Lock()
         self.subscribers = []  # list of queue.Queue for SSE clients
         self.current_counts = {"total": 0, "keyholders": 0, "volunteers": 0, "students": 0}
+        self.confirm_token = None    # force-close confirm token, if a countdown is running
+        self.confirm_deadline = 0.0  # monotonic clock, end of that countdown
+
+    def arm_confirm(self, token, seconds):
+        """Hold the confirm token the server minted with a force-close warning."""
+        with self.lock:
+            self.confirm_token = token
+            self.confirm_deadline = time.monotonic() + seconds
+
+    def take_confirm(self):
+        """Pop the confirm token for the next scan. Single use, and only while
+        its countdown is still running — an expired countdown confirms nothing."""
+        with self.lock:
+            token = self.confirm_token
+            live = time.monotonic() < self.confirm_deadline
+            self.confirm_token = None
+            self.confirm_deadline = 0.0
+            return token if live else None
 
     def subscribe(self):
         """Register a new SSE client, returns a Queue to read events from."""
@@ -242,8 +264,11 @@ class KioskHandler(BaseHTTPRequestHandler):
     border: 2px solid #fbbf24;
     color: #fff;
     white-space: pre-wrap;
-    animation: fadeout 12s forwards;
+    /* No fade: the force-close warning stays fully legible for its whole
+       countdown, and the countdown itself removes it. */
+    animation: none;
   }}
+  #fc-countdown {{ font-size: 2.5rem; }}
   @keyframes fadeout {{
     0% {{ opacity: 1; }}
     80% {{ opacity: 1; }}
@@ -287,6 +312,27 @@ class KioskHandler(BaseHTTPRequestHandler):
     }}
   }}
 
+  // Visible force-close countdown. Ticks the <span> the banner carries, then
+  // clears the banner — the token expires on the proxy at the same moment.
+  let countdownTimer = null;
+  let bannerTimer = null;
+
+  function startCountdown(seconds) {{
+    clearInterval(countdownTimer);
+    const el = document.getElementById("fc-countdown");
+    if (!el) return;
+    let left = seconds;
+    countdownTimer = setInterval(() => {{
+      left -= 1;
+      if (left <= 0) {{
+        clearInterval(countdownTimer);
+        document.getElementById("flash-container").innerHTML = '';
+        return;
+      }}
+      el.textContent = left;
+    }}, 1000);
+  }}
+
   function connectSSE() {{
     const source = new EventSource("/events");
 
@@ -317,7 +363,11 @@ class KioskHandler(BaseHTTPRequestHandler):
           banner.offsetHeight;
           banner.style.animation = null;
         }}
-        setTimeout(() => {{ container.innerHTML = ''; }}, 12000);
+        const secs = data.countdown || 0;
+        clearInterval(countdownTimer);
+        clearTimeout(bannerTimer);
+        bannerTimer = setTimeout(() => {{ container.innerHTML = ''; }}, secs ? secs * 1000 : 12000);
+        if (secs) startCountdown(secs);
       }}
       // Tell iframe to refresh attendance display with inline data
       const iframe = document.querySelector("iframe");
@@ -533,7 +583,10 @@ def stdin_scanner_listener(backend, state):
             break
 
 def handle_scan(backend, state, participant_id):
-    body, status = backend.post_scan(participant_id)
+    # Any scan ends a running force-close countdown; carrying the token is what
+    # turns this one into the confirm.
+    body, status = backend.post_scan(participant_id, state.take_confirm())
+    countdown = 0
 
     # Build banner HTML for the wrapper page.
     # All values below originate from the backend response (participant names,
@@ -547,6 +600,13 @@ def handle_scan(backend, state, participant_id):
     if status >= 400 or "error" in body:
         if body.get("type") == "warning":
             warn = html.escape(body.get("error", "Warning")).replace("\n", "<br>")
+            token = body.get("forceCloseToken")
+            seconds = body.get("confirmSeconds")
+            seconds = seconds if isinstance(seconds, int) and 0 < seconds <= 120 else 15
+            if token:
+                state.arm_confirm(token, seconds)
+                countdown = seconds
+                warn += f'<br><span id="fc-countdown">{seconds}</span>s left to confirm'
             banner_html = f'<div class="banner banner-warning">⚠️ {warn}</div>'
         else:
             err = html.escape(body.get("error", "Unknown error"))
@@ -562,7 +622,7 @@ def handle_scan(backend, state, participant_id):
             banner_html = f'<div class="banner banner-ok">✓ {email} — {label}</div>'
 
     # Phase 1: Push banner immediately (no attendance data yet)
-    state.push_event({"html": banner_html})
+    state.push_event({"html": banner_html, "countdown": countdown})
 
     if status < 400 and "error" not in body:
         ptype = body.get("type", "?")

--- a/client/test_client.py
+++ b/client/test_client.py
@@ -2,7 +2,8 @@ import inspect
 import json
 import os
 import unittest
-from client import BackendClient, DEFAULT_KIOSK_PATH, main
+from unittest.mock import Mock, patch
+from client import AttendanceState, BackendClient, DEFAULT_KIOSK_PATH, handle_scan, main
 
 class TestBackendClient(unittest.TestCase):
     def test_required_methods_exist(self):
@@ -30,6 +31,58 @@ class TestExampleConfigMatchesDefaults(unittest.TestCase):
         with open(example) as f:
             cfg = json.load(f)
         self.assertEqual(cfg["kiosk_path"], DEFAULT_KIOSK_PATH)
+
+class TestForceCloseConfirm(unittest.TestCase):
+    """§5.23 explicit confirm: the warning arms a token, the next scan spends it."""
+
+    def test_post_scan_sends_the_token_only_when_one_is_held(self):
+        client = BackendClient("http://fake", "fake_key")
+        with patch.object(BackendClient, "_headers", return_value={}), \
+             patch.object(client.session, "post") as post:
+            post.return_value = Mock(status_code=200, json=Mock(return_value={}))
+
+            client.post_scan(7)
+            self.assertEqual(json.loads(post.call_args.kwargs["data"]), {"participantId": 7})
+
+            client.post_scan(7, "tok-1")
+            self.assertEqual(json.loads(post.call_args.kwargs["data"]),
+                             {"participantId": 7, "forceCloseToken": "tok-1"})
+
+    def test_token_is_single_use_and_dies_with_the_countdown(self):
+        state = AttendanceState()
+        self.assertIsNone(state.take_confirm())
+
+        state.arm_confirm("tok", 15)
+        self.assertEqual(state.take_confirm(), "tok")
+        self.assertIsNone(state.take_confirm(), "a spent token must not confirm twice")
+
+        state.arm_confirm("tok", 0)  # countdown already over
+        self.assertIsNone(state.take_confirm(), "an expired countdown confirms nothing")
+
+    def test_warning_arms_the_countdown_and_the_next_scan_confirms(self):
+        state = AttendanceState()
+        events = []
+        state.push_event = events.append
+        backend = Mock(attendance_path=None)
+        backend.post_scan.return_value = ({
+            "type": "warning", "error": "others are here",
+            "forceCloseToken": "tok-1", "confirmSeconds": 15,
+        }, 400)
+
+        handle_scan(backend, state, 7)
+
+        self.assertEqual(backend.post_scan.call_args.args, (7, None))
+        self.assertEqual(events[0]["countdown"], 15)
+        self.assertIn('id="fc-countdown"', events[0]["html"])
+
+        backend.post_scan.return_value = ({
+            "type": "checkout", "message": "Checked out and Facility closed",
+            "participant": {"email": "k@example.com"},
+        }, 200)
+        handle_scan(backend, state, 7)
+
+        self.assertEqual(backend.post_scan.call_args.args, (7, "tok-1"))
+        self.assertEqual(events[1]["countdown"], 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/designs/KIOSK_RESILIENCE.md
+++ b/docs/designs/KIOSK_RESILIENCE.md
@@ -280,7 +280,7 @@ window and free (the key lives on the Pi). The client stops calling
 | `2xx` JSON `{type: checkin\|checkout\|duplicate_ignored\|ignored_debounce\|parked}` | **ack** — DELETE from outbox |
 | `503` / non-JSON body / `Retry-After` present | **warming, not failure** — keep; sleep `max(Retry-After≈30s, backoff)`; §3.5's ~10-min cap reclassifies a stuck "warming" |
 | `429` | backoff, respect `Retry-After` |
-| `400` JSON `{type:"warning"}` | **ack** — the last-keyholder force-close caution; the touch row WAS recorded server-side. "The confirm badge is its own queued event" holds only while the confirm is inferred from spacing; under §5.23's explicit confirm state a queued confirm carries a token minted before the outage and must be treated as expired, not honored |
+| `400` JSON `{type:"warning"}` | **ack** — the last-keyholder force-close caution; the touch row WAS recorded server-side. Carries `forceCloseToken` + `confirmSeconds`; the next scan echoes the token and closes whenever it lands (§5.23a, decided 2026-08-18 — a pre-outage token is honored, not expired) |
 | other `400` / `404` / `409` | **terminal** — `state='dead'`, escalate (D6/D7) |
 | `401` | retry + escalate to the warning banner — clock skew (NTP) or key mismatch; **never** dead-letter, re-signing succeeds once the clock/key recovers |
 | other `5xx` | retry with backoff — handler threw, transaction rolled back, idempotent |
@@ -379,7 +379,8 @@ POST /api/scan                       Auth unchanged (withKiosk; re-sign every at
 Body (new fields optional):
   { participantId: number,
     clientEventId?: string,          // UUID, stable across retries of one scan
-    scannedAt?:     string }         // ISO8601, instant the badge was read
+    scannedAt?:     string,          // ISO8601, instant the badge was read
+    forceCloseToken?: string }       // SHIPPED: echoes the warning's token (§5.23)
 
 Server:
   legacy body {participantId}        → exactly today's behavior (timestamp=now, no dedup key)
@@ -817,7 +818,9 @@ implementation, not a re-open. Questions 23–27 (v3 audit) are still open.
     next scan **ends the countdown and exits the state** — that is the
     confirm. Debounce no longer infers close from log spacing. Leftover
     debounce width (noise only) is an implementation default. Token
-    lifetime and queued-confirm expiry remain under §5.23.
+    lifetime and queued-confirm expiry: settled on §5.23 (2026-08-18) —
+    15s countdown at the edge, pre-outage tokens honored, confirm exempt
+    from the debounce.
 
 17. **Overnight poll / idle-stop exemption.**
     **Decided:** exempt only **kiosk-proxied** traffic (`signedRequest`).
@@ -863,14 +866,24 @@ implementation, not a re-open. Questions 23–27 (v3 audit) are still open.
     first two options.
     **Forced choice:** the warning issues a short-lived confirm token, or
     stamps the pending close on the keyholder's visit, and the second scan
-    must reference it. Residual open: **(a)** does a *queued* confirm honor a
-    token minted before the outage — recommended **no, expire it**, which
-    makes D4's "the confirm badge is its own queued event" wrong as written;
-    **(b)** token lifetime, and whether a confirm scan is exempt from the
-    debounce (the remainder of §5.16); **(c)** whether the fix ships
-    standalone ahead of Phase 1 — recommended yes, it is a live bug and
-    Phase 1 would otherwise freeze the adjacency rule into the replay
-    contract.
+    must reference it.
+    **Decided 2026-08-18 — and built.** The warning mints a token on the
+    keyholder's open Visit (`forceCloseToken`, beside `forceCloseWarnedAt`)
+    and returns it with the countdown length; only a scan echoing it
+    force-closes.
+    **(a) Honor a pre-outage token.** Validity is by issuance, not delivery:
+    there is no elapsed-time gate server-side, so a confirm queued through an
+    outage still closes when it lands. The recommendation above is overruled;
+    D4's "the confirm badge is its own queued event" stands as written, and
+    the §2 contract row calling a queued confirm expired is superseded.
+    **(b) Lifetime = the countdown, enforced at the edge.** 15 visible
+    seconds on the kiosk; the client drops the token when the countdown
+    lapses, and any next scan spends it either way (§5.16's "the next scan
+    ends the countdown"). A scan carrying a live token **is** exempt from the
+    3s debounce — otherwise the debounce swallows the confirm and Q16's
+    dead [0s,3s) front of the window survives. Single-use: the confirm spends
+    the token, so a stray second read finds nothing to match and debounces.
+    **(c) Ships standalone, ahead of the queue slice.**
 24. **The safety display owes a third state: *roster known incomplete*.**
     Two independent sources of a knowingly-wrong roster now exist: §5.14's
     (B)/(C) leave physically-present people off it, and audit B4 puts
@@ -918,6 +931,11 @@ implementation, not a re-open. Questions 23–27 (v3 audit) are still open.
     open backfill hard-refuses. Add the staleness
     mismatch recorded in §2 D7 and there are two guards for one hazard, one
     of them absent.
+    **Decided 2026-08-18: one rule — the manual open follows C too** (hold,
+    then project when a keyholder Visit exists), same as a scan. Not built
+    here: on `main` both paths still hard-refuse with the same 403, so they
+    agree today; C needs the deferred-projection substrate (§6, §5.22) and
+    lands with it, on both paths together.
     **Prerequisite:** audit B4 is undecided. The route's open-visit path and
     the register rule it contradicts (`docs/rules/attendance-checkin.md` — a
     visit recorded for someone else is always a closed one) shipped in the


### PR DESCRIPTION
Slice of #1347. Implements the ruling on the epic's last comment ("Phase 1 leftovers, decided.", 2026-08-18) — **not** the whole epic.

## The ruling, implemented

> - Confirm token across an outage: **honor** the pre-outage confirm. The queued second badge still closes.
> - Visible countdown: **15 seconds.**
> - Manual open visit while the server thinks closed: **match C** (hold, then project when a keyholder Visit exists). Same as a scan.
> - Explicit confirm (countdown + token) ships in **its own PR before** the outbox/replay cut.

**(a) Honor across an outage.** The confirm has **no elapsed-time gate server-side**. Validity is by issuance: the warning mints a token, and any later scan echoing it closes the facility whenever it lands — seconds later or after a multi-hour outage. This overrules §5.23's own "recommended no, expire it", so D4's "the confirm badge is its own queued event" stands as written and the §2 contract row that called a queued confirm expired is superseded (both updated in this PR).

**(b) 15-second visible countdown.** The kiosk banner carries a ticking counter; the countdown *is* the token's lifetime and it is enforced at the edge — `client.py` drops the token when the countdown lapses, and the banner clears with it. The server keeps no timer, which is exactly what makes (a) work.

**(c) Manual open while closed → match C.** Recorded on §5.26, **not built here**. On `main` the manual open backfill (`attendance/manual/route.ts`) and the scan check-in path (`processCheckin`) *already answer identically* — both return the same "Facility is closed. A Keyholder must check in first." 403. The divergence §5.26 describes only appears once the scan path becomes C, which happens in the queue/substrate cut. C's "hold, then project" half requires the §6 Stage-2 substrate + re-runnable projection, which this slice explicitly excludes; a hold with no projector would silently swallow the backfill, which is worse than today's refusal. So the decision is written down and lands with the substrate, on both paths together.

**(d)** Ships alone, before #1667.

## Mechanism

- **State: `Visit.forceCloseToken`**, beside the existing `forceCloseWarnedAt` — the §5.23 shape extended, not a parallel one. `forceCloseWarnedAt` stays as the "when we showed it" audit stamp; the token is what decides.
- **Warning** (`400 {type:"warning"}`) now carries `forceCloseToken` + `confirmSeconds`. **Confirm** = `POST /api/scan` with `forceCloseToken` matching the token on the caller's own open visit.
- **Single use.** The warning mints a *fresh* token every time, so an unconfirmed countdown can never be redeemed later; the confirm closes the visit, so the token matches nothing afterwards.
- **Debounce.** A scan carrying a **live** token is exempt from the 3s debounce — without that, the debounce swallows the confirm and Q16's dead `[0s,3s)` front of the window survives into the new mechanism (§5.16: "the next scan ends the countdown — that is the confirm"). The exemption is keyed on the token still matching an *open* visit, so the classic hazard (one badge swipe read twice, milliseconds apart) is unchanged: the first read spends the token and closes, the second matches nothing and debounces as before.
- **Web surface.** `/` self-check-in round-trips the token too (no ticking UI, the message states the window) — otherwise an explicit-confirm-only server would leave that path warning forever with no way to confirm.

## Design sections honored

- **§5.23 (B2)** — the forced choice, taken as "warning issues a short-lived confirm token"; all three residual opens (a)/(b)/(c) decided and recorded.
- **§5.16 (Q16)** — the confirm is explicit state with a visible countdown; the debounce no longer infers close from log spacing, and no longer swallows the confirm.
- **§0 invariant 1** — the debounce exception is preserved for noise, and force-close confirm is no longer inferred from that window.
- **§4 gate "Before Phase 1 — B2 / §5.23"** — this is that gate.
- Doc updated: §5 Q16, Q23, Q26, the §2 `/api/scan` contract block and its `{type:"warning"}` client row.

## Interaction with #1667 (offline store-and-replay)

**#1667 rebases on this after it merges.** No file on that branch is touched here.

#1667's F1 fix parks *every* replayed last-keyholder checkout as `force_close_review` and never reads or writes the force-close state — a blanket ban, taken while §5.23(a) was still open and recommended "expire it". The ruling went the other way, and this PR is what makes the safe version possible: a replayed second badge carrying a **valid pre-outage token** should close, because the token proves a human saw the warning and confirmed at the door. On rebase, #1667's park should narrow from "any replayed last-keyholder checkout" to "any replayed last-keyholder checkout **without** a matching `forceCloseToken`". Everything else in F1 stands.

Mechanical conflicts to expect on that rebase: `processCheckout`'s parameter list (both PRs add a 5th argument — `confirmToken` here, `replayEventId` there), the debounce block in `route.ts`, `post_scan`/`handle_scan` in `client.py`, and the same two design-doc rows.

## Tests

Local, all green:

- `checkin-app`: `npx tsc --noEmit` clean; `npm run lint` clean; **full unit suite 280 suites / 2789 tests pass**.
  - `scanServiceKeyholderWarning.test.ts` — rewritten off the timestamp window: warn mints a token and returns it with `confirmSeconds`; matching token closes; **a token "minted days ago" still closes** (the (a) pin); no token re-warns with a *different* token; wrong token re-warns instead of closing.
  - `scanRoute.test.ts` — a live token passes the debounce and is forwarded to `processCheckout`; a spent/unknown token still debounces (the double-read pin); a non-string token is treated as absent and never hits the DB.
  - `attendance/manual/[id]/route.test.ts` — the outbound-stripper pin extended to `forceCloseToken` (tier `internal`, must not reach a browser).
- `client/` (`python -m unittest discover -v`, venv + `requirements.txt`): **10/10 pass**, including `post_scan` sending the field only when a token is held, `take_confirm` being single-use and expiring with the countdown, and the warning→countdown→confirm sequence through `handle_scan`.
- **CI-only** (no local DB): `scanCausalChain.integration.test.ts` updated to the token and given a new case — warn, then badge again **inside** the 3s debounce with the token, and the facility closes.

## Migration

`20260818150000_visit_force_close_token` — one nullable column, `ADD COLUMN IF NOT EXISTS` (retry-safe), expand-only: the previous release never names it, so its reads are unaffected.

## Not in this slice

Health state machine and recovery ladder (§3), the offline queue and replay path (§2 — that is #1667), the §6 reconciliation substrate and deferred projection C, the server-side DLQ and `unsynced-scans` review panel, #254's facility-level force-close lock, and §5.24–25 (cannot-vouch display, minimize-by-surface) which stay Phase 2. Match-C for the manual open backfill is decided and recorded but lands with the substrate, per above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
