### PR TITLE
fix(finance-ops): disable membership payment-plan buttons for own household

### DIFF
--- a/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
+++ b/checkin-app/src/app/finance-ops/membership-payment-plan/page.tsx
@@ -9,6 +9,7 @@ import { DataTable, type DataTableColumn } from '@/components/admin/DataTable';
 import { useRequireRole } from '@/hooks/useRequireRole';
 import { useOrgTime } from '@/components/TimezoneProvider';
 import { notifyNavRefresh } from '@/lib/nav-refresh';
+import { sharesHousehold } from '@/lib/conflictOfInterest';
 
 import { PageLoader } from "@/components/ui/PageLoader";
 
@@ -26,7 +27,10 @@ type MembershipPaymentPlanRequest = {
 
 export default function MembershipPaymentPlansPage() {
   const { formatDateTime } = useOrgTime();
-  const { ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
+  const { user: me, ready, loading: authLoading } = useRequireRole(['isSysadmin', 'isBoardMember']);
+
+  const ownHousehold = (req: MembershipPaymentPlanRequest) =>
+    sharesHousehold(me?.householdId, req.orgMembership.household.id);
 
   const [requests, setRequests] = useState<MembershipPaymentPlanRequest[]>([]);
   const [loading, setLoading] = useState(true);
@@ -167,10 +171,10 @@ export default function MembershipPaymentPlansPage() {
       align: 'right',
       render: (req) => (
         <Group justify="flex-end" gap="xs" wrap="nowrap">
-          <Button size="xs" fz={15} color="red" variant="light" onClick={() => handleDeny(req.id)}>
+          <Button size="xs" fz={15} color="red" variant="light" disabled={ownHousehold(req)} title={ownHousehold(req) ? "You can't deny your own household's plan — someone outside your household must." : undefined} onClick={() => handleDeny(req.id)}>
             Deny
           </Button>
-          <Button size="xs" fz={15} variant="light" onClick={() => handleApprove(req.id)}>
+          <Button size="xs" fz={15} variant="light" disabled={ownHousehold(req)} title={ownHousehold(req) ? "You can't approve your own household's plan — someone outside your household must." : undefined} onClick={() => handleApprove(req.id)}>
             Approve &amp; Activate
           </Button>
         </Group>


### PR DESCRIPTION
## Summary

- Add conflict-of-interest mirror to the membership payment-plan queue page — the last of five COI-gated surfaces that was still offering buttons the server would refuse with a 403.
- Disable Approve and Deny buttons with a tooltip when the actor shares the row's household, matching the copy and pattern used by the other four surfaces (`membership-ops/applications`, `membership-ops/households`, `finance-ops/payment-plan`, `finance-ops/shopify-holds`).
- No registry or route change needed: the GET response already includes `household.id` via the Prisma `include: { household: true }`, and `Household` is already in the registry `returns`.

Fixes #1392

## Test plan

- [ ] Verify tsc passes (confirmed locally — the pre-existing `TS7006` in `refuse/route.ts` is unrelated)
- [ ] Board member viewing their own household's payment-plan request sees greyed-out Approve & Deny buttons with tooltip
- [ ] Board member viewing another household's request can still click both buttons normally
- [ ] Server-side 403 still fires as a safety net if somehow clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)