### PR TITLE
fix(print-badges): filter-aware empty state and hidden count (#1636)

### DIFF
--- a/checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx
@@ -229,6 +229,23 @@ describe("facility-ops/print-badges page", () => {
     expect(await screen.findByText("Kim Keyholder")).toBeInTheDocument();
   });
 
+  it("shows filter-aware empty state when search matches only inactive people", async () => {
+    setSession({ id: 1, isSysadmin: true });
+    const inactiveOnly = [
+      { id: 5, name: "Inactive Ian", email: "ian@example.com", isMember: false },
+      { id: 6, name: "Expired Eve", email: "eve@example.com", isMember: false },
+    ];
+    mockFetchJson({ "/api/people/search": { people: inactiveOnly } });
+    renderWithProviders(<PrintBadgesPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/hidden by the filter/)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/2 hidden by the filter/)).toBeInTheDocument();
+    expect(screen.queryByText("No participants found.")).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /hide inactive \(2\)/i })).toBeChecked();
+  });
+
   it("holds badge generation when the member roster request fails", async () => {
     setSession({ id: 1, isSysadmin: true });
     const logged = jest.spyOn(console, "error").mockImplementation(() => {});

--- a/checkin-app/src/app/facility-ops/print-badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/page.tsx
@@ -109,6 +109,7 @@ export default function PrintBadgesPage() {
   // Every count, every checkbox and the PDF itself read `visible`/`selectedVisible`,
   // never `participants`/`selectedIds` — a hidden person can't leak into a print run.
   const visible = hideInactive ? participants.filter(p => p.isMember) : participants;
+  const hidden = participants.length - visible.length;
   const selectedVisible = visible.filter(p => selectedIds.has(p.id));
 
   const toggleAll = () => {
@@ -234,7 +235,7 @@ export default function PrintBadgesPage() {
           onChange={(e) => setSearchTerm(e.currentTarget.value)}
         />
         <Checkbox
-          label="Hide inactive"
+          label={hidden ? `Hide inactive (${hidden})` : "Hide inactive"}
           checked={hideInactive}
           onChange={(e) => setHideInactive(e.currentTarget.checked)}
         />
@@ -253,7 +254,9 @@ export default function PrintBadgesPage() {
         rows={visible}
         getRowKey={(p) => p.id}
         loading={loading}
-        emptyMessage="No participants found."
+        emptyMessage={hidden > 0
+          ? `No active people match — ${hidden} hidden by the filter.`
+          : "No participants found."}
         rowProps={(p) => ({ bg: selectedIds.has(p.id) ? 'var(--mantine-color-blue-light)' : undefined })}
       />
     </Stack>


### PR DESCRIPTION
## Summary

- The default-on "Hide inactive" filter dropped rows client-side but the empty message still read "No participants found", misleading badge operators into thinking the person wasn't in the system
- Checkbox label now shows "Hide inactive (N)" when N > 0, so the operator sees the hidden count without unchecking
- Empty message switches to "No active people match — N hidden by the filter." when the filter is responsible for the empty table
- No server changes — both signals are derived from the existing `participants` and `visible` arrays

## Test plan

- [x] New test: search-matches-only-inactive asserts filter message, hidden count on label, and absence of the old "No participants found" message
- [x] All 11 existing print-badges tests pass

Fixes #1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)