### PR TITLE
feat(attendance): supervising-adult test + close interrupt and banner (#1436, #1550)

### DIFF
--- a/checkin-app/prisma/migrations/20260818120000_visit_supervision_warned_at/migration.sql
+++ b/checkin-app/prisma/migrations/20260818120000_visit_supervision_warned_at/migration.sql
@@ -1,0 +1,5 @@
+-- Additive, nullable: old code neither reads nor writes it, so the drain window
+-- is safe. Every existing open visit starts unstamped, i.e. unconfirmed. Kept
+-- separate from forceCloseWarnedAt — the keyholder close-guard is its own
+-- interrupt and both can be pending on the same visit (#1436).
+ALTER TABLE "Visit" ADD COLUMN "supervisionWarnedAt" TIMESTAMP(3);

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -1121,6 +1121,12 @@ model Visit {
   /// @sensitivity:internal
   forceCloseWarnedAt DateTime?
 
+  /// When the kiosk last showed this person the "the room drops below two
+  /// supervising adults" warning (#1436). Its own stamp, not forceCloseWarnedAt:
+  /// the keyholder close-guard is a separate interrupt that can be pending at the
+  /// same time. @sensitivity:internal
+  supervisionWarnedAt DateTime?
+
   person Person @relation(fields: [personId], references: [id])
   event  Event?      @relation(fields: [associatedEventId], references: [id])
 

--- a/checkin-app/prisma/schema.prisma
+++ b/checkin-app/prisma/schema.prisma
@@ -1124,7 +1124,8 @@ model Visit {
   /// When the kiosk last showed this person the "the room drops below two
   /// supervising adults" warning (#1436). Its own stamp, not forceCloseWarnedAt:
   /// the keyholder close-guard is a separate interrupt that can be pending at the
-  /// same time. @sensitivity:internal
+  /// same time.
+  /// @sensitivity:internal
   supervisionWarnedAt DateTime?
 
   person Person @relation(fields: [personId], references: [id])

--- a/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
+++ b/checkin-app/src/app/api/household/__tests__/participantPiiMinimization.test.ts
@@ -30,6 +30,9 @@ jest.mock("@/lib/prisma", () => ({
     default: {
         person: { findUnique: jest.fn() },
         visit: { findMany: jest.fn() },
+        // The supervising-adult test reads the board's background-check recheck
+        // policy (#1436); unset here, which is the default.
+        boardSettings: { findUnique: jest.fn() },
     },
 }));
 

--- a/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
+++ b/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
@@ -7,6 +7,16 @@
 const findMany = jest.fn();
 jest.mock("@/lib/prisma", () => ({ __esModule: true, default: { visit: { findMany: (...a: unknown[]) => findMany(...a) } } }));
 
+// Who counts as a supervising adult is lib/supervision's rule and is tested there
+// (#1436/#1550). Pinned at 1 — short of two-deep — so what this file asserts is its
+// OWN half: whether a youth is accompanied by an adult of their household.
+jest.mock("@/lib/supervision", () => ({
+    __esModule: true,
+    MIN_SUPERVISING_ADULTS: 2,
+    supervisingAdultVisits: jest.fn().mockResolvedValue(new Map()),
+    supervisingAdultCount: () => 1,
+}));
+
 import { getFullAttendance } from "@/lib/getFullAttendance";
 
 // Age fixtures are relative to now so they never age past the youth boundary the
@@ -108,8 +118,8 @@ describe("getFullAttendance() — privileged caller (unchanged)", () => {
 describe("two-deep calc fails closed on unknown DOB (#300)", () => {
     // Youth (hh 8) + real adult (hh 6) + null-DOB visitor in the youth's
     // household. Under the old null→adult default the null-DOB visitor
-    // "accompanied" the youth AND made adultVisits.length 2 — masking the
-    // violation on both prongs.
+    // "accompanied" the youth, masking the violation. The supervising-adult
+    // count is the other prong and lives in lib/supervision now.
     const nullDobRow = {
         id: 204, arrivedAt: new Date("2026-07-01T14:20:00Z"), departedAt: null, personId: 80,
         person: {
@@ -130,9 +140,10 @@ describe("two-deep calc fails closed on unknown DOB (#300)", () => {
         expect(attendance[2].participant.isYouth).toBe(true);
     });
 
-    it("a DoB-stripped declared adult (#1165) still supervises", async () => {
+    it("a DoB-stripped declared adult (#1165) still accompanies their own youth", async () => {
         // Same shape, but the null-DoB visitor is a 26+ member whose DoB was
-        // deliberately deleted: isDeclaredAdult wins over the fail-closed default.
+        // deliberately deleted: isDeclaredAdult wins over the fail-closed default,
+        // so the youth of household 8 is no longer unaccompanied.
         findMany.mockResolvedValue([...rows, {
             ...nullDobRow,
             person: { ...nullDobRow.person, isDeclaredAdult: true },

--- a/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
+++ b/checkin-app/src/lib/__tests__/getFullAttendance.test.ts
@@ -10,10 +10,11 @@ jest.mock("@/lib/prisma", () => ({ __esModule: true, default: { visit: { findMan
 // Who counts as a supervising adult is lib/supervision's rule and is tested there
 // (#1436/#1550). Pinned at 1 — short of two-deep — so what this file asserts is its
 // OWN half: whether a youth is accompanied by an adult of their household.
+const supervisingAdultVisits = jest.fn().mockResolvedValue(new Map());
 jest.mock("@/lib/supervision", () => ({
     __esModule: true,
     MIN_SUPERVISING_ADULTS: 2,
-    supervisingAdultVisits: jest.fn().mockResolvedValue(new Map()),
+    supervisingAdultVisits: (...a: unknown[]) => supervisingAdultVisits(...a),
     supervisingAdultCount: () => 1,
 }));
 
@@ -52,6 +53,7 @@ const rows = [
 beforeEach(() => {
     findMany.mockReset();
     findMany.mockResolvedValue(rows);
+    supervisingAdultVisits.mockClear();
 });
 
 describe("getFullAttendance({ kiosk: true })", () => {
@@ -138,6 +140,7 @@ describe("two-deep calc fails closed on unknown DOB (#300)", () => {
         // counted as youth, not volunteer, and flagged as youth on the wire
         expect(counts).toEqual({ keyholders: 1, volunteers: 0, youth: 2, total: 3 });
         expect(attendance[2].participant.isYouth).toBe(true);
+        expect(supervisingAdultVisits).toHaveBeenCalled();
     });
 
     it("a DoB-stripped declared adult (#1165) still accompanies their own youth", async () => {
@@ -153,5 +156,8 @@ describe("two-deep calc fails closed on unknown DOB (#300)", () => {
         expect(safety.isTwoDeepViolation).toBe(false);
         expect(counts).toEqual({ keyholders: 1, volunteers: 1, youth: 1, total: 3 });
         expect(attendance[2].participant.isYouth).toBe(false);
+        // No unaccompanied youth, so the flag is false either way — the poll must
+        // not pay for the supervision queries to learn that.
+        expect(supervisingAdultVisits).not.toHaveBeenCalled();
     });
 });

--- a/checkin-app/src/lib/__tests__/scanServiceSupervisionInterrupt.test.ts
+++ b/checkin-app/src/lib/__tests__/scanServiceSupervisionInterrupt.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The departure interrupt ladder (#1436). Drives the REAL supervising-adult test
+ * through processCheckout, so the two stay wired together:
+ *
+ *   third supervising adult leaves (two remain) → warning, checkout proceeds
+ *   next one leaves (below two)                 → warning AND badge-again confirm
+ *
+ * The keyholder close-guard is a separate interrupt with its own stamp; the
+ * participant here is not a keyholder, so only the supervision rungs run.
+ */
+import type { Person } from "@/generated/prisma/client";
+import type { DbClient } from "@/lib/db-client";
+import { processCheckin, processCheckout } from "@/lib/scan-service";
+
+jest.mock("@/lib/prisma", () => ({ __esModule: true, default: {} }));
+jest.mock("@/lib/notifications", () => ({
+    sendCheckinNotifications: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("@/lib/attendanceTransitions", () => ({
+    findAssociatedEventAt: jest.fn().mockResolvedValue(null),
+    processVisitCheckout: jest.fn().mockResolvedValue([]),
+}));
+
+const adult = { id: 1, isKeyholder: false, isDeclaredAdult: true, dateOfBirth: null } as Person;
+const youth = { id: 9, isKeyholder: false, isDeclaredAdult: false, dateOfBirth: new Date("2015-01-01") } as Person;
+
+const DEPARTING_VISIT = 42;
+
+/** One open visit per household id, all fully qualifying supervising adults. */
+function openVisits(householdIds: number[]) {
+    return householdIds.map((householdId, i) => ({
+        id: i === 0 ? DEPARTING_VISIT : 100 + i,
+        person: {
+            householdId,
+            dateOfBirth: null,
+            isDeclaredAdult: true,
+            lastBackgroundCheck: new Date("2026-01-01"),
+            household: { orgMembership: { status: "ACTIVE" } },
+            programParticipants: [],
+        },
+    }));
+}
+
+function fakeDb(householdIds: number[], warnedAt: Date | null = null) {
+    const update = jest.fn().mockResolvedValue({});
+    const db = {
+        boardSettings: { findUnique: jest.fn().mockResolvedValue({ orgMembershipYearBoundary: null, bgRecheckMonths: 0 }) },
+        visit: {
+            count: jest.fn().mockResolvedValue(1),
+            findMany: jest.fn().mockResolvedValue(openVisits(householdIds)),
+            findUnique: jest.fn().mockResolvedValue({ supervisionWarnedAt: warnedAt }),
+            create: jest.fn().mockResolvedValue({ id: 500 }),
+            update,
+        },
+    };
+    return { db: db as unknown as DbClient, update };
+}
+
+async function checkout(householdIds: number[], warnedAt: Date | null = null) {
+    const { db, update } = fakeDb(householdIds, warnedAt);
+    const res = await processCheckout(adult, DEPARTING_VISIT, "kiosk", db);
+    return { res, body: await res.json(), update };
+}
+
+describe("rung 1 — the third supervising adult leaves", () => {
+    it("warns on the successful checkout and does not ask for a confirm", async () => {
+        const { res, body, update } = await checkout([10, 20, 30]);
+
+        expect(res.status).toBe(200);
+        expect(body.type).toBe("checkout");
+        expect(body.warning).toMatch(/only 2 supervising adults remain/i);
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it("stays quiet while more than two would remain", async () => {
+        const { body } = await checkout([10, 20, 30, 40]);
+        expect(body.warning).toBeUndefined();
+    });
+});
+
+describe("rung 2 — the next supervising adult leaves", () => {
+    it("blocks with a warning and stamps the visit", async () => {
+        const { res, body, update } = await checkout([10, 20]);
+
+        expect(res.status).toBe(400);
+        expect(body.type).toBe("warning");
+        expect(body.error).toMatch(/only 1 supervising adult/);
+        expect(body.error).toMatch(/3 to 15 seconds/);
+        expect(update).toHaveBeenCalledWith({
+            where: { id: DEPARTING_VISIT },
+            data: { supervisionWarnedAt: expect.any(Date) },
+        });
+    });
+
+    it("lets the checkout through on a scan that follows a fresh stamp", async () => {
+        const { res, body } = await checkout([10, 20], new Date(Date.now() - 8_000));
+
+        expect(res.status).toBe(200);
+        expect(body.type).toBe("checkout");
+    });
+
+    it("warns again once the countdown has run out", async () => {
+        const { res, body } = await checkout([10, 20], new Date(Date.now() - 60_000));
+
+        expect(res.status).toBe(400);
+        expect(body.type).toBe("warning");
+    });
+
+    it("says NO supervising adult when the last one leaves", async () => {
+        const { body } = await checkout([10]);
+        expect(body.error).toMatch(/NO supervising adult/);
+    });
+});
+
+describe("same household counts as one", () => {
+    it("does not interrupt when the departing adult's household stays represented", async () => {
+        // Three present, but two share household 10 — so two supervising adults
+        // before, and still two after. Nothing crossed.
+        const { res, body, update } = await checkout([10, 10, 20]);
+
+        expect(res.status).toBe(200);
+        expect(body.warning).toBeUndefined();
+        expect(update).not.toHaveBeenCalled();
+    });
+});
+
+describe("a departure that removes no supervising adult", () => {
+    it("is not interrupted", async () => {
+        // The departing visit is not among the supervising adults at all.
+        const { db, update } = fakeDb([10, 20]);
+        (db.visit.findMany as jest.Mock).mockResolvedValue(
+            openVisits([10, 20]).map(v => ({ ...v, id: v.id === DEPARTING_VISIT ? 999 : v.id })),
+        );
+
+        const res = await processCheckout(adult, DEPARTING_VISIT, "kiosk", db);
+
+        expect(res.status).toBe(200);
+        expect((await res.json()).warning).toBeUndefined();
+        expect(update).not.toHaveBeenCalled();
+    });
+});
+
+describe("youth check-in below two supervising adults", () => {
+    it("warns but is never blocked", async () => {
+        const { db } = fakeDb([10]);
+        const res = await processCheckin(youth, "kiosk", db);
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.type).toBe("checkin");
+        expect(body.warning).toMatch(/fewer than 2 supervising adults/i);
+    });
+
+    it("says nothing when the room is two deep", async () => {
+        const { db } = fakeDb([10, 20]);
+        expect((await (await processCheckin(youth, "kiosk", db)).json()).warning).toBeUndefined();
+    });
+
+    it("costs an adult check-in no supervision query at all", async () => {
+        const { db } = fakeDb([10]);
+        await processCheckin(adult, "kiosk", db);
+        expect(db.visit.findMany).not.toHaveBeenCalled();
+    });
+});

--- a/checkin-app/src/lib/__tests__/scanServiceSupervisionInterrupt.test.ts
+++ b/checkin-app/src/lib/__tests__/scanServiceSupervisionInterrupt.test.ts
@@ -3,7 +3,8 @@
  * through processCheckout, so the two stay wired together:
  *
  *   third supervising adult leaves (two remain) → warning, checkout proceeds
- *   next one leaves (below two)                 → warning AND badge-again confirm
+ *   next one leaves, a youth is here            → warning AND badge-again confirm
+ *   next one leaves, no youth is here           → warning, checkout proceeds
  *
  * The keyholder close-guard is a separate interrupt with its own stamp; the
  * participant here is not a keyholder, so only the supervision rungs run.
@@ -41,13 +42,19 @@ function openVisits(householdIds: number[]) {
     }));
 }
 
-function fakeDb(householdIds: number[], warnedAt: Date | null = null) {
+/** The supervising-adult query and the youth probe both hit `visit.findMany`;
+ *  the probe is the one filtering on `isDeclaredAdult: false`. Youth present by
+ *  default — the confirm rung is gated on it. */
+function fakeDb(householdIds: number[], warnedAt: Date | null = null, youthPresent = true) {
     const update = jest.fn().mockResolvedValue({});
     const db = {
         boardSettings: { findUnique: jest.fn().mockResolvedValue({ orgMembershipYearBoundary: null, bgRecheckMonths: 0 }) },
         visit: {
             count: jest.fn().mockResolvedValue(1),
-            findMany: jest.fn().mockResolvedValue(openVisits(householdIds)),
+            findMany: jest.fn().mockImplementation(({ where }) =>
+                where.person?.isDeclaredAdult === false
+                    ? (youthPresent ? [{ person: { dateOfBirth: new Date("2015-01-01") } }] : [])
+                    : openVisits(householdIds)),
             findUnique: jest.fn().mockResolvedValue({ supervisionWarnedAt: warnedAt }),
             create: jest.fn().mockResolvedValue({ id: 500 }),
             update,
@@ -56,10 +63,10 @@ function fakeDb(householdIds: number[], warnedAt: Date | null = null) {
     return { db: db as unknown as DbClient, update };
 }
 
-async function checkout(householdIds: number[], warnedAt: Date | null = null) {
-    const { db, update } = fakeDb(householdIds, warnedAt);
+async function checkout(householdIds: number[], warnedAt: Date | null = null, youthPresent = true) {
+    const { db, update } = fakeDb(householdIds, warnedAt, youthPresent);
     const res = await processCheckout(adult, DEPARTING_VISIT, "kiosk", db);
-    return { res, body: await res.json(), update };
+    return { res, body: await res.json(), update, db };
 }
 
 describe("rung 1 — the third supervising adult leaves", () => {
@@ -109,6 +116,29 @@ describe("rung 2 — the next supervising adult leaves", () => {
     it("says NO supervising adult when the last one leaves", async () => {
         const { body } = await checkout([10]);
         expect(body.error).toMatch(/NO supervising adult/);
+    });
+});
+
+describe("the confirm rung is youth-gated", () => {
+    it("warns and lets the checkout through when no youth is in the building", async () => {
+        const { res, body, update } = await checkout([10, 20], null, false);
+
+        expect(res.status).toBe(200);
+        expect(body.type).toBe("checkout");
+        expect(body.warning).toMatch(/leaves only 1 supervising adult/i);
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it("still warns when the last adult leaves an empty-of-youth room", async () => {
+        const { res, body } = await checkout([10], null, false);
+
+        expect(res.status).toBe(200);
+        expect(body.warning).toMatch(/NO supervising adult/);
+    });
+
+    it("does not probe for youth on the warn-only rung", async () => {
+        const { db } = await checkout([10, 20, 30]);
+        expect((db.visit.findMany as jest.Mock)).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/checkin-app/src/lib/__tests__/supervision.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/supervision.integration.test.ts
@@ -1,0 +1,246 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Integration coverage for the supervising-adult test (#1436 / #1550) against a
+ * real Postgres — the half the unit tests mock away is the query itself: the
+ * nested membership filter, and the participant-seat probe's "programme in
+ * session now" OR (an event bracketing now, or the programme's own dates).
+ *
+ * Also drives the two surfaces that consume it end to end: the departure
+ * interrupt ladder (processCheckout) and the compliance banner
+ * (getFullAttendance).
+ */
+import prisma from '@/lib/prisma';
+import { getFullAttendance } from '@/lib/getFullAttendance';
+import { processCheckin, processCheckout } from '@/lib/scan-service';
+import { supervisingAdultCount, supervisingAdultVisits } from '@/lib/supervision';
+import type { Person } from '@/generated/prisma/client';
+
+jest.mock('@/lib/notifications', () => ({
+    sendCheckinNotifications: jest.fn().mockResolvedValue(undefined),
+}));
+
+const TAG = 'supervision-test';
+const HOUR = 60 * 60 * 1000;
+const CLEARED = new Date('2026-06-01');
+
+describe('supervising adults (integration)', () => {
+    const people: Record<string, Person> = {};
+    const householdIds: number[] = [];
+    const programIds: number[] = [];
+
+    /** A cleared adult of their own ACTIVE member household. */
+    async function makeAdult(key: string, opts: { isKeyholder?: boolean; cleared?: boolean } = {}) {
+        const person = await prisma.person.create({
+            data: {
+                name: key,
+                email: `${key}-${TAG}@example.com`,
+                isDeclaredAdult: true,
+                isKeyholder: opts.isKeyholder ?? false,
+                lastBackgroundCheck: opts.cleared === false ? null : CLEARED,
+                household: { create: { name: `${key} HH ${TAG}` } },
+            },
+        });
+        await prisma.orgMembership.create({ data: { householdId: person.householdId, status: 'ACTIVE' } });
+        householdIds.push(person.householdId);
+        people[key] = person;
+        return person;
+    }
+
+    /** A second adult inside an existing person's household. */
+    async function makeHouseholdMate(key: string, ofKey: string) {
+        people[key] = await prisma.person.create({
+            data: {
+                name: key,
+                email: `${key}-${TAG}@example.com`,
+                isDeclaredAdult: true,
+                lastBackgroundCheck: CLEARED,
+                householdId: people[ofKey].householdId,
+            },
+        });
+        return people[key];
+    }
+
+    async function enrol(key: string, programId: number) {
+        await prisma.programParticipant.create({
+            data: { programId, personId: people[key].id, status: 'ACTIVE', pendingSince: null },
+        });
+    }
+
+    const checkIn = (key: string) =>
+        prisma.visit.create({ data: { personId: people[key].id, arrivedAt: new Date() } });
+
+    beforeAll(async () => {
+        await makeAdult('ann', { isKeyholder: true });
+        await makeHouseholdMate('al', 'ann');
+        await makeAdult('ben');
+        await makeAdult('cal');
+        await makeAdult('dee');
+        await makeAdult('gil');
+        await makeAdult('eve', { cleared: false });
+
+        people.fay = await prisma.person.create({
+            data: {
+                name: 'fay',
+                email: `fay-${TAG}@example.com`,
+                dateOfBirth: new Date('2015-01-01'),
+                household: { create: { name: `fay HH ${TAG}` } },
+            },
+        });
+        householdIds.push(people.fay.householdId);
+
+        // In session by EVENT: no programme dates at all, one event bracketing now.
+        const byEvent = await prisma.program.create({ data: { name: `Event Prog ${TAG}` } });
+        programIds.push(byEvent.id);
+        await prisma.event.create({
+            data: {
+                name: `Now ${TAG}`,
+                programId: byEvent.id,
+                startAt: new Date(Date.now() - HOUR),
+                endAt: new Date(Date.now() + HOUR),
+            },
+        });
+        await enrol('dee', byEvent.id);
+
+        // In session by DATES: no events, the programme's own dates cover today.
+        const byDates = await prisma.program.create({
+            data: {
+                name: `Dates Prog ${TAG}`,
+                phase: 'RUNNING',
+                startAt: new Date(Date.now() - 30 * 24 * HOUR),
+                endAt: new Date(Date.now() + 30 * 24 * HOUR),
+            },
+        });
+        programIds.push(byDates.id);
+        await enrol('gil', byDates.id);
+    });
+
+    beforeEach(async () => {
+        await prisma.visit.deleteMany({});
+    });
+
+    afterAll(async () => {
+        const ids = Object.values(people).map(p => p.id);
+        await prisma.visit.deleteMany({ where: { personId: { in: ids } } });
+        await prisma.programParticipant.deleteMany({ where: { programId: { in: programIds } } });
+        await prisma.event.deleteMany({ where: { programId: { in: programIds } } });
+        await prisma.program.deleteMany({ where: { id: { in: programIds } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: householdIds } } });
+        await prisma.person.deleteMany({ where: { id: { in: ids } } });
+        await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
+    });
+
+    const count = async () => supervisingAdultCount(await supervisingAdultVisits());
+
+    describe('the test itself', () => {
+        it('counts cleared adults of ACTIVE member households, one per household', async () => {
+            await checkIn('ann');
+            await checkIn('al');
+            await checkIn('ben');
+
+            expect(await count()).toBe(2);
+        });
+
+        it('never counts an adult holding a seat on a programme in session now', async () => {
+            await checkIn('ann');
+            await checkIn('dee');
+            await checkIn('gil');
+
+            expect(await count()).toBe(1);
+        });
+
+        it('never counts an adult with no background check on file', async () => {
+            await checkIn('ann');
+            await checkIn('eve');
+
+            expect(await count()).toBe(1);
+        });
+
+        it('never counts a youth', async () => {
+            await checkIn('ann');
+            await checkIn('fay');
+
+            expect(await count()).toBe(1);
+        });
+    });
+
+    describe('the compliance banner (#1550)', () => {
+        it('is clear when two supervising adults cover an unaccompanied youth', async () => {
+            await checkIn('ann');
+            await checkIn('ben');
+            await checkIn('fay');
+
+            expect((await getFullAttendance()).safety.isTwoDeepViolation).toBe(false);
+        });
+
+        it('fires when the second adult is a programme participant, not a supervisor', async () => {
+            await checkIn('ann');
+            await checkIn('dee');
+            await checkIn('fay');
+
+            expect((await getFullAttendance()).safety.isTwoDeepViolation).toBe(true);
+        });
+
+        it('fires when the two adults share a household', async () => {
+            await checkIn('ann');
+            await checkIn('al');
+            await checkIn('fay');
+
+            expect((await getFullAttendance()).safety.isTwoDeepViolation).toBe(true);
+        });
+    });
+
+    describe('the departure interrupt ladder (#1436)', () => {
+        it('warns without a confirm when the third supervising adult leaves', async () => {
+            await checkIn('ann');
+            await checkIn('ben');
+            const cal = await checkIn('cal');
+
+            const res = await processCheckout(people.cal, cal.id, 'kiosk');
+            const body = await res.json();
+
+            expect(res.status).toBe(200);
+            expect(body.warning).toMatch(/only 2 supervising adults remain/i);
+            expect(await prisma.visit.findUnique({ where: { id: cal.id } })).toMatchObject({ supervisionWarnedAt: null });
+        });
+
+        it('warns AND requires a second badge when the next one leaves', async () => {
+            await checkIn('ann');
+            const ben = await checkIn('ben');
+
+            const first = await processCheckout(people.ben, ben.id, 'kiosk');
+            expect(first.status).toBe(400);
+            expect((await first.json()).type).toBe('warning');
+            const stamped = await prisma.visit.findUnique({ where: { id: ben.id } });
+            expect(stamped?.supervisionWarnedAt).not.toBeNull();
+            expect(stamped?.departedAt).toBeNull();
+
+            const second = await processCheckout(people.ben, ben.id, 'kiosk');
+            expect(second.status).toBe(200);
+            expect((await prisma.visit.findUnique({ where: { id: ben.id } }))?.departedAt).not.toBeNull();
+        });
+
+        it('stays quiet when the departing adult\'s household is still represented', async () => {
+            await checkIn('ann');
+            const al = await checkIn('al');
+            await checkIn('ben');
+
+            const res = await processCheckout(people.al, al.id, 'kiosk');
+
+            expect(res.status).toBe(200);
+            expect((await res.json()).warning).toBeUndefined();
+        });
+
+        it('warns a youth checking in below two, and lets them in anyway', async () => {
+            await checkIn('ann');
+
+            const res = await processCheckin(people.fay, 'kiosk');
+            const body = await res.json();
+
+            expect(res.status).toBe(200);
+            expect(body.type).toBe('checkin');
+            expect(body.warning).toMatch(/fewer than 2 supervising adults/i);
+        });
+    });
+});

--- a/checkin-app/src/lib/__tests__/supervision.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/supervision.integration.test.ts
@@ -205,8 +205,9 @@ describe('supervising adults (integration)', () => {
             expect(await prisma.visit.findUnique({ where: { id: cal.id } })).toMatchObject({ supervisionWarnedAt: null });
         });
 
-        it('warns AND requires a second badge when the next one leaves', async () => {
+        it('warns AND requires a second badge when the next one leaves a youth here', async () => {
             await checkIn('ann');
+            await checkIn('fay');
             const ben = await checkIn('ben');
 
             const first = await processCheckout(people.ben, ben.id, 'kiosk');
@@ -219,6 +220,19 @@ describe('supervising adults (integration)', () => {
             const second = await processCheckout(people.ben, ben.id, 'kiosk');
             expect(second.status).toBe(200);
             expect((await prisma.visit.findUnique({ where: { id: ben.id } }))?.departedAt).not.toBeNull();
+        });
+
+        it('warns without a confirm when the same departure leaves no youth behind', async () => {
+            await checkIn('ann');
+            const ben = await checkIn('ben');
+
+            const res = await processCheckout(people.ben, ben.id, 'kiosk');
+
+            expect(res.status).toBe(200);
+            expect((await res.json()).warning).toMatch(/leaves only 1 supervising adult/i);
+            const closed = await prisma.visit.findUnique({ where: { id: ben.id } });
+            expect(closed?.supervisionWarnedAt).toBeNull();
+            expect(closed?.departedAt).not.toBeNull();
         });
 
         it('stays quiet when the departing adult\'s household is still represented', async () => {

--- a/checkin-app/src/lib/__tests__/supervision.integration.test.ts
+++ b/checkin-app/src/lib/__tests__/supervision.integration.test.ts
@@ -116,12 +116,15 @@ describe('supervising adults (integration)', () => {
         await enrol('gil', byDates.id);
     });
 
+    /** Only this suite's rows: a bare deleteMany({}) wipes every other suite's visits too. */
+    const ownIds = () => Object.values(people).map(p => p.id);
+
     beforeEach(async () => {
-        await prisma.visit.deleteMany({});
+        await prisma.visit.deleteMany({ where: { personId: { in: ownIds() } } });
     });
 
     afterAll(async () => {
-        const ids = Object.values(people).map(p => p.id);
+        const ids = ownIds();
         await prisma.visit.deleteMany({ where: { personId: { in: ids } } });
         await prisma.programParticipant.deleteMany({ where: { programId: { in: programIds } } });
         await prisma.event.deleteMany({ where: { programId: { in: programIds } } });

--- a/checkin-app/src/lib/__tests__/supervision.test.ts
+++ b/checkin-app/src/lib/__tests__/supervision.test.ts
@@ -117,7 +117,7 @@ describe("supervisingAdultCount(excludeVisitId)", () => {
 });
 
 describe("the programme-in-session probe", () => {
-    it("asks for an event bracketing now, dates covering today, or an open-ended RUNNING programme", async () => {
+    it("asks for an event bracketing now, dates covering today, or a RUNNING programme with an open end or no start", async () => {
         const now = new Date("2026-08-18T15:00:00Z");
         findMany.mockResolvedValue([]);
         await supervisingAdultVisits(undefined, now);
@@ -128,6 +128,9 @@ describe("the programme-in-session probe", () => {
             { events: { some: { startAt: { lte: now }, endAt: { gte: now } } } },
             { startAt: { lte: expect.any(Date) }, endAt: { gte: expect.any(Date) } },
             { startAt: { lte: expect.any(Date) }, endAt: null, phase: "RUNNING" },
+            // A RUNNING programme with no start date: `lte` never matches null, so
+            // without this arm its participants fail OPEN into the count.
+            { startAt: null, phase: "RUNNING" },
         ]);
     });
 });

--- a/checkin-app/src/lib/__tests__/supervision.test.ts
+++ b/checkin-app/src/lib/__tests__/supervision.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The supervising-adult test (#1436 / #1550) — the shared rule behind the
+ * departure interrupt and the two-deep compliance banner. Policy's "two deep" is
+ * two unrelated cleared volunteers, so every edge here is a way the old
+ * count-bare-adults check reported a room compliant when it was not.
+ */
+const findMany = jest.fn();
+const boardSettingsFindUnique = jest.fn();
+jest.mock("@/lib/prisma", () => ({
+    __esModule: true,
+    default: {
+        visit: { findMany: (...a: unknown[]) => findMany(...a) },
+        boardSettings: { findUnique: (...a: unknown[]) => boardSettingsFindUnique(...a) },
+    },
+}));
+
+import { supervisingAdultCount, supervisingAdultVisits } from "@/lib/supervision";
+
+const yearsAgo = (n: number) => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() - n);
+    d.setDate(d.getDate() - 1);
+    return d;
+};
+
+/** An open visit by a person who qualifies on every prong; override to break one. */
+function visit(id: number, householdId: number, person: Record<string, unknown> = {}) {
+    return {
+        id,
+        person: {
+            householdId,
+            dateOfBirth: yearsAgo(40),
+            isDeclaredAdult: false,
+            lastBackgroundCheck: yearsAgo(1),
+            household: { orgMembership: { status: "ACTIVE" } },
+            programParticipants: [],
+            ...person,
+        },
+    };
+}
+
+beforeEach(() => {
+    findMany.mockReset();
+    boardSettingsFindUnique.mockReset();
+    // No recheck policy configured — the default. Clearance never expires, but a
+    // person still needs one on file.
+    boardSettingsFindUnique.mockResolvedValue({ orgMembershipYearBoundary: null, bgRecheckMonths: 0 });
+});
+
+async function count(rows: ReturnType<typeof visit>[]) {
+    findMany.mockResolvedValue(rows);
+    return supervisingAdultCount(await supervisingAdultVisits());
+}
+
+describe("who counts as a supervising adult", () => {
+    it("counts a cleared adult of an ACTIVE member household", async () => {
+        expect(await count([visit(1, 10), visit(2, 20)])).toBe(2);
+    });
+
+    it("counts two adults of ONE household as one adult", async () => {
+        expect(await count([visit(1, 10), visit(2, 10), visit(3, 20)])).toBe(2);
+    });
+
+    it("excludes a youth", async () => {
+        expect(await count([visit(1, 10), visit(2, 20, { dateOfBirth: yearsAgo(15) })])).toBe(1);
+    });
+
+    it("excludes an unknown age but keeps a DoB-stripped declared adult (#1165, #300)", async () => {
+        const unknown = visit(1, 10, { dateOfBirth: null });
+        const declared = visit(2, 20, { dateOfBirth: null, isDeclaredAdult: true });
+        expect(await count([unknown, declared])).toBe(1);
+    });
+
+    it("excludes an adult whose household is not an ACTIVE member — ACTIVE encodes cleared", async () => {
+        const revoked = visit(2, 20, { household: { orgMembership: { status: "REVOKED" } } });
+        const noMembership = visit(3, 30, { household: { orgMembership: null } });
+        expect(await count([visit(1, 10), revoked, noMembership])).toBe(1);
+    });
+
+    it("excludes an adult with no background check on file", async () => {
+        expect(await count([visit(1, 10), visit(2, 20, { lastBackgroundCheck: null })])).toBe(1);
+    });
+
+    it("excludes an adult holding a participant seat on a programme in session now", async () => {
+        const participant = visit(2, 20, { programParticipants: [{ programId: 7 }] });
+        expect(await count([visit(1, 10), participant])).toBe(1);
+    });
+});
+
+describe("clearance validity", () => {
+    // Boundary Aug 1, recheck every 12 months: a check expires at the boundary
+    // following lastBackgroundCheck + 12 months.
+    const settings = { orgMembershipYearBoundary: new Date(Date.UTC(2000, 7, 1)), bgRecheckMonths: 12 };
+
+    it("excludes an adult whose clearance has expired under the board's recheck policy", async () => {
+        boardSettingsFindUnique.mockResolvedValue(settings);
+        expect(await count([visit(1, 10), visit(2, 20, { lastBackgroundCheck: yearsAgo(5) })])).toBe(1);
+    });
+
+    it("keeps an adult whose clearance is inside the recheck window", async () => {
+        boardSettingsFindUnique.mockResolvedValue(settings);
+        expect(await count([visit(1, 10), visit(2, 20)])).toBe(2);
+    });
+});
+
+describe("supervisingAdultCount(excludeVisitId)", () => {
+    const supervising = new Map([[1, 10], [2, 10], [3, 20]]);
+
+    it("answers as if that visit had already departed", () => {
+        expect(supervisingAdultCount(supervising)).toBe(2);
+        expect(supervisingAdultCount(supervising, 3)).toBe(1);
+    });
+
+    it("does not drop the count when the household is still represented", () => {
+        expect(supervisingAdultCount(supervising, 1)).toBe(2);
+    });
+});
+
+describe("the programme-in-session probe", () => {
+    it("asks for an event bracketing now, dates covering today, or an open-ended RUNNING programme", async () => {
+        const now = new Date("2026-08-18T15:00:00Z");
+        findMany.mockResolvedValue([]);
+        await supervisingAdultVisits(undefined, now);
+
+        const where = findMany.mock.calls[0][0].select.person.select.programParticipants.where;
+        expect(where.status).toBe("ACTIVE");
+        expect(where.program.OR).toEqual([
+            { events: { some: { startAt: { lte: now }, endAt: { gte: now } } } },
+            { startAt: { lte: expect.any(Date) }, endAt: { gte: expect.any(Date) } },
+            { startAt: { lte: expect.any(Date) }, endAt: null, phase: "RUNNING" },
+        ]);
+    });
+});

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -101,11 +101,13 @@ export async function getFullAttendance(opts: { kiosk?: boolean } = {}) {
     });
     // Two deep is two SUPERVISING adults, not two bodies over 18 (#1550) — the
     // same test the departure interrupt uses. ponytail: its own query rather than
-    // widening the select above, so both surfaces run one shared rule.
-    const supervisingAdults = supervisingAdultCount(await supervisingAdultVisits());
+    // widening the select above, so both surfaces run one shared rule. Asked only
+    // when a youth is unaccompanied — the only case the flag can be true — so an
+    // adult-only room costs this poll no extra queries, as processCheckin does.
     const safety = {
         isLastKeyholder: keyholderVisits.length === 1,
-        isTwoDeepViolation: unaccompaniedYouth.length > 0 && supervisingAdults < MIN_SUPERVISING_ADULTS,
+        isTwoDeepViolation: unaccompaniedYouth.length > 0
+            && supervisingAdultCount(await supervisingAdultVisits()) < MIN_SUPERVISING_ADULTS,
     };
 
     // Drop email/googleId from the wire (M1): resolve the same name-or-email-prefix

--- a/checkin-app/src/lib/getFullAttendance.ts
+++ b/checkin-app/src/lib/getFullAttendance.ts
@@ -1,6 +1,7 @@
 import prisma from "@/lib/prisma";
 import { isYouth } from "@/lib/time";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import { MIN_SUPERVISING_ADULTS, supervisingAdultCount, supervisingAdultVisits } from "@/lib/supervision";
 
 /**
  * Current-attendance feed.
@@ -98,9 +99,13 @@ export async function getFullAttendance(opts: { kiosk?: boolean } = {}) {
         if (!sv.person.householdId) return true;
         return !adultVisits.some(av => av.person.householdId === sv.person.householdId);
     });
+    // Two deep is two SUPERVISING adults, not two bodies over 18 (#1550) — the
+    // same test the departure interrupt uses. ponytail: its own query rather than
+    // widening the select above, so both surfaces run one shared rule.
+    const supervisingAdults = supervisingAdultCount(await supervisingAdultVisits());
     const safety = {
         isLastKeyholder: keyholderVisits.length === 1,
-        isTwoDeepViolation: unaccompaniedYouth.length > 0 && adultVisits.length < 2,
+        isTwoDeepViolation: unaccompaniedYouth.length > 0 && supervisingAdults < MIN_SUPERVISING_ADULTS,
     };
 
     // Drop email/googleId from the wire (M1): resolve the same name-or-email-prefix

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -5,10 +5,16 @@ import { apiError, apiJson } from "@/lib/api-response";
 import type { Person } from "@/generated/prisma/client";
 import { type DbClient, isRootClient } from "@/lib/db-client";
 import { MAX_VISIT_MS } from "@/lib/visitTimes";
+import { MIN_SUPERVISING_ADULTS, supervisingAdultCount, supervisingAdultVisits } from "@/lib/supervision";
+import { isYouth } from "@/lib/time";
 
 /** How long a displayed force-close warning stays confirmable. The scan route's
  *  3s debounce eats the front of it, so the kiosk copy says "3 to 60 seconds". */
 const FORCE_CLOSE_CONFIRM_MS = 60_000;
+
+/** Countdown on the supervision confirm (#1436). Same 3s debounce eats the front,
+ *  so the kiosk copy says "3 to 15 seconds". */
+const SUPERVISION_CONFIRM_MS = 15_000;
 
 /**
  * Process a check-in for a participant who has no active visit.
@@ -51,9 +57,21 @@ export async function processCheckin(participant: Person, authType: string, db: 
         console.error('Checkin notification error:', err)
     );
 
+    // A youth arriving into a room short of supervision is WARNED, never blocked
+    // (#1436): opening the door before the second adult is the keyholder's call to
+    // make, and the app's job is to tell the room. Only asked for youth, so an
+    // ordinary adult check-in still costs no extra query.
+    const isYouthArrival = !participant.isDeclaredAdult
+        && isYouth(participant.dateOfBirth, { unknownIs: "youth" });
+    const supervisionWarning = isYouthArrival
+        && supervisingAdultCount(await supervisingAdultVisits(db)) < MIN_SUPERVISING_ADULTS
+        ? `Warning: fewer than ${MIN_SUPERVISING_ADULTS} supervising adults are in the building.`
+        : undefined;
+
     return apiJson({
         message: "Checked in successfully",
         type: "checkin" as const,
+        warning: supervisionWarning,
         participant,
         visit: newVisit,
         signedRequest: authType === "kiosk",
@@ -144,6 +162,16 @@ export async function processCheckout(
         }
     }
 
+    // SUPERVISION INTERRUPT (#1436). Fires on EVERY departure, not just a
+    // keyholder's — the close-guard above is a separate interrupt with its own
+    // stamp. Skipped when the facility is closing: that sweep departs everyone.
+    let supervisionWarning: string | undefined;
+    if (!facilityClosed) {
+        const interrupt = await supervisionInterrupt(activeVisitId, db);
+        if (interrupt?.confirmRequired) return interrupt.response;
+        supervisionWarning = interrupt?.warning;
+    }
+
     const finalVisits = await processVisitCheckout(activeVisitId, new Date(), db, "SCANNER");
     const updatedVisit = finalVisits.length > 0 ? finalVisits[finalVisits.length - 1] : null;
 
@@ -155,11 +183,65 @@ export async function processCheckout(
     return apiJson({
         message: facilityClosed ? "Checked out and Facility closed" : "Checked out successfully",
         type: "checkout" as const,
+        warning: supervisionWarning,
         participant,
         visit: updatedVisit,
         facilityClosed,
         signedRequest: authType === "kiosk",
     });
+}
+
+/**
+ * The two-rung supervision ladder for a departure (#1436), keyed on how many
+ * supervising adults would REMAIN — and only when this departure is what removes
+ * one. A second adult from the same household leaving changes nothing, because
+ * the household is still represented; that is the same-household rule.
+ *
+ *   remaining === 2 (the third supervising adult leaves) → warn, do not confirm.
+ *   remaining  <  2 (the next one leaves)                → warn AND confirm.
+ *
+ * The confirm is bound to the warning having been SHOWN, not to badge adjacency:
+ * only a scan following a fresh `supervisionWarnedAt` stamp goes through, exactly
+ * as the force-close confirm works. Countdown window is
+ * {@link SUPERVISION_CONFIRM_MS}; #1347's explicit-confirm slice renders the tick.
+ */
+async function supervisionInterrupt(
+    activeVisitId: number,
+    db: DbClient,
+): Promise<{ confirmRequired: true; response: Response } | { confirmRequired: false; warning?: string } | null> {
+    const supervising = await supervisingAdultVisits(db);
+    const before = supervisingAdultCount(supervising);
+    const remaining = supervisingAdultCount(supervising, activeVisitId);
+    if (remaining >= before || remaining > MIN_SUPERVISING_ADULTS) return null;
+
+    if (remaining === MIN_SUPERVISING_ADULTS) {
+        return {
+            confirmRequired: false,
+            warning: `Warning: only ${MIN_SUPERVISING_ADULTS} supervising adults remain in the building.`,
+        };
+    }
+
+    const ownVisit = await db.visit.findUnique({
+        where: { id: activeVisitId },
+        select: { supervisionWarnedAt: true },
+    });
+    const warnedAt = ownVisit?.supervisionWarnedAt;
+    if (warnedAt != null && Date.now() - warnedAt.getTime() <= SUPERVISION_CONFIRM_MS) {
+        return { confirmRequired: false };
+    }
+
+    await db.visit.update({
+        where: { id: activeVisitId },
+        data: { supervisionWarnedAt: new Date() },
+    });
+    const left = remaining === 1 ? "only 1 supervising adult" : "NO supervising adult";
+    return {
+        confirmRequired: true,
+        response: apiJson({
+            error: `Warning! Checking out leaves ${left} in the building.\n\nBadge again in 3 to ${SUPERVISION_CONFIRM_MS / 1000} seconds to confirm.`,
+            type: "warning" as const,
+        }, 400),
+    };
 }
 
 /** Mark every still-open visit as departed. Facility-wide, not participant-scoped:

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -5,7 +5,7 @@ import { apiError, apiJson } from "@/lib/api-response";
 import type { Person } from "@/generated/prisma/client";
 import { type DbClient, isRootClient } from "@/lib/db-client";
 import { MAX_VISIT_MS } from "@/lib/visitTimes";
-import { MIN_SUPERVISING_ADULTS, supervisingAdultCount, supervisingAdultVisits } from "@/lib/supervision";
+import { MIN_SUPERVISING_ADULTS, supervisingAdultCount, supervisingAdultVisits, youthIsPresent } from "@/lib/supervision";
 import { isYouth } from "@/lib/time";
 
 /** How long a displayed force-close warning stays confirmable. The scan route's
@@ -198,7 +198,10 @@ export async function processCheckout(
  * the household is still represented; that is the same-household rule.
  *
  *   remaining === 2 (the third supervising adult leaves) → warn, do not confirm.
- *   remaining  <  2 (the next one leaves)                → warn AND confirm.
+ *   remaining  <  2 (the next one leaves), youth present → warn AND confirm.
+ *   remaining  <  2 with no youth in the building        → warn, do not confirm.
+ *
+ * Only the confirm rung is youth-gated; the warn rung over-warns deliberately.
  *
  * The confirm is bound to the warning having been SHOWN, not to badge adjacency:
  * only a scan following a fresh `supervisionWarnedAt` stamp goes through, exactly
@@ -221,6 +224,15 @@ async function supervisionInterrupt(
         };
     }
 
+    const left = remaining === 1 ? "only 1 supervising adult" : "NO supervising adult";
+
+    // The confirm rung is youth-gated (#1436, 2026-08-19): policy's floor is two
+    // adults whenever a youth is, so an adult-only room locking up warns and goes.
+    // Probed on this rung only — every quieter departure pays nothing for it.
+    if (!(await youthIsPresent(db))) {
+        return { confirmRequired: false, warning: `Warning: checking out leaves ${left} in the building.` };
+    }
+
     const ownVisit = await db.visit.findUnique({
         where: { id: activeVisitId },
         select: { supervisionWarnedAt: true },
@@ -234,7 +246,6 @@ async function supervisionInterrupt(
         where: { id: activeVisitId },
         data: { supervisionWarnedAt: new Date() },
     });
-    const left = remaining === 1 ? "only 1 supervising adult" : "NO supervising adult";
     return {
         confirmRequired: true,
         response: apiJson({

--- a/checkin-app/src/lib/supervision.ts
+++ b/checkin-app/src/lib/supervision.ts
@@ -36,7 +36,9 @@ export const MIN_SUPERVISING_ADULTS = 2;
 /**
  * A program is in session now: one of its events brackets this instant, or the
  * program's own dates cover today. An open-ended RUNNING program counts from its
- * start — an unset end date must not read as "not in session".
+ * start — an unset end date must not read as "not in session". A RUNNING program
+ * with no start date either: `lte` never matches null, so without the fourth arm
+ * its participants fail OPEN into the supervising count.
  */
 function programInSessionNow(now: Date, today: Date): Prisma.ProgramWhereInput {
     return {
@@ -44,6 +46,7 @@ function programInSessionNow(now: Date, today: Date): Prisma.ProgramWhereInput {
             { events: { some: { startAt: { lte: now }, endAt: { gte: now } } } },
             { startAt: { lte: today }, endAt: { gte: today } },
             { startAt: { lte: today }, endAt: null, phase: "RUNNING" },
+            { startAt: null, phase: "RUNNING" },
         ],
     };
 }

--- a/checkin-app/src/lib/supervision.ts
+++ b/checkin-app/src/lib/supervision.ts
@@ -122,6 +122,20 @@ export async function supervisingAdultVisits(
 }
 
 /**
+ * Is a youth in the building? The adult prong inverted, over the same open
+ * visits: not declared adult, and not 18+ by date of birth — unknown age fails
+ * closed as youth (#300). Only the `isDeclaredAdult` half is a query filter; the
+ * age half stays with {@link isYouth} so the rule keeps one expression.
+ */
+export async function youthIsPresent(db: DbClient = prisma): Promise<boolean> {
+    const candidates = await db.visit.findMany({
+        where: { departedAt: null, deletedAt: null, person: { ...LIVE_PERSON, isDeclaredAdult: false } },
+        select: { person: { select: { dateOfBirth: true } } },
+    });
+    return candidates.some(v => isYouth(v.person.dateOfBirth, { unknownIs: "youth" }));
+}
+
+/**
  * How many supervising adults the room has: distinct households, so a couple
  * counts once. Pass `excludeVisitId` to ask the same question as if that visit
  * had already ended — what the departure interrupt compares against.

--- a/checkin-app/src/lib/supervision.ts
+++ b/checkin-app/src/lib/supervision.ts
@@ -1,0 +1,135 @@
+import type { Prisma } from "@/generated/prisma/client";
+import prisma from "@/lib/prisma";
+import type { DbClient } from "@/lib/db-client";
+import { LIVE_PERSON } from "@/lib/person/filters";
+import { personRecordIsActiveOrgMember } from "@/lib/orgMembership";
+import { bgValidUntilBoundary } from "@/lib/membership/renewal";
+import { isYouth, orgCalendarDay } from "@/lib/time";
+
+/**
+ * SUPERVISING ADULT — the single test behind both the departure interrupt
+ * (#1436) and the two-deep compliance banner (#1550). Policy's "two deep" is two
+ * *unrelated cleared volunteers*, not two bodies over 18, so counting bare adults
+ * reports a room compliant when it is not (Definitions Policy, Art. III).
+ *
+ * A supervising adult is:
+ *   - an adult (declared, or 18+ by date of birth; unknown age fails closed as
+ *     youth, #300),
+ *   - with a still-valid background clearance — the household's org membership is
+ *     ACTIVE (ACTIVE is what encodes "background check cleared", see
+ *     lib/orgMembership) AND their own `lastBackgroundCheck` has not expired under
+ *     the board's recheck policy,
+ *   - who holds no ACTIVE participant seat on a program that is in session now.
+ *     A transition-year 18+ participant with a clearance is being supervised, not
+ *     supervising; the same person counts later as a volunteer on another program.
+ *
+ * Two people from one household count as ONE, so the unit of counting is the
+ * household, not the person.
+ *
+ * NOT part of the test: the volunteer-family fee flag, and school enrollment —
+ * "student" here means program participant. Capturing school enrollment is #1442.
+ */
+
+/** Policy's two-deep floor. Below this the room is short of supervision. */
+export const MIN_SUPERVISING_ADULTS = 2;
+
+/**
+ * A program is in session now: one of its events brackets this instant, or the
+ * program's own dates cover today. An open-ended RUNNING program counts from its
+ * start — an unset end date must not read as "not in session".
+ */
+function programInSessionNow(now: Date, today: Date): Prisma.ProgramWhereInput {
+    return {
+        OR: [
+            { events: { some: { startAt: { lte: now }, endAt: { gte: now } } } },
+            { startAt: { lte: today }, endAt: { gte: today } },
+            { startAt: { lte: today }, endAt: null, phase: "RUNNING" },
+        ],
+    };
+}
+
+/**
+ * Is this person's background clearance still valid today? Reuses the renewal
+ * rule ({@link bgValidUntilBoundary}), which returns null when the board has set
+ * no recheck policy — that means "never expires", not "expired". No check on file
+ * is never valid: missing data fails closed, same as an unknown date of birth.
+ */
+function clearanceIsValid(
+    lastBackgroundCheck: Date | null,
+    settings: { orgMembershipYearBoundary: Date | null; bgRecheckMonths: number },
+    today: Date,
+): boolean {
+    if (!lastBackgroundCheck) return false;
+    const validUntil = bgValidUntilBoundary(lastBackgroundCheck, settings);
+    return validUntil === null || validUntil.getTime() >= today.getTime();
+}
+
+/**
+ * Every supervising adult currently in the building, as `visitId -> householdId`.
+ *
+ * Returning the mapping rather than a bare number is what lets the departure
+ * interrupt ask both questions from ONE query: how many supervising adults are
+ * here, and how many would remain if this visit ended. The household rule then
+ * falls out for free — a second adult from the same household leaving does not
+ * drop the count, because the household is still represented.
+ */
+export async function supervisingAdultVisits(
+    db: DbClient = prisma,
+    now: Date = new Date(),
+): Promise<Map<number, number>> {
+    const today = orgCalendarDay(now);
+    const settings = (await db.boardSettings.findUnique({
+        where: { id: 1 },
+        select: { orgMembershipYearBoundary: true, bgRecheckMonths: true },
+    })) ?? { orgMembershipYearBoundary: null, bgRecheckMonths: 0 };
+
+    const openVisits = await db.visit.findMany({
+        where: { departedAt: null, deletedAt: null, person: LIVE_PERSON },
+        select: {
+            id: true,
+            person: {
+                select: {
+                    householdId: true,
+                    dateOfBirth: true,
+                    isDeclaredAdult: true,
+                    lastBackgroundCheck: true,
+                    household: { select: { orgMembership: { select: { status: true } } } },
+                    // Seat on a program in session now — one row is enough to exclude.
+                    programParticipants: {
+                        where: { status: "ACTIVE", program: programInSessionNow(now, today) },
+                        select: { programId: true },
+                        take: 1,
+                    },
+                },
+            },
+        },
+    });
+
+    const supervising = new Map<number, number>();
+    for (const visit of openVisits) {
+        const p = visit.person;
+        const isAdult = p.isDeclaredAdult || !isYouth(p.dateOfBirth, { unknownIs: "youth" });
+        if (!isAdult) continue;
+        if (!personRecordIsActiveOrgMember(p)) continue;
+        if (!clearanceIsValid(p.lastBackgroundCheck, settings, today)) continue;
+        if (p.programParticipants.length > 0) continue;
+        supervising.set(visit.id, p.householdId);
+    }
+    return supervising;
+}
+
+/**
+ * How many supervising adults the room has: distinct households, so a couple
+ * counts once. Pass `excludeVisitId` to ask the same question as if that visit
+ * had already ended — what the departure interrupt compares against.
+ */
+export function supervisingAdultCount(
+    supervising: Map<number, number>,
+    excludeVisitId?: number,
+): number {
+    const households = new Set<number>();
+    for (const [visitId, householdId] of supervising) {
+        if (visitId !== excludeVisitId) households.add(householdId);
+    }
+    return households.size;
+}

--- a/checkin-app/src/security/generated/classifications.ts
+++ b/checkin-app/src/security/generated/classifications.ts
@@ -276,6 +276,7 @@ export const classifications = {
         deletedAt: 'internal',
         deletedById: 'internal',
         forceCloseWarnedAt: 'internal',
+        supervisionWarnedAt: 'internal',
     },
     AuditLog: {
         id: 'internal',

--- a/client/client.py
+++ b/client/client.py
@@ -556,7 +556,12 @@ def handle_scan(backend, state, participant_id):
         email = html.escape(str(body.get("participant", {}).get("email", "?")))
         msg = html.escape(body.get("message", ""))
         label = "CHECKED IN" if stype == "checkin" else "CHECKED OUT"
-        if msg and msg != "Checked in successfully" and msg != "Checked out successfully":
+        warning = html.escape(body.get("warning", "")).replace("\n", "<br>")
+        if warning:
+            # Scan succeeded but the room is short of supervising adults (#1436):
+            # amber, and it dwells 12s instead of 5s. Still confirms the scan.
+            banner_html = f'<div class="banner banner-warning">✓ {email} — {label}<br>⚠️ {warning}</div>'
+        elif msg and msg != "Checked in successfully" and msg != "Checked out successfully":
             banner_html = f'<div class="banner banner-ok">✓ {email} — {msg}</div>'
         else:
             banner_html = f'<div class="banner banner-ok">✓ {email} — {label}</div>'

--- a/client/test_client.py
+++ b/client/test_client.py
@@ -2,7 +2,69 @@ import inspect
 import json
 import os
 import unittest
-from client import BackendClient, DEFAULT_KIOSK_PATH, main
+from client import BackendClient, DEFAULT_KIOSK_PATH, handle_scan, main
+
+
+class FakeBackend:
+    attendance_path = ""
+
+    def __init__(self, body, status=200):
+        self._reply = (body, status)
+
+    def post_scan(self, participant_id):
+        return self._reply
+
+
+class FakeState:
+    def __init__(self):
+        self.events = []
+
+    def push_event(self, event):
+        self.events.append(event)
+
+
+def scan_banner(body, status=200):
+    state = FakeState()
+    handle_scan(FakeBackend(body, status), state, 1)
+    return state.events[0]["html"]
+
+
+class TestSupervisionWarningBanner(unittest.TestCase):
+    """A scan that succeeds but leaves the room short of supervising adults
+    (checkin#1436) still confirms the scan — in amber, which dwells longer."""
+
+    def test_warning_renders_amber_and_still_confirms_the_scan(self):
+        html_out = scan_banner({
+            "type": "checkout",
+            "message": "Checked out successfully",
+            "warning": "Warning: only 2 supervising adults remain in the building.",
+            "participant": {"email": "a@example.com"},
+        })
+
+        self.assertIn("banner-warning", html_out)
+        self.assertIn("CHECKED OUT", html_out)
+        self.assertIn("only 2 supervising adults remain", html_out)
+
+    def test_warning_is_escaped_like_every_other_backend_value(self):
+        html_out = scan_banner({
+            "type": "checkin",
+            "warning": "<img src=x onerror=alert(1)>",
+            "participant": {"email": "a@example.com"},
+        })
+
+        self.assertNotIn("<img", html_out)
+        self.assertIn("&lt;img", html_out)
+
+    def test_no_warning_leaves_the_ordinary_green_banner(self):
+        html_out = scan_banner({
+            "type": "checkin",
+            "message": "Checked in successfully",
+            "participant": {"email": "a@example.com"},
+        })
+
+        self.assertIn("banner-ok", html_out)
+        self.assertNotIn("banner-warning", html_out)
+
 
 class TestBackendClient(unittest.TestCase):
     def test_required_methods_exist(self):

--- a/docs/rules/attendance-checkin.md
+++ b/docs/rules/attendance-checkin.md
@@ -79,23 +79,40 @@ Things the app takes as true because they are handled outside it.
 
 ### Supervision
 
-- The two-deep check counts adults present, and only where a youth is there
-  without an adult from their own household. It does not require the two to be
-  volunteers, to be non-students, or to be unrelated to one another, so a room
-  reads compliant while none of those holds.  [Short of policy — *Policy: Definitions Policy, Art. III, "Two Deep"*]
+- The two-deep check counts supervising adults, not adults present. A supervising
+  adult is an adult whose background clearance is still valid and who is not
+  themselves a participant on a program running at that moment. Two people of one
+  household count as one, so a couple is not two deep.  [Decision — *Policy: Definitions Policy, Art. III, "Two Deep"*]
+
+- Being a participant on a program in session is what disqualifies someone from
+  supervising it, not being at school: a member of eighteen or nineteen enrolled
+  in a program does not count while that program runs, and counts again as a
+  volunteer on another. School enrollment is not recorded at all, so the part of
+  policy that turns on it cannot be tested here.  [Short of policy — *Policy: Definitions Policy, Art. III, "Two Deep"*]
+
+- A clearance that is not recorded is not a clearance: someone with no background
+  check on file, or one older than the board's recheck interval, is not one of the
+  supervising adults.  [Decision — *Principle: fail closed*]
 
 - Someone whose age is unknown counts as a youth in the supervision check: not
   one of the supervising adults, and one of the people needing cover.  [Decision — *Principle: fail closed*]
 
 - Two deep is shown as a warning. It does not stop anyone entering or checking
   in — surfacing the shortfall to the people in the room is the whole of what the
-  app does about it.  [Decision — deliberate limit]
+  app does about it. A youth arriving into a room short of supervision is warned
+  about, never turned away: whether to open the door is the keyholder's call.  [Decision — deliberate limit]
 
 - Keyholders reach every household's emergency contacts, not only those of the
   people currently in the building.  [Decision]
 
-- Departure is interrupted on the keyholder count, not the adult-to-youth
-  composition: the last keyholder is stopped to confirm, any other adult is not.  [Decision — deliberate limit]
+- Every departure that takes a supervising adult out of the building is
+  interrupted, whoever is leaving. Dropping to two is a warning and nothing more;
+  dropping below two stops the departure until the person badges again within
+  fifteen seconds. The keyholder close-guard is a separate interrupt and both can
+  be waiting on one person at once.  [Decision — *Policy: Event, Location and Keyholder Policy, §VIII.4*]
+
+- The interrupt is on the badge scanner. Checking someone out from the web does
+  not raise it.  [Decision — deliberate limit]
 
 ### The kiosk
 

--- a/docs/rules/attendance-checkin.md
+++ b/docs/rules/attendance-checkin.md
@@ -106,10 +106,14 @@ Things the app takes as true because they are handled outside it.
   people currently in the building.  [Decision]
 
 - Every departure that takes a supervising adult out of the building is
-  interrupted, whoever is leaving. Dropping to two is a warning and nothing more;
-  dropping below two stops the departure until the person badges again within
-  fifteen seconds. The keyholder close-guard is a separate interrupt and both can
-  be waiting on one person at once.  [Decision — *Policy: Event, Location and Keyholder Policy, §VIII.4*]
+  interrupted, whoever is leaving. Dropping to two is a warning and nothing more.
+  Dropping below two stops the departure until the person badges again within
+  fifteen seconds — but only while a youth is in the building. With no youth
+  there, that departure is warned about and goes through: two deep is owed
+  whenever a youth is present, so an adult-only room locking up has nothing to
+  confirm, and an interrupt raised where nothing is at stake teaches people to
+  badge through the one that matters. The keyholder close-guard is a separate
+  interrupt and both can be waiting on one person at once.  [Decision — *Policy: Event, Location and Keyholder Policy, §VIII.4*]
 
 - The interrupt is on the badge scanner. Checking someone out from the web does
   not raise it.  [Decision — deliberate limit]


### PR DESCRIPTION
Fixes #1436
Fixes #1550

Both issues were decided together in their v1.2 rulings and share **one helper**, so they ship as one PR.

## The rulings implemented

From #1436's v1.2 decisions (and the earlier policy answers on the same issue):

> - 3rd qualifying adult badges out → warning only (two remain). No confirm.
> - Next qualifying adult badges out → warning + confirm (15s countdown; same explicit confirm as #1347).
> - Same household counts as one adult.
> - Fires on every departure. Keyholder close-guard stays separate.
> - Youth check-in while below two: warning only, not blocked.

> Who counts as a supervising adult:
> - Adult with a **still-valid background clearance**.
> - **Not** a current `ProgramParticipant` on any program that is in session now (event overlapping now, or program dates covering now). Transition-year 18+ participants with a clearance do not count while they hold that seat; the same person can count later as a volunteer on a different program.
> - Not the volunteer-family fee flag.

And the follow-up ruling on this PR's open question (2026-08-19):

> **YES — the confirm rung is youth-gated.** With no youth present, that departure downgrades to the warning-only shape. The warn rung itself stays un-gated.

From #1550's v1.2 decisions:

> The banner uses the same supervising-adult test as the close interrupt … Not in this release: school-enrollment (#1442). "Student" here means program participant, not school youth.

## The shared helper

`checkin-app/src/lib/supervision.ts` is the single expression of the test. It answers **who is supervising the room right now**, and both surfaces consume it.

```ts
supervisingAdultVisits(db?, now?): Promise<Map<number /*visitId*/, number /*householdId*/>>
supervisingAdultCount(supervising, excludeVisitId?): number
youthIsPresent(db?): Promise<boolean>
MIN_SUPERVISING_ADULTS = 2
```

A person qualifies when all of these hold:

| Prong | How it is tested | Why that check |
|---|---|---|
| adult | `isDeclaredAdult`, else `isYouth(dob, { unknownIs: 'youth' })` | matches the existing fail-closed rule (#300) and the DoB-stripped 26+ case (#1165) |
| still-valid clearance | household `OrgMembership.status === 'ACTIVE'` **and** `bgValidUntilBoundary(lastBackgroundCheck, boardSettings) >= today` | `ACTIVE` is what encodes "background check cleared" (`lib/orgMembership`); the expiry half reuses the renewal rule rather than inventing a second one. No check on file is never valid — same fail-closed posture as unknown age. With `bgRecheckMonths` unset (the default) clearance has no expiry, so this does not silently empty the room. |
| no participant seat in session | `programParticipants` where `status: ACTIVE` and the program has an event bracketing now, **or** its own dates cover today, **or** it is open-ended and `RUNNING` | the ruling's two arms, plus two fail-safe arms: `lte` never matches null, so neither an unset `endAt` nor an unset `startAt` may read as "not in session" — a RUNNING programme missing either date would otherwise fail OPEN and let its participants count as supervisors |
| household | the map is keyed visit→household and counted as **distinct households** | "same household counts as ONE" |

Deliberately **not** in the test: `OrgMembership.isVolunteer` (the volunteer-family fee flag) and school enrollment.

Returning the visit→household map rather than a bare number is what lets the interrupt answer both of its questions from **one** query — "how many are here" and "how many would remain" — and it makes the household rule fall out for free.

**Where each surface consumes it**

- `lib/getFullAttendance.ts` — `isTwoDeepViolation` now reads `supervisingAdultCount(...) < MIN_SUPERVISING_ADULTS` instead of `adultVisits.length < 2`. That one flag feeds **both** banners (`/attendance/current` and the home page) and the `TWO_DEEP_VIOLATION` board notification, so #1550 is fixed at the single site that computes it. The supervision queries are awaited only when a youth is unaccompanied — the only case the flag can be true — so an adult-only room costs the attendance poll no extra queries, the same gate `processCheckin` uses. The "is this youth accompanied by an adult of their own household" prong is unchanged — different question, not in scope.
- `lib/scan-service.ts` — `processCheckout` runs the ladder on every departure; `processCheckin` warns a youth arriving below two.

## The interrupt ladder

`supervisionInterrupt()` in `scan-service.ts`. There is **no counter and no session state** — the rung is derived from the count itself:

```
before    = supervisingAdultCount(supervising)
remaining = supervisingAdultCount(supervising, activeVisitId)
```

- `remaining >= before` → this departure removes no supervising adult (a youth leaving, a non-qualifying adult leaving, or **the second adult of a household that stays represented**). Silent.
- `remaining > 2` → silent.
- `remaining === 2` → warning only. The checkout **completes**; the text rides the success response's new `warning` field.
- `remaining < 2` **and a youth has an open visit** → warning **and** confirm. 400 with `type: "warning"`, and `Visit.supervisionWarnedAt` is stamped. Only a scan following a fresh stamp inside 15s goes through.
- `remaining < 2` with **no youth in the building** → warning only, same shape as the rung above: the checkout completes, nothing is stamped, no second badge is asked for.

**The youth gate** (ruling of 2026-08-19) is on the confirm rung *only*. Two deep is owed whenever a youth is present, so an adult-only room locking up — the ordinary evening — has nothing to confirm, and a 400 raised where nothing is at stake is the fastest way to train badge-through on the night it matters. The warn rung stays un-gated: over-warning there is deliberate and costs a line of text.

`youthIsPresent()` is the adult prong inverted over the same open-visit population (`departedAt: null, deletedAt: null`, live person): not `isDeclaredAdult`, and not 18+ by DoB — unknown age fails closed as youth (#300), the same classification `processCheckin` uses for its arrival warning. Only the `isDeclaredAdult` half is a query filter; the age half stays with `isYouth` so the rule keeps one expression. The probe runs **inside the `remaining < 2` branch only**, so every quieter departure — including the whole warn rung — pays nothing for it.

This is why "3rd adult" needs no tracking: the third qualifying adult leaving is exactly the departure whose `remaining` lands on 2, and the next one is exactly the departure whose `remaining` falls below it. The household rule is enforced by the same arithmetic rather than by a second code path.

`supervisionWarnedAt` is its own column, not a reuse of `forceCloseWarnedAt`: the keyholder close-guard is a separate interrupt and both can be pending on one visit. The ladder is skipped entirely when the keyholder guard is force-closing, since that sweep departs everyone. Migration is additive and nullable (`20260818120000_visit_supervision_warned_at`).

## #1347 convergence

**PR #1669 now owns the explicit-confirm interface.** This body previously said `feat/1347-explicit-confirm` "is empty" — true when this branch was cut, false since #1669 opened. What #1669 ships:

- `Visit.forceCloseToken`, minted per warning and consumed by the confirming scan,
- `confirmSeconds` in the 400 body, so the window is server-owned but client-rendered,
- the client countdown as `AttendanceState.arm_confirm` / `take_confirm`.

**On rebase after #1669 lands**, this PR's supervision confirm converges on that token shape — the cross-review's **S2**:

- mint a supervision token per warning, in place of the `supervisionWarnedAt` timestamp stamp,
- return `confirmSeconds` in the 400 body and let #1669's countdown render the tick, dropping the "3 to 15 seconds" copy,
- **drop the server-side 15s elapsed window** (`SUPERVISION_CONFIRM_MS`). It is the mechanism #1669 deleted for force-close, and for the same reason: an elapsed-time window can be satisfied by two queued replays arriving inside it, where a minted-and-consumed token cannot,
- **acceptance criteria from review (2026-08-19):** the debounce exemption keys on the supervision token so the confirm window truly opens at 0s (Q16 front door); convergence tests drive `POST /api/scan` end-to-end (not direct `processCheckout` calls), pinning that a second badge inside 3s confirms; `confirmSeconds` + token ride the 400 body so the kiosk countdown ticks,
- add a test that a supervision token cannot force-close and a force-close token cannot confirm a supervision departure — two interrupts can be pending on one visit, so the tokens must not be interchangeable.

## Kiosk client

The warning-only rung needs a way to say "the scan succeeded *and* the room is short". `client/client.py` gained three lines: a 2xx body carrying `warning` renders the amber `banner-warning` (12s dwell) with the CHECKED IN/OUT confirmation inside it, rather than the 5s green one. Escaped like every other backend value.

## Tests

Unit (`npx jest`, 282 suites / 2810 tests green locally):

- `src/lib/__tests__/supervision.test.ts` — the helper's edge cases: same-household counts once, participant-seat exclusion, clearance validity (none on file, expired under the recheck policy, inside the window), non-ACTIVE household, youth, unknown age vs. DoB-stripped declared adult, and the program-in-session probe's four arms.
- `src/lib/__tests__/scanServiceSupervisionInterrupt.test.ts` — the ladder end to end through the **real** helper: both rungs, the confirm window opening/expiring, "NO supervising adult" copy, the same-household non-event, a departure that removes nobody, and the youth check-in warning (plus a check that an adult check-in costs no extra query). The youth gate adds three: below two **with** no youth completes with the warning and no stamp, the last adult leaving an adult-only room still warns, and the warn-only rung never runs the youth probe.
- `src/lib/__tests__/getFullAttendance.test.ts` — retargeted at its own half (accompaniment) now that the count moved out, plus the short-circuit — no unaccompanied youth, no supervision queries.
- `client/test_client.py` — the amber warning banner, its escaping, and that an ordinary scan is untouched. `python3 -m unittest discover` green.

Integration (CI-only, no local Postgres — **not run locally**):

- `src/lib/__tests__/supervision.integration.test.ts` — the query itself against real Postgres (nested membership filter, both in-session arms), the banner for all three ways two adults fail to be two deep, and the full ladder including the stamp/second-badge round trip and its youth-free twin (same departure, no youth → warned and through, nothing stamped).

## Register

`docs/rules/attendance-checkin.md` §Supervision is rewritten: the two-deep line now states who counts, the keyholder-only interrupt is no longer a deliberate limit, the departure rule states the youth gate on the confirm (and why the warn rung keeps over-warning), and what still cannot be tested (school enrollment) is stated **at the rule** as `[Short of policy]` per §3.7.

## Out of scope

- **#1442 — school enrollment.** "Student" here is a program participant. The school-enrollment half of policy's not-a-student test is recorded as a shortfall at the rule, not built.
- **#1624.**
- **The web checkout path.** thpr's register-handover comment flagged the A10 inversion (DELETE checkout closes the last keyholder with no confirmation), but the governing v1.2 ruling scopes this to the badge interrupt — "fires on every departure" answers *which person*, not *which code path*. Stated as a deliberate limit in the register; worth its own issue.
- **`docs/DOCUMENTATION_STANDARD.md` §3.7** still uses "a supervision check counting bare adults" as its worked example of a divergence. It teaches the *shape*, so it is left alone rather than rewritten inside a feature PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



