### PR TITLE
fix(facility-ops): give print-badges the role gate its nav entry promises (#1639)

### DIFF
--- a/checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/__tests__/page.test.tsx
@@ -221,6 +221,14 @@ describe("facility-ops/print-badges page", () => {
     expect(printedNameCell("John Smith")).toBe("John");
   }, 15000);
 
+  it("admits an operations user", async () => {
+    setSession({ id: 5, isOperations: true });
+    mockFetchJson({ "/api/people/search": { people: participants } });
+    renderWithProviders(<PrintBadgesPage />);
+
+    expect(await screen.findByText("Kim Keyholder")).toBeInTheDocument();
+  });
+
   it("holds badge generation when the member roster request fails", async () => {
     setSession({ id: 1, isSysadmin: true });
     const logged = jest.spyOn(console, "error").mockImplementation(() => {});

--- a/checkin-app/src/app/facility-ops/print-badges/page.tsx
+++ b/checkin-app/src/app/facility-ops/print-badges/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
-import { useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
 import QRCode from "qrcode";
 import { pdf } from "@react-pdf/renderer";
 import { Badge, Button, Checkbox, Group, Stack, Text, TextInput } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
+import { useRequireRole } from "@/hooks/useRequireRole";
+import { FACILITY_AGGREGATE_ROLES } from "@/lib/facilityNav";
+import { PageLoader } from "@/components/ui/PageLoader";
 import { DataTable, type DataTableColumn } from "@/components/admin/DataTable";
 import BadgeDocument from "@/components/admin/BadgeDocument";
 import StickerDocument from "@/components/admin/StickerDocument";
@@ -22,8 +23,7 @@ type ParticipantRow = {
 };
 
 export default function PrintBadgesPage() {
-  const { status } = useSession();
-  const router = useRouter();
+  const { ready, loading: authLoading } = useRequireRole(FACILITY_AGGREGATE_ROLES);
 
   const [participants, setParticipants] = useState<ParticipantRow[]>([]);
   // Every ACTIVE member org-wide — the population printed names disambiguate against.
@@ -35,12 +35,6 @@ export default function PrintBadgesPage() {
   const [hideInactive, setHideInactive] = useState(true);
   const [isGenerating, setIsGenerating] = useState(false);
   const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push('/');
-    }
-  }, [status, router]);
 
   const fetchParticipants = useCallback(async () => {
     setLoading(true);
@@ -61,15 +55,15 @@ export default function PrintBadgesPage() {
   }, [searchTerm]);
 
   useEffect(() => {
-    if (status === "authenticated") {
+    if (ready) {
       fetchParticipants();
     }
-  }, [status, fetchParticipants]);
+  }, [ready, fetchParticipants]);
 
   // Once on mount — deliberately NOT keyed on searchTerm. The printed name must not
   // move when the operator types.
   useEffect(() => {
-    if (status !== "authenticated") return;
+    if (!ready) return;
     const url = new URL('/api/people/search', window.location.origin);
     url.searchParams.set('roster', 'active');
     fetch(url.toString())
@@ -85,7 +79,7 @@ export default function PrintBadgesPage() {
         setRoster(null);
         notifications.show({ color: 'red', message: 'Could not load the active member roster, so badge names cannot be resolved. Reload to retry.', autoClose: false });
       });
-  }, [status]);
+  }, [ready]);
 
   const printedNames = useMemo(() => computeDisplayNames(roster ?? []), [roster]);
   const printedYears = useMemo(() => new Map((roster ?? []).map(m => [m.id, m.year])), [roster]);
@@ -172,7 +166,8 @@ export default function PrintBadgesPage() {
     }
   };
 
-  if (status === "loading") return null;
+  if (authLoading) return <PageLoader />;
+  if (!ready) return null;
 
   const columns: DataTableColumn<ParticipantRow>[] = [
     {


### PR DESCRIPTION
## Summary

- Replace the manual `useSession`/`useEffect(redirect)` in `print-badges/page.tsx` with `useRequireRole(FACILITY_AGGREGATE_ROLES)`, matching its four facility-ops siblings
- The `facilityNav.ts` comment says each page passes its roles array to `useRequireRole` — print-badges was the only exception, riding the section gate instead of enforcing its own
- Add "admits an operations user" test case

Fixes item 3 of #1639. Items 1–2 shipped in #1643, items 4–5 in #1642.

## Test plan

- [x] All 11 print-badges unit tests pass (including new operations-user test)
- [x] `pageRegistry` drift-guard tests pass
- [x] `tsc --noEmit` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)