### PR TITLE
fix(programs): raise leader age floor from 18 to 23

### DIFF
--- a/checkin-app/__tests__/programSignupIntegration.test.ts
+++ b/checkin-app/__tests__/programSignupIntegration.test.ts
@@ -98,6 +98,7 @@ describe('Full Program Signup Integration Flow', () => {
     it('should complete the full program signup flow', async () => {
         // 1. SysAdmin creates a program
         mockGetSession.mockResolvedValue({ user: { id: sysAdminId, isSysadmin: true } });
+        (prisma.person.findUnique as jest.Mock).mockResolvedValue({ dateOfBirth: null, isDeclaredAdult: true });
         (prisma.program.create as jest.Mock).mockResolvedValue({ id: programId, name: 'Integration Test Program' });
         (prisma.auditLog.create as jest.Mock).mockResolvedValue({});
 

--- a/checkin-app/src/app/__tests__/auditLog.integration.test.ts
+++ b/checkin-app/src/app/__tests__/auditLog.integration.test.ts
@@ -72,7 +72,7 @@ describe('AuditLog Integration Tests', () => {
 
         // Setup mock database records
         const admin = await prisma.person.create({
-            data: { email: 'admin-audit-test@example.com', name: 'Admin Test', isSysadmin: true, household: { create: { name: "Test HH" } } }
+            data: { email: 'admin-audit-test@example.com', name: 'Admin Test', isSysadmin: true, isDeclaredAdult: true, household: { create: { name: "Test HH" } } }
         });
         testAdminId = admin.id;
 

--- a/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoutes.integration.test.ts
@@ -33,6 +33,7 @@ describe('Sensitive route authorization', () => {
     let searchTargetId: number;
     let personaId: number;
     let adultId: number;
+    let youngAdultId: number;
     let minorId: number;
     let declaredAdultId: number;
     const householdIds: number[] = [];
@@ -83,6 +84,13 @@ describe('Sensitive route authorization', () => {
         adultId = adult.id;
         householdIds.push(adult.householdId);
 
+        // 20 years old — an adult (18+) but below the leader floor (23).
+        const youngAdult = await prisma.person.create({
+            data: { name: `ZZYoungAdult ${TAG}`, email: `youngadult-${TAG}@example.com`, dateOfBirth: yearsAgo(20), household: { create: { name: "Test HH" } } },
+        });
+        youngAdultId = youngAdult.id;
+        householdIds.push(youngAdult.householdId);
+
         const minor = await prisma.person.create({
             data: { name: `ZZMinor ${TAG}`, email: `minor-${TAG}@example.com`, dateOfBirth: yearsAgo(10), household: { create: { name: "Test HH" } } },
         });
@@ -105,7 +113,7 @@ describe('Sensitive route authorization', () => {
 
     afterAll(async () => {
         process.env.CHECKIN_ENV = ENV_BEFORE;
-        await prisma.person.deleteMany({ where: { id: { in: [plainId, searchTargetId, personaId, adultId, minorId, declaredAdultId] } } });
+        await prisma.person.deleteMany({ where: { id: { in: [plainId, searchTargetId, personaId, adultId, youngAdultId, minorId, declaredAdultId] } } });
         // The target's orgMembership row must go before its household (RESTRICT FK).
         await prisma.orgMembership.deleteMany({ where: { householdId: { in: householdIds } } });
         await prisma.household.deleteMany({ where: { id: { in: householdIds } } });
@@ -207,8 +215,8 @@ describe('Sensitive route authorization', () => {
         });
 
         // ?filter=adults backs both lead-mentor pickers (program-ops/new and
-        // program-ops/programs/[id]). The param used to be read nowhere, so a minor
-        // could be picked as a program lead mentor.
+        // program-ops/programs/[id]). The floor is 23 (Policy: Sponsored Program
+        // Policy, Art. IV), not 18.
         describe('?filter=adults', () => {
             const ids = async (u: string) => {
                 mockSession.mockResolvedValue({ user: { id: plainId, isBoardMember: true } });
@@ -217,11 +225,12 @@ describe('Sensitive route authorization', () => {
                 return (await res.json()).people.map((p: { id: number }) => p.id);
             };
 
-            it('returns adults (by DoB and by isDeclaredAdult) and excludes minors', async () => {
+            it('returns 23+ adults and isDeclaredAdult, excludes minors and young adults', async () => {
                 const got = await ids(`http://localhost/api/people/search?q=ZZ&filter=adults`);
                 expect(got).toContain(adultId);
                 expect(got).toContain(declaredAdultId);
                 expect(got).not.toContain(minorId);
+                expect(got).not.toContain(youngAdultId);
             });
 
             it('applies no age filter without the param, or with an unrecognized value', async () => {

--- a/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programPriceRoundTrip.integration.test.ts
@@ -51,7 +51,7 @@ describe('Program price round-trip (dollars -> cents) Integration Tests', () => 
         adminId = admin.id;
 
         const lead = await prisma.person.create({
-            data: { email: 'lead-price-roundtrip-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } },
+            data: { email: 'lead-price-roundtrip-test@example.com', name: 'Lead', isDeclaredAdult: true, household: { create: { name: "Test HH" } } },
         });
         leadId = lead.id;
     });

--- a/checkin-app/src/app/__tests__/programVariantRoundtripShopify.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programVariantRoundtripShopify.integration.test.ts
@@ -80,7 +80,7 @@ describe('Shopify variant round-trip: create -> persist -> webhook match', () =>
         });
         boardId = board.id;
         const lead = await prisma.person.create({
-            data: { email: `lead-${TAG}@example.com`, name: 'Lead', household: { create: { name: `Lead HH ${TAG}` } } },
+            data: { email: `lead-${TAG}@example.com`, name: 'Lead', isDeclaredAdult: true, household: { create: { name: `Lead HH ${TAG}` } } },
         });
         leadId = lead.id;
         const participant = await prisma.person.create({

--- a/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsAPI.integration.test.ts
@@ -53,7 +53,7 @@ describe('Programs API Integration Tests', () => {
 
         // Create Lead
         const lead = await prisma.person.create({
-            data: { email: 'lead-programs-api-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } }
+            data: { email: 'lead-programs-api-test@example.com', name: 'Lead', isDeclaredAdult: true, household: { create: { name: "Test HH" } } }
         });
         leadId = lead.id;
 

--- a/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsIdAPI.integration.test.ts
@@ -699,7 +699,7 @@ describe('Individual Program API Integration Tests', () => {
 
         beforeAll(async () => {
             const newLead = await prisma.person.create({
-                data: { email: 'newlead-prog-id-api-test@example.com', name: 'New Lead', household: { create: { name: "Test HH" } } }
+                data: { email: 'newlead-prog-id-api-test@example.com', name: 'New Lead', isDeclaredAdult: true, household: { create: { name: "Test HH" } } }
             });
             newLeadId = newLead.id;
 

--- a/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
+++ b/checkin-app/src/app/__tests__/programsSettingsAPI.integration.test.ts
@@ -62,13 +62,13 @@ describe('Program Settings API Integration Tests', () => {
 
         // Create Lead
         const lead = await prisma.person.create({
-            data: { email: 'lead-settings-api-test@example.com', name: 'Lead', household: { create: { name: "Test HH" } } }
+            data: { email: 'lead-settings-api-test@example.com', name: 'Lead', isDeclaredAdult: true, household: { create: { name: "Test HH" } } }
         });
         leadId = lead.id;
 
         // Create New Lead Candidate
         const newLead = await prisma.person.create({
-            data: { email: 'newlead-settings-api-test@example.com', name: 'New Lead', household: { create: { name: "Test HH" } } }
+            data: { email: 'newlead-settings-api-test@example.com', name: 'New Lead', isDeclaredAdult: true, household: { create: { name: "Test HH" } } }
         });
         newLeadId = newLead.id;
 

--- a/checkin-app/src/app/api/people/search/route.ts
+++ b/checkin-app/src/app/api/people/search/route.ts
@@ -6,6 +6,7 @@ import { ACTIVE_ORG_MEMBER_PERSON_WHERE, personRecordIsActiveOrgMember } from "@
 import { apiError } from "@/lib/api-response";
 import { rolesToFlags } from "@/lib/roles";
 import { LIVE_PERSON } from "@/lib/person/filters";
+import { leaderAgeCutoff } from "@/lib/programAge";
 import { badgeYearCycle, MAX_DATE } from "@/lib/membership/renewal";
 
 export const dynamic = 'force-dynamic';
@@ -79,11 +80,9 @@ export const GET = withAuth(
             // Only `adults` is recognized; any other value (or none) filters by age not at all.
             const adultsOnly = url.searchParams.get('filter') === 'adults';
 
-            // DB-level 18-year boundary for the adults filter below. Mirrors the
-            // under-18 threshold in isYouth (lib/time.ts); kept inline because this
-            // is a Prisma `where` predicate, not an in-memory classification.
-            const eighteenYearsAgo = new Date();
-            eighteenYearsAgo.setFullYear(eighteenYearsAgo.getFullYear() - 18);
+            // The only callers are the lead-mentor pickers, so "adults" means
+            // leader-eligible: 23+ by DOB, or isDeclaredAdult (marked 25+).
+            const ageCutoff = leaderAgeCutoff();
 
             const people = await prisma.person.findMany({
                 // Both clauses below are ORs, so they go in an AND array rather than as
@@ -99,14 +98,9 @@ export const GET = withAuth(
                                 { email: { contains: q, mode: 'insensitive' as const } },
                             ]
                         }] : []),
-                        // Adult = 18+. The isDeclaredAdult leg keeps members a lead marked
-                        // 25+ without a DoB (schema.prisma) in the picker; a null-DoB person
-                        // who was never declared adult is excluded, which is what a strict
-                        // 18+ rule means — the "mark 25+" control in the Details modal is
-                        // the affordance to fix that.
                         ...(adultsOnly ? [{
                             OR: [
-                                { dateOfBirth: { lte: eighteenYearsAgo } },
+                                { dateOfBirth: { lte: ageCutoff } },
                                 { isDeclaredAdult: true },
                             ]
                         }] : []),

--- a/checkin-app/src/app/api/programs/[id]/route.ts
+++ b/checkin-app/src/app/api/programs/[id]/route.ts
@@ -9,7 +9,7 @@ import { adjustProgramInventory } from "@/lib/shopify";
 import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
 import { LIVE_PERSON } from "@/lib/person/filters";
-import { validateProgramAgeBounds } from "@/lib/programAge";
+import { validateProgramAgeBounds, isLeaderAgeEligible } from "@/lib/programAge";
 import { parseDateOnly } from "@/lib/time";
 import { ProgramPhase, EnrollmentStatus } from "@/generated/prisma/client";
 
@@ -264,6 +264,16 @@ export const PATCH = withAuth({}, async (req, auth, ctx: { params: Promise<{ id:
             }
             if (!isSysAdminOrBoard && leadMentorId !== currentProgram.leadMentorId) {
                 return apiError("Forbidden: Only administrators can reassign lead mentors", 403);
+            }
+            const mentor = await prisma.person.findUnique({
+                where: { id: leadMentorId },
+                select: { dateOfBirth: true, isDeclaredAdult: true },
+            });
+            if (!mentor) {
+                return apiError("Lead mentor not found", 400);
+            }
+            if (!isLeaderAgeEligible(mentor)) {
+                return apiError("Lead mentor must be at least 23 years old", 400);
             }
         }
 

--- a/checkin-app/src/app/api/programs/__tests__/programsCreateDate.test.ts
+++ b/checkin-app/src/app/api/programs/__tests__/programsCreateDate.test.ts
@@ -33,6 +33,9 @@ const mockAuditLogCreate = jest.fn().mockResolvedValue({});
 jest.mock('@/lib/prisma', () => ({
     __esModule: true,
     default: {
+        person: {
+            findUnique: jest.fn().mockResolvedValue({ dateOfBirth: null, isDeclaredAdult: true }),
+        },
         program: {
             create: (...args: unknown[]) => mockProgramCreate(...args),
         },

--- a/checkin-app/src/app/api/programs/route.ts
+++ b/checkin-app/src/app/api/programs/route.ts
@@ -10,7 +10,7 @@ import { dollarsToCentsOrNull } from "@inventory/money";
 import { apiError } from "@/lib/api-response";
 import { LIVE_PERSON } from "@/lib/person/filters";
 import { staleWhileRevalidate } from "@/lib/staleCache";
-import { validateProgramAgeBounds } from "@/lib/programAge";
+import { validateProgramAgeBounds, isLeaderAgeEligible } from "@/lib/programAge";
 import { parseDateOnly } from "@/lib/time";
 
 // Public catalog projection: every Program column whose `/// @sensitivity:` tier
@@ -182,6 +182,17 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
 
         if (!leadMentorId) {
             return apiError("Lead Mentor is required", 400);
+        }
+
+        const mentor = await prisma.person.findUnique({
+            where: { id: parseInt(leadMentorId, 10) },
+            select: { dateOfBirth: true, isDeclaredAdult: true },
+        });
+        if (!mentor) {
+            return apiError("Lead mentor not found", 400);
+        }
+        if (!isLeaderAgeEligible(mentor)) {
+            return apiError("Lead mentor must be at least 23 years old", 400);
         }
 
         const maxPart = maxParticipants != null ? parseInt(maxParticipants, 10) : null;

--- a/checkin-app/src/lib/__tests__/programAge.test.ts
+++ b/checkin-app/src/lib/__tests__/programAge.test.ts
@@ -1,4 +1,4 @@
-import { checkProgramAge, isKnownAdult, validateProgramAgeBounds, MAX_PROGRAM_AGE } from "@/lib/programAge";
+import { checkProgramAge, isKnownAdult, isLeaderAgeEligible, LEADER_MIN_AGE, validateProgramAgeBounds, MAX_PROGRAM_AGE } from "@/lib/programAge";
 import { orgCalendarDay } from "@/lib/time";
 
 // as-of date pins calculateAge so the DOB cases don't drift with wall-clock time.
@@ -73,6 +73,37 @@ describe("isKnownAdult", () => {
 
   it("lets a real DOB outrank the declared-adult flag", () => {
     expect(isKnownAdult({ dateOfBirth: yearsAgo(15), isDeclaredAdult: true })).toBe(false);
+  });
+});
+
+describe("isLeaderAgeEligible", () => {
+  const yearsAgo = (n: number) => {
+    const d = orgCalendarDay();
+    d.setUTCFullYear(d.getUTCFullYear() - n);
+    return d;
+  };
+
+  it("admits someone 23 or older", () => {
+    expect(isLeaderAgeEligible({ dateOfBirth: yearsAgo(23) })).toBe(true);
+    expect(isLeaderAgeEligible({ dateOfBirth: yearsAgo(40) })).toBe(true);
+  });
+
+  it("rejects someone under 23", () => {
+    expect(isLeaderAgeEligible({ dateOfBirth: yearsAgo(22) })).toBe(false);
+    expect(isLeaderAgeEligible({ dateOfBirth: yearsAgo(18) })).toBe(false);
+  });
+
+  it("admits isDeclaredAdult (marked 25+)", () => {
+    expect(isLeaderAgeEligible({ dateOfBirth: null, isDeclaredAdult: true })).toBe(true);
+  });
+
+  it("fails closed on unknown DOB without the flag", () => {
+    expect(isLeaderAgeEligible({ dateOfBirth: null })).toBe(false);
+    expect(isLeaderAgeEligible({ dateOfBirth: null, isDeclaredAdult: false })).toBe(false);
+  });
+
+  it("constant matches 23", () => {
+    expect(LEADER_MIN_AGE).toBe(23);
   });
 });
 

--- a/checkin-app/src/lib/dev/seed-helpers.ts
+++ b/checkin-app/src/lib/dev/seed-helpers.ts
@@ -70,13 +70,14 @@ export async function seedBaseline(prisma: Db): Promise<void> {
     // 2. The 9 debug personas (solo personas get a single-person household of their own)
     const isBoardMember = await prisma.person.upsert({
         where: { email: "boardmember@example.com" },
-        update: { name: "Board Member", phone: "555-555-0001", isSysadmin: true, isBoardMember: true },
+        update: { name: "Board Member", phone: "555-555-0001", isSysadmin: true, isBoardMember: true, isDeclaredAdult: true },
         create: {
             email: "boardmember@example.com",
             name: "Board Member",
             phone: "555-555-0001",
             isSysadmin: true,
             isBoardMember: true,
+            isDeclaredAdult: true,
             household: { create: { name: "Board Member Household" } },
         },
     });

--- a/checkin-app/src/lib/programAge.ts
+++ b/checkin-app/src/lib/programAge.ts
@@ -1,4 +1,4 @@
-import { calculateAge, isYouth } from "@/lib/time";
+import { calculateAge, isYouth, orgCalendarDay } from "@/lib/time";
 
 /**
  * Whether we KNOW this person is an adult: declared over 25, or 18+ by DOB.
@@ -67,6 +67,29 @@ export function checkProgramAge(
   if (minAge !== null && age < minAge) return { ok: false, reason: "age", label: "Too young" };
   if (maxAge !== null && age > maxAge) return { ok: false, reason: "age", label: "Too old" };
   return { ok: true };
+}
+
+// Policy: Sponsored Program Policy, Art. IV — a program leader is at least 23.
+export const LEADER_MIN_AGE = 23;
+
+/**
+ * Whether this person is eligible to be a program leader by age. Fails closed:
+ * unknown DOB without isDeclaredAdult is not old enough.
+ */
+export function isLeaderAgeEligible(person: { dateOfBirth: Date | string | null; isDeclaredAdult?: boolean | null }): boolean {
+  if (person.dateOfBirth) return calculateAge(person.dateOfBirth) >= LEADER_MIN_AGE;
+  return !!person.isDeclaredAdult;
+}
+
+/**
+ * DB-level date threshold for the leader-picker query: born on or before this
+ * date ⇒ 23 or older today. The isDeclaredAdult OR leg covers null-DOB adults
+ * (flag means "marked 25+" which clears 23).
+ */
+export function leaderAgeCutoff(): Date {
+  const d = new Date(orgCalendarDay());
+  d.setUTCFullYear(d.getUTCFullYear() - LEADER_MIN_AGE);
+  return d;
 }
 
 /**

--- a/docs/rules/programs.md
+++ b/docs/rules/programs.md
@@ -103,9 +103,8 @@ Things the app takes as true because they are handled outside it.
 - A program leader is 23 or older, the floor belonging to the role rather than to
   adulthood. A program volunteer has no age floor at all — youth volunteer too.  [Decision — *Policy: Sponsored Program Policy, Art. IV*]
 
-- Nothing checks either the age floor or the requirement that a leader be a
-  member who has passed a background check: the leader pickers admit anyone 18 or
-  over.  [Short of policy — *Policy: Sponsored Program Policy, Art. IV*]
+- Nothing checks that a program leader is a member who has passed a background
+  check.  [Short of policy — *Policy: Sponsored Program Policy, Art. IV*]
 
 - Nobody under 18 enrolls themselves, and nobody whose age is unknown does
   either; only a known adult may. The bar is the guardian-consent line and is


### PR DESCRIPTION
## Summary

Fixes #1433 — the program-leader picker used an 18+ age floor; policy requires 23 (Sponsored Program Policy, Art. IV).

- Picker search route (`?filter=adults`) now uses a 23-year cutoff instead of 18. `isDeclaredAdult` (marked 25+) still clears the bar.
- Server-side age validation added to both `POST /api/programs` and `PATCH /api/programs/[id]` on `leadMentorId` — a direct API call can no longer bypass the picker.
- Unknown DOB without `isDeclaredAdult` fails closed (not old enough).
- Register line in `docs/rules/programs.md` narrowed to the remaining shortfall (member + background check, not yet enforced).

The member-plus-background-check half of the same policy line has no issue of its own and is **not** addressed here — the `[Short of policy]` line stays, narrowed to that half.

## Test plan

- [x] Unit tests for `isLeaderAgeEligible` (boundary at 23, isDeclaredAdult, fail-closed on null DOB)
- [x] Integration test adds a 20-year-old fixture — excluded from the picker, pinning the new boundary
- [x] Existing integration tests updated (lead fixtures gain `isDeclaredAdult: true` to pass the new gate)
- [ ] CI passes (unit + integration)

---
_Posted by Claude._

🤖 Generated with [Claude Code](https://claude.com/claude-code)