### PR TITLE
fix(membership-ops): require name on every Person creation path

### DIFF
--- a/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
+++ b/checkin-app/src/app/__tests__/adminParticipants.integration.test.ts
@@ -214,10 +214,11 @@ describe('Admin Participants API Integration Tests', () => {
 
             const req = new Request('http://localhost:4000/api/membership-ops/participants', {
                 method: 'POST',
-                body: JSON.stringify({ 
-                    name: 'Child User', 
+                body: JSON.stringify({
+                    name: 'Child User',
                     email: 'new-child-participants-test@example.com',
-                    parentEmail: 'new-parent-participants-test@example.com' 
+                    parentEmail: 'new-parent-participants-test@example.com',
+                    parentName: 'New Parent'
                 })
             });
 
@@ -229,12 +230,33 @@ describe('Admin Participants API Integration Tests', () => {
             expect(data.participant.email).toBe('new-child-participants-test@example.com');
             expect(data.participant.householdId).not.toBeNull();
 
-            // Verify the parent was created
+            // Verify the parent was created with the provided name
             const parent = await prisma.person.findUnique({
                 where: { email: 'new-parent-participants-test@example.com' }
             });
             expect(parent).toBeDefined();
+            expect(parent?.name).toBe('New Parent');
             expect(parent?.householdId).toBe(data.participant.householdId);
+        });
+
+        it('should reject creating a child with parentEmail but no parentName when parent does not exist', async () => {
+            (getServerSession as jest.Mock).mockResolvedValue({
+                user: { id: testAdminId, isSysadmin: true, isBoardMember: false }
+            });
+
+            const req = new Request('http://localhost:4000/api/membership-ops/participants', {
+                method: 'POST',
+                body: JSON.stringify({
+                    name: 'Child User',
+                    email: 'reject-child-participants-test@example.com',
+                    parentEmail: 'reject-parent-participants-test@example.com'
+                })
+            });
+
+            const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+            expect(res.status).toBe(400);
+            const data = await res.json();
+            expect(data.error).toMatch(/parent name/i);
         });
     });
 

--- a/checkin-app/src/app/api/household/route.ts
+++ b/checkin-app/src/app/api/household/route.ts
@@ -89,6 +89,10 @@ export const PATCH = withAuth(
                 return apiError(PHONE_ERROR, 400);
             }
 
+            if (!memberName?.trim()) {
+                return apiError("Name is required", 400);
+            }
+
             if (!memberDob && !memberOver25) {
                 // A new member's age must be known: either a DoB, or an explicit
                 // "25+" declaration (mirrors the client form's requirement).

--- a/checkin-app/src/app/api/membership-ops/participants/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/route.ts
@@ -16,7 +16,7 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
         const body = await req.json();
         // `alreadyMember` lets an admin confirm a newly-created household is already
         // a paid member (defaults false — new participants are visitors, not members).
-        const { name, email, parentEmail, dob, householdId, alreadyMember = false } = body;
+        const { name, email, parentEmail, parentName, dob, householdId, alreadyMember = false } = body;
 
         if (!email && !parentEmail && !householdId) {
             return apiError("Email, Parent Email, or Household assignment is required", 400);
@@ -51,11 +51,17 @@ export const POST = withAuth({ roles: ['isSysadmin', 'isBoardMember'] }, async (
             });
 
             if (!parent) {
+                if (!parentName?.trim()) {
+                    return apiError("Parent name is required when creating a new parent", 400);
+                }
+                const trimmedParentName = parentName.trim();
+                const parentLastName = trimmedParentName.split(/\s+/).pop() || "";
                 parent = await prisma.person.create({
                     data: {
                         email: parentEmail,
+                        name: trimmedParentName,
                         household: {
-                            create: { name: "Household" }
+                            create: { name: parentLastName ? `${parentLastName} Household` : "Household" }
                         }
                     }
                 });

--- a/checkin-app/src/app/membership-ops/participants/new/__tests__/page.test.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/__tests__/page.test.tsx
@@ -48,6 +48,7 @@ describe("membership-ops/participants/new page", () => {
             name: "Jane Doe",
             email: "jane@example.com",
             parentEmail: null,
+            parentName: null,
             dob: null,
             householdId: null,
             alreadyMember: false,
@@ -175,7 +176,7 @@ describe("membership-ops/participants/new page", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
-            name: "", email: null, parentEmail: null, dob: null, householdId: 9, alreadyMember: false,
+            name: "", email: null, parentEmail: null, parentName: null, dob: null, householdId: 9, alreadyMember: false,
           }),
         }),
       ),
@@ -194,6 +195,7 @@ describe("membership-ops/participants/new page", () => {
     fireEvent.change(screen.getByLabelText("Date of Birth"), { target: { value: "2015-01-01" } });
     await screen.findByText("Student Detected");
     fireEvent.change(screen.getByLabelText(/Parent \/ Guardian Google Email/), { target: { value: "parent@example.com" } });
+    fireEvent.change(screen.getByPlaceholderText("e.g. John Doe"), { target: { value: "Parent Name" } });
     fireEvent.click(screen.getByLabelText("Confirm this household is already a paid member"));
 
     const submitBtn = screen.getByRole("button", { name: "Create Participant" });
@@ -206,7 +208,7 @@ describe("membership-ops/participants/new page", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
-            name: "", email: null, parentEmail: "parent@example.com", dob: "2015-01-01", householdId: null, alreadyMember: true,
+            name: "", email: null, parentEmail: "parent@example.com", parentName: "Parent Name", dob: "2015-01-01", householdId: null, alreadyMember: true,
           }),
         }),
       ),

--- a/checkin-app/src/app/membership-ops/participants/new/page.tsx
+++ b/checkin-app/src/app/membership-ops/participants/new/page.tsx
@@ -33,6 +33,7 @@ function NewParticipantForm() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [parentEmail, setParentEmail] = useState("");
+  const [parentName, setParentName] = useState("");
   const [dob, setDob] = useState("");
 
   // Household selection state (the EntityPicker owns the transient query/results)
@@ -89,6 +90,7 @@ function NewParticipantForm() {
           name,
           email: email || null,
           parentEmail: isYouthSelected ? parentEmail : null,
+          parentName: isYouthSelected && parentEmail ? parentName : null,
           dob: dob || null,
           householdId: householdId ? parseInt(householdId) : null,
           alreadyMember: !householdId && alreadyMember
@@ -102,6 +104,7 @@ function NewParticipantForm() {
         setName("");
         setEmail("");
         setParentEmail("");
+        setParentName("");
         setDob("");
         setHouseholdId("");
         setHouseholdSearch("");
@@ -118,7 +121,7 @@ function NewParticipantForm() {
     }
   };
 
-  const submitDisabled = saving || (!isYouthSelected && !email && !householdId) || (isYouthSelected && !parentEmail && !householdId);
+  const submitDisabled = saving || (!isYouthSelected && !email && !householdId) || (isYouthSelected && !parentEmail && !householdId) || (isYouthSelected && !!parentEmail && !parentName.trim());
 
   return (
     <Container size="md" pb="md">
@@ -178,6 +181,17 @@ function NewParticipantForm() {
                   onChange={(e) => setParentEmail(e.currentTarget.value)}
                   placeholder="parent@example.com"
                 />
+                {parentEmail && (
+                  <TextInput
+                    label="Parent / Guardian Name"
+                    description="Required in case this parent is not already in the system."
+                    required
+                    value={parentName}
+                    onChange={(e) => setParentName(e.currentTarget.value)}
+                    placeholder="e.g. John Doe"
+                    mt="sm"
+                  />
+                )}
               </Paper>
             )}
 

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -46,7 +46,7 @@ export class IntakeError extends Error {
  */
 export type IntakeRejection = {
     section: "secondaryParent";
-    code: "lead_limit";
+    code: "lead_limit" | "name_required";
     message: string;
 };
 
@@ -304,7 +304,7 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
             await prisma.person.update({
                 where: { id: sp.id },
                 data: {
-                    ...(sp.name !== undefined && { name: sp.name }),
+                    ...(sp.name !== undefined && sp.name !== null && { name: sp.name }),
                     ...(sp.dob !== undefined && normalizeAdultDob(sp.dob)),
                     ...(sp.over25 !== undefined && !sp.dob && { isDeclaredAdult: !!sp.over25 }),
                     ...(sp.allergies !== undefined && { allergies: sp.allergies }),
@@ -324,6 +324,12 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
                 },
             });
             await addLeadOrRecord(created.id);
+        } else if (sp.email) {
+            rejections.push({
+                section: "secondaryParent",
+                code: "name_required",
+                message: "A name is required for the second parent / guardian.",
+            });
         }
     }
 

--- a/checkin-app/src/lib/membership/intake.ts
+++ b/checkin-app/src/lib/membership/intake.ts
@@ -312,11 +312,11 @@ export async function saveIntake(userId: number, input: IntakeSaveInput) {
             });
             // A second guardian is a household lead (parent).
             await addLeadOrRecord(sp.id);
