### PR TITLE
fix(programs): hide empty parens when lead-mentor email is PII-stripped

### DIFF
--- a/checkin-app/src/app/program-ops/programs/[id]/page.tsx
+++ b/checkin-app/src/app/program-ops/programs/[id]/page.tsx
@@ -56,6 +56,11 @@ const PHASE_BADGE: Record<string, { label: string; color: string }> = {
   FINISHED: { label: 'Finished', color: 'teal' },
 };
 
+function mentorLabel(name: string | null, email: string): string {
+  const label = name || 'Unnamed';
+  return email ? `${label} (${email})` : label;
+}
+
 export default function ProgramDetailsPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const { user: sessionUser, loading: authLoading, ready } = useRequireRole([]);
@@ -111,7 +116,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
         setLeadMentorIdInput(data.leadMentorId !== null ? String(data.leadMentorId) : "");
         setMemberPrice(data.orgMemberPriceCents !== null ? String(data.orgMemberPriceCents / 100) : "");
         setNonMemberPrice(data.nonOrgMemberPriceCents !== null ? String(data.nonOrgMemberPriceCents / 100) : "");
-        setMentorSearch(data.leadMentor ? `${data.leadMentor.name || 'Unnamed'} (${data.leadMentor.email})` : "");
+        setMentorSearch(data.leadMentor ? mentorLabel(data.leadMentor.name, data.leadMentor.email) : "");
         setShopifyProductIdInput(data.shopifyProductId ?? "");
         setVariantInput(data.shopifyVariantId ?? "");
         setIsEditingMentor(false);
@@ -352,7 +357,7 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                   {isSysAdminOrBoard ? (
                     program.leadMentor && !isEditingMentor ? (
                       <Group>
-                        <Text c="green">{program.leadMentor.name || 'Unnamed'} ({program.leadMentor.email})</Text>
+                        <Text c="green">{mentorLabel(program.leadMentor.name, program.leadMentor.email)}</Text>
                         <Button size="xs" fz={15} variant="default" type="button" onClick={() => { setIsEditingMentor(true); setMentorSearch(""); setLeadMentorIdInput(""); }}>Change</Button>
                       </Group>
                     ) : (
@@ -365,17 +370,17 @@ export default function ProgramDetailsPage({ params }: { params: Promise<{ id: s
                             search={searchAdults}
                             getOptionLabel={(p) => p.name || 'Unnamed'}
                             getOptionDescription={(p) => p.email}
-                            onSelect={(p) => { setLeadMentorIdInput(p.id.toString()); setMentorSearch(`${p.name || 'Unnamed'} (${p.email})`); }}
+                            onSelect={(p) => { setLeadMentorIdInput(p.id.toString()); setMentorSearch(mentorLabel(p.name, p.email)); }}
                             onClear={() => { setLeadMentorIdInput(""); setMentorSearch(""); }}
                           />
                         </Box>
                         {program.leadMentor && (
-                          <Button size="xs" fz={15} variant="subtle" color="red" type="button" onClick={() => { setIsEditingMentor(false); setLeadMentorIdInput(String(program.leadMentorId)); setMentorSearch(`${program.leadMentor?.name || 'Unnamed'} (${program.leadMentor?.email})`); }}>Cancel</Button>
+                          <Button size="xs" fz={15} variant="subtle" color="red" type="button" onClick={() => { setIsEditingMentor(false); setLeadMentorIdInput(String(program.leadMentorId)); setMentorSearch(program.leadMentor ? mentorLabel(program.leadMentor.name, program.leadMentor.email) : ''); }}>Cancel</Button>
                         )}
                       </Group>
                     )
                   ) : (
-                    program.leadMentor ? <Text c="green">{program.leadMentor.name || 'Unnamed'} ({program.leadMentor.email})</Text> : <Text c="dimmed">No Lead Mentor Assigned</Text>
+                    program.leadMentor ? <Text c="green">{mentorLabel(program.leadMentor.name, program.leadMentor.email)}</Text> : <Text c="dimmed">No Lead Mentor Assigned</Text>
                   )}
                   <Text size="xs" c={isSysAdminOrBoard ? 'yellow' : 'dimmed'} mt="xs">
                     {isSysAdminOrBoard ? '*You have permission to reassign this program.' : '*Only Administrators/Board Members can change the Lead Mentor.'}


### PR DESCRIPTION
Fixes #1223

## Summary

- Non-privileged callers see the sensitivity stripper blank `Person.email` to `""`, so the program management page rendered `Daniel Kay ()` instead of `Daniel Kay`.
- Extracted a `mentorLabel(name, email)` helper that omits the parenthesized email when the string is empty.
- Applied across all 5 interpolation sites in the program detail page (display, fetch hydration, picker select, cancel restore).

## Test plan

- [ ] View a program detail page as a non-admin user — lead mentor should show name only, no empty `()`
- [ ] View as sysadmin/board — lead mentor should show `Name (email@example.com)` as before
- [ ] Change lead mentor via picker, cancel, re-change — label stays correct throughout

---
_Posted by Claude._