### PR TITLE
feat(programs): show capacity next to enrolled counts (3/6)

### DIFF
--- a/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/__tests__/page.test.tsx
@@ -97,6 +97,14 @@ describe("ProgramDetailsPage", () => {
     expect(screen.getByText("Mandy Mentor (mandy@example.com)")).toBeInTheDocument();
   });
 
+  it("renders a zero max participants as a real cap, not as uncapped", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    mockFetchJson({ "/api/programs/1": { ...programData, maxParticipants: 0 } });
+    renderPage();
+
+    expect(await screen.findByText("2 / 0")).toBeInTheDocument();
+  });
+
   it("switches to the roster tab and shows volunteers/participants", async () => {
     setSession({ id: 1, isSysadmin: true });
     mockFetchJson({ "/api/programs/1": programData });

--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -298,7 +298,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
 
                 <Card withBorder radius="md" padding="md">
                   <Group justify="space-around">
-                    <Stack gap={0} align="center"><Text fz="xl" fw={700}>{program.participants?.length || 0} {program.maxParticipants ? `/ ${program.maxParticipants}` : ''}</Text><Text size="sm" c="dimmed">Participants Enrolled</Text></Stack>
+                    <Stack gap={0} align="center"><Text fz="xl" fw={700}>{program.participants?.length || 0} {program.maxParticipants != null ? `/ ${program.maxParticipants}` : ''}</Text><Text size="sm" c="dimmed">Participants Enrolled</Text></Stack>
                     <Divider orientation="vertical" />
                     <Stack gap={0} align="center"><Text fz="xl" fw={700}>{program.volunteers?.length || 0}</Text><Text size="sm" c="dimmed">Assigned Volunteers</Text></Stack>
                     <Divider orientation="vertical" />

--- a/checkin-app/src/app/program-ops/programs/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/programs/__tests__/page.test.tsx
@@ -43,6 +43,24 @@ describe("AdminProgramsIndex", () => {
     expect(screen.getByText("Robotics Club")).toBeInTheDocument();
   });
 
+  // [maxParticipants, enrolled, rendered]
+  const capacityCases: [number | null, number, string][] = [
+    [null, 3, "3"],   // uncapped: no slash
+    [0, 3, "3/0"],    // a 0 cap is a real cap, not "uncapped"
+    [6, 3, "3/6"],
+    [6, 6, "6/6"],
+    [6, 7, "7/6"],    // over capacity renders as-is, unclamped
+  ];
+
+  it.each(capacityCases)("shows capacity in Participants: max %p with %i enrolled renders %s", async (maxParticipants, participants, expected) => {
+    mockFetchJson({
+      "/api/programs": [{ ...programs[0], maxParticipants, _count: { participants, events: 2 } }],
+    });
+    renderWithProviders(<AdminProgramsIndex />);
+    await screen.findByText("Robotics Club");
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
   it("navigates to the create-program page", async () => {
     mockFetchJson({ "/api/programs": programs });
     renderWithProviders(<AdminProgramsIndex />);

--- a/checkin-app/src/app/program-ops/programs/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/page.tsx
@@ -19,6 +19,7 @@ type Program = {
   orgMemberPriceCents?: number | null;
   nonOrgMemberPriceCents?: number | null;
   shopifyVariantId?: string | null;
+  maxParticipants?: number | null;
   _count?: { participants?: number; events?: number };
 };
 
@@ -115,7 +116,7 @@ export default function AdminProgramsIndex() {
     {
       header: "Participants",
       align: "right",
-      render: (p) => p._count?.participants ?? 0,
+      render: (p) => `${p._count?.participants ?? 0}${p.maxParticipants != null ? `/${p.maxParticipants}` : ""}`,
       sortBy: (p) => p._count?.participants ?? 0,
     },
     {

--- a/checkin-app/src/app/programs/__tests__/page.test.tsx
+++ b/checkin-app/src/app/programs/__tests__/page.test.tsx
@@ -13,7 +13,7 @@ const programs = [
   {
     id: 1, name: "Robotics Club", startAt: "2026-01-10T00:00:00.000Z", endAt: "2026-05-10T00:00:00.000Z",
     orgMemberOnly: false, phase: "RUNNING", enrollmentStatus: "OPEN", leadMentorId: 1,
-    _count: { participants: 4, volunteers: 1, events: 2 },
+    maxParticipants: null, _count: { participants: 4, volunteers: 1, events: 2 },
   },
 ];
 
@@ -61,12 +61,33 @@ describe("slow-load wait message", () => {
   });
 });
 
+describe("capacity in the Enrolled stat", () => {
+  // [maxParticipants, enrolled, rendered]
+  const cases: [number | null, number, string][] = [
+    [null, 3, "3"],   // uncapped: no slash
+    [0, 3, "3/0"],    // a 0 cap is a real cap, not "uncapped"
+    [6, 3, "3/6"],
+    [6, 6, "6/6"],
+    [6, 7, "7/6"],    // over capacity renders as-is, unclamped
+  ];
+
+  it.each(cases)("maxParticipants %p with %i enrolled renders %s", async (maxParticipants, participants, expected) => {
+    mockFetchJson({
+      "/api/programs?active=true": [
+        { ...programs[0], maxParticipants, _count: { participants, volunteers: 1, events: 2 } },
+      ],
+    });
+    renderWithProviders(<PublicProgramsDirectory />);
+    expect(await screen.findByText(expected)).toBeInTheDocument();
+  });
+});
+
 describe("counts omitted (system waking)", () => {
   it("renders program cards without the enrollment figures block when _count is absent", async () => {
     setSession(null);
     mockFetchJson({
       "/api/programs?": [
-        { id: 1, name: "Robotics", description: "Bots", phase: "ACTIVE", enrollmentStatus: "OPEN", startAt: "2026-08-01T00:00:00Z", endAt: null },
+        { id: 1, name: "Robotics", description: "Bots", phase: "ACTIVE", enrollmentStatus: "OPEN", startAt: "2026-08-01T00:00:00Z", endAt: null, maxParticipants: 6 },
       ],
     });
     renderWithProviders(<PublicProgramsDirectory />);

--- a/checkin-app/src/app/programs/page.tsx
+++ b/checkin-app/src/app/programs/page.tsx
@@ -18,6 +18,7 @@ type ProgramSummary = {
   phase: string;
   enrollmentStatus: string;
   leadMentorId: number | null;
+  maxParticipants: number | null;
   _count?: {
     participants: number;
     volunteers: number;
@@ -137,7 +138,7 @@ export default function PublicProgramsDirectory() {
                   <Card withBorder radius="sm" padding="xs" mb="md">
                     <Group justify="space-around">
                       <Stack gap={0} align="center">
-                        <Text fw={700}>{program._count.participants}</Text>
+                        <Text fw={700}>{program._count.participants}{program.maxParticipants != null && `/${program.maxParticipants}`}</Text>
                         <Text size="xs" c="dimmed">Enrolled</Text>
                       </Stack>
                       <Divider orientation="vertical" />


### PR DESCRIPTION
Both program **list** views showed a bare enrolled count, while both program **detail** pages already showed capacity. `/api/programs` already returns `maxParticipants` (it's in `PUBLIC_PROGRAM_SELECT`), so this is render-only — no schema, no migration, no API change, no new files, nothing under `src/security/`.

Fixes #1673

## Surfaces

| # | Surface | Before | After |
|---|---------|--------|-------|
| 1 | Public program detail (`programs/[id]`) | already `Capacity: 3/6` + `(Full)` | unchanged (reference implementation) |
| 2 | Program-ops program detail, General tab | already `3 / 6`, but a `0` cap rendered as uncapped | `3 / 0` — truthy test → `!= null` (spacing unchanged) |
| 3 | Public programs directory card, "Enrolled" | bare `3` | `3/6` |
| 4 | Program-ops programs list, "Participants" column | bare `3` | `3/6` (keeps the `?? 0` fallback; `sortBy` still the raw count, so the column sorts numerically) |
| 5 | My Programs → Attendance | `Total Enrolled: 3` | **deliberately unchanged** — see below |

Uncapped programs (`maxParticipants: null`) still render the bare count with no slash.

## Numerator semantics

`_count.participants` on `/api/programs` counts **all** `ProgramParticipant` rows — same rule the capacity enforcer uses (`lockProgramAndCheckCapacity`, where a PENDING/scholarship-held seat consumes capacity). So on surfaces 1–4 the numerator and denominator agree with what the enroller will actually accept.

Surface 5 is different and is left alone (plan open question 1): its number comes from `/api/nav/todo-counts`, which counts `status: "ACTIVE"` only. Printing that as `3/6` would understate fullness and imply seats the enforcer would refuse. The honest fix there is a separate all-status count on `LedProgram`, not repurposing the ACTIVE one.

Also per the plan's recommended defaults: no "Full" marker on the list views (open question 2 — `6/6` already says it, and the ops list has its own Open/Closed badge), and `PATCH /api/programs/[id]` capacity validation stays with #477 (open question 3).

## Tests

Extended the three existing suites (no new files):

- `programs/__tests__/page.test.tsx` and `program-ops/programs/__tests__/page.test.tsx` — table-driven over `null → 3` (no slash), `0 → 3/0`, `6 → 3/6`, at capacity `6/6`, over capacity `7/6` (rendered as-is, unclamped).
- `program-ops/programs/[id]/__tests__/page.test.tsx` — `maxParticipants: 0` renders `2 / 0` rather than reading as uncapped.
- The public suite's existing "counts omitted (system waking)" case now carries a `maxParticipants`, so it also proves capacity alone doesn't resurrect the stat block when `_count` is absent.

Each falsy-zero test was verified to **fail** against the unfixed code by reverting the guard in place:

```
programs/__tests__/page.test.tsx                    FAIL  Unable to find an element with the text: 3/0
program-ops/programs/__tests__/page.test.tsx        FAIL  Unable to find an element with the text: 3/0
program-ops/programs/[id]/__tests__/page.test.tsx   FAIL  renders a zero max participants as a real cap, not as uncapped
```

## Local verification

```
npx tsc --noEmit                              exit 0, no output
npx eslint --max-warnings 0 <6 touched files> exit 0, no output
npx jest --testPathPatterns 'src/app/(programs|program-ops/programs)'
  Test Suites: 5 passed, 5 total
  Tests:       91 passed, 91 total
```

No integration/flow tests needed — no route or DB behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URSrfChi89qKn1hLbjaX3K
