### PR TITLE
docs(rules): person IDs are sparse, never reused

### DIFF
--- a/docs/rules/people-households.md
+++ b/docs/rules/people-households.md
@@ -149,6 +149,14 @@ Things the app takes as true because they are handled outside it.
 - Where someone signs in with Google, the address they sign in with is the
   address they are contacted at. There is no second one to diverge from it.  [Decision]
 
+- A person's identifier is opaque, and its only job is to be unique and to stay
+  unique. It is sparse, never dense and never reissued: a save that was rolled
+  back or a database pause leaves gaps in the numbering, and those gaps are
+  expected rather than a fault to close. It is never worked out from the people
+  already on file either — issuing the highest number in use plus one hands a
+  deleted person's number to a new one, and every badge printed for the first
+  would then scan as the second at the kiosk.  [Decision]
+
 - A person is never lost. A merged record is kept and marked as merged rather
   than removed, and drops out of every live list, count and roster. A record of
   what happened still names them, because hiding a since-merged identity there


### PR DESCRIPTION
Person IDs jump by ~32 whenever the database pauses and resumes — Aurora's storage layer prefetches sequence values that a resume discards. The [design comment on the issue](https://github.com/innovationtreehouse/checkin/issues/1693#issuecomment-5377141681) settled what to do about it: **accept the gaps and write the decision down.** This PR is the whole fix — no code, no schema, no migration.

## Why MAX(id)+1 was rejected

The proposal was to derive each new ID from the highest one in use. That reuses IDs, and this app has the two ingredients that make reuse dangerous:

- **Badges make person IDs physical and long-lived.** The badge QR encodes the raw person ID, and printed badges outlive the row.
- **Hard deletes of Person exist in production today** — the NextAuth adapter's `deleteUser` hard-deletes a Person row (merge deliberately tombstones, but the adapter path is live, and manual SQL cleanup always looms).

Together: newest person deleted → next signup receives their number → **every badge ever printed for the deleted person now scans as the new person at the kiosk.** In a youth check-in system that is a safety defect, not an inconvenience.

The gap problem, meanwhile, is aesthetic: at ~250 people and one pause a day, IDs reach six digits in roughly eight years and the int4 ceiling is ~180,000 years out. A six-digit numeric payload is still a version-1 QR code. Gaps are also inherent to Postgres regardless — every rolled-back insert burns one.

## The change

One bullet added to `docs/rules/people-households.md`, under Procedure → Identity and age, next to the other rules about what a person record is. Per `docs/DOCUMENTATION_STANDARD.md` §3.8 it carries no PR number, issue number, or date, and states the constraint rather than the history:

> - A person's identifier is opaque, and its only job is to be unique and to stay unique. It is sparse, never dense and never reissued: a save that was rolled back or a database pause leaves gaps in the numbering, and those gaps are expected rather than a fault to close. It is never worked out from the people already on file either — issuing the highest number in use plus one hands a deleted person's number to a new one, and every badge printed for the first would then scan as the second at the kiosk.  [Decision]

If dense human-facing numbers are ever genuinely wanted, the right shape is a separate badge number from a monotonic counter table, assigned at first print — display-layer prettiness that never touches PK semantics. Not proposed here; file it if the want materialises.

Fixes #1693

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URSrfChi89qKn1hLbjaX3K