-        } else if (sp.name || sp.email) {
+        } else if (sp.name) {
             const created = await prisma.person.create({
                 data: {
                     householdId,
-                    name: sp.name ?? null,
+                    name: sp.name,
                     ...(sp.email && { email: sp.email.toLowerCase() }),
                     ...normalizeAdultDob(sp.dob),
                     ...(!sp.dob && { isDeclaredAdult: !!sp.over25 }),


### PR DESCRIPTION
## Summary

- **Admin participants route**: reject 400 when `parentEmail` doesn't match an existing Person and no `parentName` is provided; previously created a nameless parent from just an email
- **Household add-member route**: reject 400 when `memberName` is missing or blank
- **Intake secondary parent**: reject with `name_required` when only email is provided (was silently skipped); guard the update path against writing explicit null name
- **New participant form**: add `parentName` field (appears when `parentEmail` is entered), disable submit until filled

## What's NOT in this PR

- **Bulk import route** (`import/route.ts:208`): still uses `email.split('@')[0]` as a manufactured name — different fix (CSV format change), separate PR
- **`NOT NULL` migration**: this enforces at app level first; DB constraint follows once existing nulls are backfilled
- **Kiosk email-prefix display fallback removal**: deferred until all Persons have names (already consolidated to two lib sites: `kiosk-names.ts` and `getFullAttendance.ts`)

## Test plan

- [x] Existing parent-create test updated to send `parentName`, asserts parent gets the name
- [x] New test: rejection when `parentEmail` provided without `parentName` and parent doesn't exist
- [x] Page unit tests updated for `parentName` in request body
- [ ] Integration: verify intake secondary parent email-only gets `name_required` rejection
- [ ] Integration: verify household add-member without name gets 400

Part of #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)