### PR TITLE
fix(program-ops): redirect to program page after creating program events (#1222)

### DIFF
--- a/checkin-app/src/app/program-ops/sessions/new/__tests__/page.test.tsx
+++ b/checkin-app/src/app/program-ops/sessions/new/__tests__/page.test.tsx
@@ -4,7 +4,7 @@ jest.mock("next/navigation", () => require("@/test-helpers/rtl").navMock());
 jest.mock("next-auth/react", () => require("@/test-helpers/rtl").authMock());
 
 import { screen, fireEvent, waitFor } from "@testing-library/react";
-import { renderWithProviders, mockFetchJson, setSession, resetRtl, router } from "@/test-helpers/rtl";
+import { renderWithProviders, mockFetchJson, setSession, setSearchParams, resetRtl, router } from "@/test-helpers/rtl";
 import NewEventPage from "../page";
 
 beforeEach(() => resetRtl());
@@ -34,6 +34,30 @@ describe("NewEventPage", () => {
       ),
     );
     expect(router.push).toHaveBeenCalledWith("/program-ops/events");
+  });
+
+  it("redirects to the program page when programId is set", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    setSearchParams("programId=5");
+    const fetchMock = mockFetchJson({ "/api/programs": programs, "/api/events": { id: 100 } });
+    renderWithProviders(<NewEventPage />);
+
+    await screen.findByText("Schedule Event");
+
+    fireEvent.change(screen.getByLabelText("Event Name", { exact: false }), { target: { value: "Session 2" } });
+    fireEvent.change(screen.getByLabelText("Date", { exact: false }), { target: { value: "2026-03-01" } });
+    fireEvent.change(screen.getByLabelText("Start Time", { exact: false }), { target: { value: "10:00" } });
+    fireEvent.change(screen.getByLabelText("End Time", { exact: false }), { target: { value: "12:00" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Event(s)" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/events",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+    expect(router.push).toHaveBeenCalledWith("/program-ops/programs/5");
   });
 
   it("flags an end time before the start time", async () => {

--- a/checkin-app/src/app/program-ops/sessions/new/page.tsx
+++ b/checkin-app/src/app/program-ops/sessions/new/page.tsx
@@ -163,7 +163,7 @@ export function NewEventForm() {
 
       if (res.ok) {
         setSubmitted(true); // clear unsaved-changes guard before redirect
-        router.push('/program-ops/events');
+        router.push(programId ? `/program-ops/programs/${programId}` : '/program-ops/events');
       } else {
         const err = await res.json().catch(() => ({}));
         setMessage(err.error || "Failed to create event");


### PR DESCRIPTION
## Summary

- After creating event(s) for a program, redirect back to the program management page (`/program-ops/programs/{id}`) instead of the standalone events list
- Standalone (no program) event creation still redirects to `/program-ops/events`
- The cancel button already used this logic; the success path now matches

Fixes #1222

## Test plan

- [x] Existing test still passes (standalone event → `/program-ops/events`)
- [x] New test: programId in search params → redirects to `/program-ops/programs/5`
- [x] End-time validation test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)