### PR TITLE
fix(merge): repoint every Person relation the merge previously stranded (#1456 2b-0)

### DIFF
--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -1067,6 +1067,19 @@ describe("Merge Participants API", () => {
             expect(await movedTallies()).toMatchObject({ roles: { migrated: 1, deduped: 1 } });
         });
 
+        // Ordering pin: the granter sweep runs AFTER the holder pass, so the stamp on
+        // the row the dedupe just deleted is not counted as moved. Sweep-first would
+        // report roleGrants: 1 for a row that no longer exists.
+        it("does not count a granter stamp on a role row the dedupe deleted", async () => {
+            await prisma.personRole.create({ data: { personId: pKeepId, role: "BOARD" } });
+            await prisma.personRole.create({ data: { personId: pMergeId, role: "BOARD", grantedById: pMergeId } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            expect(await movedTallies()).toMatchObject({ roles: { migrated: 0, deduped: 1 }, roleGrants: 0 });
+        });
+
         it("moves the PersonRole granter stamp (grantedById)", async () => {
             await prisma.personRole.create({ data: { personId: actorId, role: "KEYHOLDER", grantedById: pMergeId } });
 
@@ -1132,6 +1145,56 @@ describe("Merge Participants API", () => {
             const { collisions } = await res.json();
             expect((collisions as { type: string }[]).map(c => c.type)).toEqual(['bgAttestationSubject']);
             expect(collisions[0].message).toContain("subject of the same background check");
+        });
+    });
+
+    // One record REVIEWED an attestation naming the other as SUBJECT. Only one row
+    // exists, so no unique constraint fires: the subjectPersonId repoint silently
+    // makes reviewerId === subjectPersonId, and approvalsForSubject counts that
+    // self-approval toward REQUIRED_APPROVALS.
+    describe("cross-role attestation collision (reviewer of the other's own check)", () => {
+        const seedCrossRole = async (reviewerId: number, subjectPersonId: number) => {
+            const process = await prisma.orgMembershipProcess.create({ data: { kind: "PERSON_BG", status: "PENDING_BG_REVIEW" } });
+            createdProcessIds.push(process.id);
+            return prisma.backgroundCheckAttestation.create({ data: { processId: process.id, reviewerId, subjectPersonId, result: "APPROVE" } });
+        };
+
+        it("409s when the KEEPER reviewed an attestation naming the merged-away record", async () => {
+            const att = await seedCrossRole(pKeepId, pMergeId);
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(409);
+            const data = await res.json();
+            expect((data.collisions as { type: string }[]).map(c => c.type)).toEqual(['bgAttestationCrossRole']);
+            expect(data.error).toContain("reviewer of their own background check");
+
+            // The row is untouched — no self-review was created.
+            const after = await prisma.backgroundCheckAttestation.findUnique({ where: { id: att.id } });
+            expect(after?.subjectPersonId).toBe(pMergeId);
+            expect(after?.reviewerId).not.toBe(after?.subjectPersonId);
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBeNull();
+        });
+
+        it("409s in the other direction too — merged-away record as reviewer, keeper as subject", async () => {
+            await seedCrossRole(pMergeId, pKeepId);
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(409);
+            expect(((await res.json()).collisions as { type: string }[]).map(c => c.type)).toEqual(['bgAttestationCrossRole']);
+        });
+
+        it("analyze reports it, both directions", async () => {
+            await seedCrossRole(pKeepId, pMergeId);
+
+            const res = await analyzeGET(analyzeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+            const { collisions } = await res.json();
+            expect((collisions as { type: string }[]).map(c => c.type)).toEqual(['bgAttestationCrossRole']);
+            expect(collisions[0].message).toContain("reviewer of their own background check");
+
+            // Direction-independent: the same pair swapped reports the same collision.
+            const swapped = await analyzeGET(analyzeReq(pMergeId, pKeepId));
+            expect(((await swapped.json()).collisions as { type: string }[]).map(c => c.type)).toEqual(['bgAttestationCrossRole']);
         });
     });
 

--- a/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/__tests__/route.integration.test.ts
@@ -116,9 +116,11 @@ describe("Merge Participants API", () => {
         const personIds = [pKeepId, pMergeId, actorId, ...extraPersonIds];
 
         // RESTRICT-FK children must go before their Person rows.
-        await prisma.backgroundCheckAttestation.deleteMany({ where: { reviewerId: { in: personIds } } });
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { OR: [{ reviewerId: { in: personIds } }, { subjectPersonId: { in: personIds } }] } });
+        await prisma.rawBadgeLog.deleteMany({ where: { personId: { in: personIds } } });
         await prisma.corporationLead.deleteMany({ where: { personId: { in: personIds } } });
         await prisma.corporationMember.deleteMany({ where: { personId: { in: personIds } } });
+        await prisma.trustedAdultReview.deleteMany({ where: { householdId } });
         await prisma.trustedAdult.deleteMany({ where: { householdId } });
         await prisma.toolStatus.deleteMany({ where: { personId: { in: personIds } } });
         await prisma.rSVP.deleteMany({ where: { personId: { in: personIds } } });
@@ -978,6 +980,159 @@ describe("Merge Participants API", () => {
         // Sessions are the deliberate exception: deleted, not moved — no reason to
         // inherit a login session, and forcing re-login is smaller and safer.
         expect(await prisma.session.count({ where: { userId: { in: [pKeepId, pMergeId] } } })).toBe(0);
+    });
+
+    // #1456 slice 2b-0: relations the merge never repointed, so the fact stayed on a
+    // record the app treats as nonexistent — and, for the RESTRICT and CASCADE ones,
+    // made a later Person delete impossible or silently destructive.
+    describe("repoints every Person relation (2b-0)", () => {
+        /** Audit tallies for the merge just run. */
+        const movedTallies = async () => {
+            const log = await prisma.auditLog.findFirst({ where: { tableName: "Person", affectedEntityId: pKeepId, secondaryAffectedEntity: pMergeId } });
+            return (log?.newData as { moved: Record<string, unknown> }).moved;
+        };
+
+        // RESTRICT: this row is what makes `DELETE FROM "Person"` fail for essentially
+        // every real tombstone.
+        it("moves RawBadgeLog scans to the survivor", async () => {
+            await prisma.rawBadgeLog.create({ data: { personId: pMergeId, location: "front-desk" } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            expect(await prisma.rawBadgeLog.count({ where: { personId: pMergeId } })).toBe(0);
+            expect((await prisma.rawBadgeLog.findFirst({ where: { personId: pKeepId } }))?.location).toBe("front-desk");
+            expect(await movedTallies()).toMatchObject({ rawBadgeLogs: 1 });
+        });
+
+        // SET NULL: left behind, the audit fact becomes "nobody read the note".
+        it("moves the intake-note acknowledgement (OrgMembershipProcess.noteAckById)", async () => {
+            const process = await prisma.orgMembershipProcess.create({
+                data: { kind: "PERSON_BG", status: "PENDING_BG_REVIEW", noteAckById: pMergeId, noteAckAt: new Date() },
+            });
+            createdProcessIds.push(process.id);
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            expect((await prisma.orgMembershipProcess.findUnique({ where: { id: process.id } }))?.noteAckById).toBe(pKeepId);
+            expect(await movedTallies()).toMatchObject({ noteAcks: 1 });
+        });
+
+        it("moves the attendance confirmation (Event.attendanceConfirmedById)", async () => {
+            const event = await prisma.event.create({
+                data: {
+                    name: "Confirmed Event", startAt: new Date(Date.now() - 86400000), endAt: new Date(Date.now() - 82800000),
+                    attendanceConfirmedById: pMergeId, attendanceConfirmedAt: new Date(),
+                },
+            });
+            createdEventId = event.id;
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            expect((await prisma.event.findUnique({ where: { id: event.id } }))?.attendanceConfirmedById).toBe(pKeepId);
+            expect(await movedTallies()).toMatchObject({ attendanceConfirmations: 1 });
+        });
+
+        it("moves the trusted-adult board decision (TrustedAdultReview.decidedById)", async () => {
+            const adult = await prisma.trustedAdult.create({
+                data: { householdId, trustedAdultName: "Grandma", trustedAdultPhone: "555-0199", disclosedById: actorId, familyContext: "context" },
+            });
+            const review = await prisma.trustedAdultReview.create({
+                data: { trustedAdultId: adult.id, householdId, kind: "INITIAL", decidedById: pMergeId },
+            });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            expect((await prisma.trustedAdultReview.findUnique({ where: { id: review.id } }))?.decidedById).toBe(pKeepId);
+            expect(await movedTallies()).toMatchObject({ trustedAdultDecisions: 1 });
+        });
+
+        // CASCADE: a role left on the tombstone is a security grant a later delete
+        // would take with it, with no audit row.
+        it("moves a PersonRole the survivor lacks, dedupes one it already holds, and loses none silently", async () => {
+            await prisma.personRole.create({ data: { personId: pKeepId, role: "BOARD" } });
+            await prisma.personRole.create({ data: { personId: pMergeId, role: "BOARD" } });
+            await prisma.personRole.create({ data: { personId: pMergeId, role: "KEYHOLDER" } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            const surviving = await prisma.personRole.findMany({ where: { personId: { in: [pKeepId, pMergeId] } }, select: { personId: true, role: true } });
+            expect(surviving.map(r => `${r.personId}:${r.role}`).sort()).toEqual([`${pKeepId}:BOARD`, `${pKeepId}:KEYHOLDER`]);
+            // The dropped row is the duplicate grant, and the audit says so — the
+            // KEYHOLDER grant is not quietly gone.
+            expect(await movedTallies()).toMatchObject({ roles: { migrated: 1, deduped: 1 } });
+        });
+
+        it("moves the PersonRole granter stamp (grantedById)", async () => {
+            await prisma.personRole.create({ data: { personId: actorId, role: "KEYHOLDER", grantedById: pMergeId } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            const granted = await prisma.personRole.findUnique({ where: { personId_role: { personId: actorId, role: "KEYHOLDER" } } });
+            expect(granted?.grantedById).toBe(pKeepId);
+            expect(await movedTallies()).toMatchObject({ roleGrants: 1 });
+        });
+
+        // The repoint AND the proof it isn't over-refused: two DIFFERENT reviewers each
+        // naming one of the duplicate identities is an ordinary 2-of-N review.
+        it("moves BackgroundCheckAttestation.subjectPersonId, even when another reviewer named the survivor", async () => {
+            const reviewer2 = await prisma.person.create({ data: { name: "Second Reviewer", householdId: await makeHousehold("Reviewer Two Household") } });
+            extraPersonIds.push(reviewer2.id);
+            const process = await prisma.orgMembershipProcess.create({ data: { kind: "PERSON_BG", status: "PENDING_BG_REVIEW" } });
+            createdProcessIds.push(process.id);
+
+            await prisma.backgroundCheckAttestation.create({ data: { processId: process.id, reviewerId: reviewer2.id, subjectPersonId: pKeepId, result: "APPROVE" } });
+            const mergeSide = await prisma.backgroundCheckAttestation.create({ data: { processId: process.id, reviewerId: actorId, subjectPersonId: pMergeId, result: "APPROVE" } });
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+
+            expect((await prisma.backgroundCheckAttestation.findUnique({ where: { id: mergeSide.id } }))?.subjectPersonId).toBe(pKeepId);
+            expect(await prisma.backgroundCheckAttestation.count({ where: { processId: process.id, subjectPersonId: pKeepId } })).toBe(2);
+            expect(await movedTallies()).toMatchObject({ bgAttestationSubjects: { migrated: 1, left: 0 } });
+        });
+    });
+
+    // #1456 Decision 3: #1686's collision key was `processId` alone, so the subject
+    // half of @@unique([processId, reviewerId, subjectPersonId]) went undetected.
+    describe("subject-side attestation collision", () => {
+        /** One reviewer attested BOTH records as the subject of one process. */
+        const seedSubjectCollision = async () => {
+            const process = await prisma.orgMembershipProcess.create({ data: { kind: "PERSON_BG", status: "PENDING_BG_REVIEW" } });
+            createdProcessIds.push(process.id);
+            await prisma.backgroundCheckAttestation.create({ data: { processId: process.id, reviewerId: actorId, subjectPersonId: pKeepId, result: "APPROVE" } });
+            await prisma.backgroundCheckAttestation.create({ data: { processId: process.id, reviewerId: actorId, subjectPersonId: pMergeId, result: "APPROVE" } });
+            return process.id;
+        };
+
+        it("409s, naming the collision, and moves nothing", async () => {
+            await seedSubjectCollision();
+
+            const res = await POST(mergeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(409);
+            const data = await res.json();
+            // Neither record is the REVIEWER here — only the widened key sees this.
+            expect((data.collisions as { type: string }[]).map(c => c.type)).toEqual(['bgAttestationSubject']);
+            expect(data.error).toContain("subject of the same background check");
+
+            expect((await prisma.person.findUnique({ where: { id: pMergeId } }))?.mergedIntoId).toBeNull();
+            expect(await prisma.backgroundCheckAttestation.count({ where: { subjectPersonId: pMergeId } })).toBe(1);
+        });
+
+        it("analyze reports it too, so the picker warns before the operator commits", async () => {
+            await seedSubjectCollision();
+
+            const res = await analyzeGET(analyzeReq(pKeepId, pMergeId));
+            expect(res.status).toBe(200);
+            const { collisions } = await res.json();
+            expect((collisions as { type: string }[]).map(c => c.type)).toEqual(['bgAttestationSubject']);
+            expect(collisions[0].message).toContain("subject of the same background check");
+        });
     });
 
     // One human owes ONE background check: both sides can hold an open PERSON_BG, and

--- a/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
@@ -161,6 +161,15 @@ export const GET = withAuth(
             if (sharedBgProcessCount > 0) {
                 collisions.push({ type: 'bgAttestation', message: `Both attested the same background check (${sharedBgProcessCount} shared review${sharedBgProcessCount > 1 ? 's' : ''}). Investigate before merging.` });
             }
+            // Cross-role: one record reviewed an attestation naming the other as
+            // subject. Only one row exists, so no unique fires — the repoint would
+            // quietly turn it into a self-review that still counts toward clearance.
+            const crossRoleCount = subjectAttestations.filter(x =>
+                (x.subjectPersonId === aId && x.reviewerId === bId) || (x.subjectPersonId === bId && x.reviewerId === aId)
+            ).length;
+            if (crossRoleCount > 0) {
+                collisions.push({ type: 'bgAttestationCrossRole', message: `One record reviewed a background check naming the other as its subject (${crossRoleCount} attestation${crossRoleCount > 1 ? 's' : ''}). Merging would make the survivor the reviewer of their own background check — investigate before merging.` });
+            }
             const aSubjectKeys = new Set(
                 subjectAttestations.filter(x => x.subjectPersonId === aId).map(x => `${x.processId}:${x.reviewerId}`)
             );

--- a/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/analyze/route.ts
@@ -103,7 +103,7 @@ export const GET = withAuth(
             const collisions: Array<{ type: string; message: string }> = [];
             const now = new Date();
 
-            const [sharedPrograms, sharedTools, sharedFutureEvents, sharedBgProcessCount, aOpen, bOpen] = await Promise.all([
+            const [sharedPrograms, sharedTools, sharedFutureEvents, sharedBgProcessCount, subjectAttestations, aOpen, bOpen] = await Promise.all([
                 prisma.program.findMany({
                     where: {
                         AND: [
@@ -140,6 +140,14 @@ export const GET = withAuth(
                         ],
                     },
                 }),
+                // Subject side of @@unique([processId, reviewerId, subjectPersonId]):
+                // a repoint collides only when ONE reviewer attested both records under
+                // the same process, so the pairs are intersected below rather than
+                // counted per process.
+                prisma.backgroundCheckAttestation.findMany({
+                    where: { subjectPersonId: { in: [aId, bId] } },
+                    select: { processId: true, reviewerId: true, subjectPersonId: true },
+                }),
                 prisma.visit.findFirst({ where: { personId: aId, departedAt: null, deletedAt: null }, select: { id: true } }),
                 prisma.visit.findFirst({ where: { personId: bId, departedAt: null, deletedAt: null }, select: { id: true } }),
             ]);
@@ -152,6 +160,14 @@ export const GET = withAuth(
             }
             if (sharedBgProcessCount > 0) {
                 collisions.push({ type: 'bgAttestation', message: `Both attested the same background check (${sharedBgProcessCount} shared review${sharedBgProcessCount > 1 ? 's' : ''}). Investigate before merging.` });
+            }
+            const aSubjectKeys = new Set(
+                subjectAttestations.filter(x => x.subjectPersonId === aId).map(x => `${x.processId}:${x.reviewerId}`)
+            );
+            const sharedSubjectCount = subjectAttestations
+                .filter(x => x.subjectPersonId === bId && aSubjectKeys.has(`${x.processId}:${x.reviewerId}`)).length;
+            if (sharedSubjectCount > 0) {
+                collisions.push({ type: 'bgAttestationSubject', message: `One reviewer attested both records as the subject of the same background check (${sharedSubjectCount} shared attestation${sharedSubjectCount > 1 ? 's' : ''}). Investigate before merging.` });
             }
             for (const e of sharedFutureEvents) {
                 collisions.push({ type: 'rsvp', message: `Both RSVP'd to ${e.name}. Remove one RSVP first.` });

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -321,12 +321,28 @@ export const POST = withAuth(
                 });
             }
 
+            // Cross-role: one record REVIEWED an attestation naming the other as its
+            // SUBJECT. No unique constraint fires — there is only one row — so the
+            // repoint silently collapses it into reviewerId === subjectPersonId, and
+            // approvalsForSubject (lib/membership/review.ts) has no self-exclusion, so
+            // that self-approval counts toward REQUIRED_APPROVALS. attest()'s
+            // same-household gate is create-time only and never sees this.
+            const bgCrossRoleCollisions = [
+                ...keepParticipant.bgAttestations.filter(a => a.subjectPersonId === mergeId),
+                ...mergeParticipant.bgAttestations.filter(a => a.subjectPersonId === keepId),
+            ];
+            if (bgCrossRoleCollisions.length > 0) {
+                collisions.push({
+                    type: 'bgAttestationCrossRole',
+                    message: `One record reviewed a background check naming the other as its subject (${bgCrossRoleCollisions.length} attestation${bgCrossRoleCollisions.length > 1 ? 's' : ''}). Merging would make the survivor the reviewer of their own background check — investigate before merging.`,
+                });
+            }
+
             // Subject side of the same unique triple. Repointing subjectPersonId
             // collides when ONE reviewer attested both identities under the same
             // process — i.e. read the same human off a PDF twice. Two DIFFERENT
             // reviewers naming the two identities is an ordinary 2-of-N review and
-            // merges cleanly. A tombstone that is the *reviewer* on a shared process
-            // is already refused above, whichever role it plays on the other row.
+            // merges cleanly.
             const keepSubjectKeys = new Set(keepParticipant.bgAttestationsAsSubject.map(bgSubjectKey));
             const bgSubjectCollisions = mergeParticipant.bgAttestationsAsSubject.filter(a => keepSubjectKeys.has(bgSubjectKey(a)));
             if (bgSubjectCollisions.length > 0) {

--- a/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
+++ b/checkin-app/src/app/api/membership-ops/participants/merge/route.ts
@@ -65,6 +65,15 @@ function personPreImage(p: Person) {
     };
 }
 
+/**
+ * The part of `@@unique([processId, reviewerId, subjectPersonId])` that a
+ * subjectPersonId repoint does not change — two rows sharing it cannot both
+ * name the same subject.
+ */
+function bgSubjectKey(a: { processId: number; reviewerId: number }): string {
+    return `${a.processId}:${a.reviewerId}`;
+}
+
 /** A login identity is present iff email OR googleId is non-empty. */
 function hasIdentity(p: { email: string | null; googleId: string | null }): boolean {
     return !isEmpty(p.email) || !isEmpty(p.googleId);
@@ -205,6 +214,7 @@ export const POST = withAuth(
                 rsvps: { include: { event: { select: { name: true, startAt: true } } } },
                 toolStatuses: { include: { tool: { select: { name: true } } } },
                 bgAttestations: true,
+                bgAttestationsAsSubject: true,
                 corporationLeads: true,
                 corporationMembers: true,
             } as const;
@@ -308,6 +318,21 @@ export const POST = withAuth(
                 collisions.push({
                     type: 'bgAttestation',
                     message: `Both attested the same background check (${bgCollisions.length} shared review${bgCollisions.length > 1 ? 's' : ''}). This indicates review under two identities — investigate before merging.`,
+                });
+            }
+
+            // Subject side of the same unique triple. Repointing subjectPersonId
+            // collides when ONE reviewer attested both identities under the same
+            // process — i.e. read the same human off a PDF twice. Two DIFFERENT
+            // reviewers naming the two identities is an ordinary 2-of-N review and
+            // merges cleanly. A tombstone that is the *reviewer* on a shared process
+            // is already refused above, whichever role it plays on the other row.
+            const keepSubjectKeys = new Set(keepParticipant.bgAttestationsAsSubject.map(bgSubjectKey));
+            const bgSubjectCollisions = mergeParticipant.bgAttestationsAsSubject.filter(a => keepSubjectKeys.has(bgSubjectKey(a)));
+            if (bgSubjectCollisions.length > 0) {
+                collisions.push({
+                    type: 'bgAttestationSubject',
+                    message: `One reviewer attested both records as the subject of the same background check (${bgSubjectCollisions.length} shared attestation${bgSubjectCollisions.length > 1 ? 's' : ''}). This indicates the same adult named under two identities — investigate before merging.`,
                 });
             }
 
@@ -418,6 +443,13 @@ export const POST = withAuth(
                 const moved = {
                     visits: 0,
                     personBgArchived: 0,
+                    rawBadgeLogs: 0,
+                    noteAcks: 0,
+                    attendanceConfirmations: 0,
+                    trustedAdultDecisions: 0,
+                    roleGrants: 0,
+                    roles: { migrated: 0, deduped: 0 },
+                    bgAttestationSubjects: { migrated: 0, left: 0 },
                     programParticipants: { migrated: 0, left: 0 },
                     programVolunteers: { migrated: 0, deduped: 0 },
                     rsvps: { migrated: 0, deduped: 0, left: 0 },
@@ -509,6 +541,34 @@ export const POST = withAuth(
                 await tx.trustedAdult.updateMany({ where: { trustedAdultPersonId: mergeId }, data: { trustedAdultPersonId: keepId } });
                 await tx.trustedAdult.updateMany({ where: { disclosedById: mergeId }, data: { disclosedById: keepId } });
 
+                // RawBadgeLog.personId is RESTRICT: a scan left on the tombstone pins
+                // that Person row in place forever.
+                moved.rawBadgeLogs = (await tx.rawBadgeLog.updateMany({ where: { personId: mergeId }, data: { personId: keepId } })).count;
+
+                // "Which staff member did this" facts, all SET NULL — left on the
+                // tombstone they read as nobody the moment the row goes.
+                moved.noteAcks = (await tx.orgMembershipProcess.updateMany({ where: { noteAckById: mergeId }, data: { noteAckById: keepId } })).count;
+                moved.attendanceConfirmations = (await tx.event.updateMany({ where: { attendanceConfirmedById: mergeId }, data: { attendanceConfirmedById: keepId } })).count;
+                moved.trustedAdultDecisions = (await tx.trustedAdultReview.updateMany({ where: { decidedById: mergeId }, data: { decidedById: keepId } })).count;
+
+                // PersonRole.personId is CASCADE — a role left on the tombstone is a
+                // security grant a later delete destroys with no audit row. PK is
+                // (personId, role), so move each role the survivor lacks and drop the
+                // duplicate: the survivor already holds that grant.
+                const keepRoles = new Set((await tx.personRole.findMany({ where: { personId: keepId }, select: { role: true } })).map(r => r.role));
+                for (const { role } of await tx.personRole.findMany({ where: { personId: mergeId }, select: { role: true } })) {
+                    const where = { personId_role: { personId: mergeId, role } };
+                    if (keepRoles.has(role)) {
+                        await tx.personRole.delete({ where });
+                        moved.roles.deduped++;
+                    } else {
+                        await tx.personRole.update({ where, data: { personId: keepId } });
+                        moved.roles.migrated++;
+                    }
+                }
+                // After the holder pass, so a granter stamp on a deduped row isn't counted.
+                moved.roleGrants = (await tx.personRole.updateMany({ where: { grantedById: mergeId }, data: { grantedById: keepId } })).count;
+
                 // bgAttestations: pre-refused collisions; left is defense-in-depth.
                 // corporationLeads/corporationMembers: bare joins, auto-dedupe.
                 const keepAttestProcessIds = new Set(keepParticipant.bgAttestations.map(a => a.processId));
@@ -518,6 +578,17 @@ export const POST = withAuth(
                         moved.bgAttestations.migrated++;
                     } else {
                         moved.bgAttestations.left++;
+                    }
+                }
+
+                // Subject side of the same rows: pre-refused collisions; left is
+                // defense-in-depth.
+                for (const att of mergeParticipant.bgAttestationsAsSubject) {
+                    if (!keepSubjectKeys.has(bgSubjectKey(att))) {
+                        await tx.backgroundCheckAttestation.update({ where: { id: att.id }, data: { subjectPersonId: keepId } });
+                        moved.bgAttestationSubjects.migrated++;
+                    } else {
+                        moved.bgAttestationSubjects.left++;
                     }
                 }
 


### PR DESCRIPTION
Part of #1456 (slice 2b-0). The minimum first PR of the Phase-2 plan: no schema
change, no migration, no boundary file, no dependency on the rest of Phase 2.

## The six relations

Six `Person` relations were never repointed by the participant merge. The rows
stay pinned to a record the rest of the app treats as nonexistent — and two of
them are why the tombstone can't simply be deleted later.

| Relation | FK | Why the repoint matters |
|---|---|---|
| `RawBadgeLog.personId` | **RESTRICT** | This is the one that gates future deletion. A scan left on the tombstone makes `DELETE FROM "Person"` fail, on essentially every real tombstone. Plain `updateMany` — no unique constraint. |
| `OrgMembershipProcess.noteAckById` | SET NULL | Who read a family's intake note. Left behind, it becomes "nobody read it" the moment the row goes. |
| `Event.attendanceConfirmedById` | SET NULL | Who confirmed attendance. Same erasure. |
| `TrustedAdultReview.decidedById` | SET NULL | Which board member decided a trusted-adult review. Same erasure. |
| `PersonRole.personId` | **CASCADE** | A role left on a tombstone is a security grant that a later delete destroys **silently, with no audit row**. Repointed with dedupe (Decision 4's default). |
| `PersonRole.grantedById` | SET NULL | Who granted the role. |
| `BackgroundCheckAttestation.subjectPersonId` | SET NULL | The adult an attestation names — and the second half of the collision problem below. |

All of it lands inside the existing transaction, with tallies in the audit
`moved` object alongside the existing ones.

**`PersonRole` dedupe.** `PersonRole`'s PK is `@@id([personId, role])` — a
composite PK, no surrogate id and no separate unique. So the holder repoint uses
the same loop-or-skip idiom already established for `bgAttestations`, keyed on
`personId_role`: move each role the survivor doesn't hold, delete the duplicate
when it does (the survivor already carries that grant). The audit records
`roles: { migrated, deduped }`, so nothing goes quietly. The `grantedById`
sweep runs **after** the holder pass, so a granter stamp on a row that was just
deduped isn't counted as moved.

## Collision-key widening (Decision 3, detection half)

`BackgroundCheckAttestation` carries
`@@unique([processId, reviewerId, subjectPersonId])`, but #1686's refusal — in
both the pre-transaction guard and the analyze route — keyed on `processId`
alone. That covers the reviewer side and misses the subject side entirely:
today it cannot even *detect* the case where both identities are the SUBJECT of
the same process.

Both surfaces now refuse two further collision classes, alongside the existing
process-level reviewer check (left as-is: "the same human attested under two
identities" is an integrity signal in its own right, not merely a constraint to
route around).

**`bgAttestationSubject`** — the exact `(processId, reviewerId)` pair, the part
of the triple a `subjectPersonId` repoint does not change:

- **Same reviewer named both identities under one process** → refuse. One
  reviewer reading the same human off a PDF twice under two identities: the
  P2002 the repoint would otherwise hit, and a fact worth a human's attention.
- **Two different reviewers each named one identity** → merges cleanly. That is
  an ordinary 2-of-N review, and after the merge both attestations correctly
  name one person. Refusing it would block the very dedupe this is for.

**`bgAttestationCrossRole`** — one record REVIEWED an attestation naming the
other as its SUBJECT. This one is not a constraint problem at all: only one row
exists, so **no unique fires**, and the `subjectPersonId` repoint silently
collapses it into `reviewerId === subjectPersonId`. `approvalsForSubject`
(`src/lib/membership/review.ts`) has no self-exclusion, so that self-approval
counts toward `REQUIRED_APPROVALS = 2`, and `attest()`'s same-household gate is
create-time only and never sees a merge. Refused in both directions.

The process-level reviewer check does **not** cover this case — it fires only
when both identities hold REVIEWER rows, and here only one does. Found by a
Fable cross-check of this PR and verified live against `deploy-db-1`; see the
comment below.

This slice is detection only — the sysadmin removal endpoint Decision 3 also
calls for is a separate PR, before R1.

## Tests

`merge/__tests__/route.integration.test.ts`, following the suite's existing
fixture idiom and per-test id-tracked cleanup (the new `RawBadgeLog` rows are
RESTRICT children, so they're torn down ahead of their `Person`; ditto
`TrustedAdultReview` ahead of `TrustedAdult`):

- One case per newly-repointed relation, each asserting the row lands on the
  survivor and the audit tally counts it.
- `PersonRole` dedupe: tombstone holds BOARD + KEYHOLDER, survivor holds BOARD →
  exactly two rows survive, both on the survivor, and the dropped duplicate is
  named in the audit.
- Ordering pin: a `grantedById` stamp on the row the dedupe deletes is **not**
  counted as moved, which fails if the granter sweep is moved ahead of the
  holder pass.
- `subjectPersonId` repoint under a second reviewer already naming the survivor —
  proving the widened key doesn't over-refuse.
- Subject-side collision → 409 naming it, nothing moved; and analyze reporting
  the same collision so the picker warns before the operator commits.
- Cross-role collision, both directions → 409 with the attestation untouched
  (`reviewerId !== subjectPersonId` still holds), plus analyze reporting it
  direction-independently.

## Verification

- `tsc --noEmit` clean; `eslint --max-warnings 0` clean on all three touched files.
- Full unit tier (`npx jest --ci --maxWorkers=12`): **283 suites / 2882 tests, all passing**.
- Merge integration suite: **82/82 passing** (69 before, 13 new).
- Revert-in-place proof on a repoint: dropping the `RawBadgeLog` `updateMany`
  fails its new test (`Expected: 0, Received: 1` — the scan stays on the
  tombstone) and nothing else; restored.
- Revert-in-place proof on the new guard: disabling the cross-role clause
  reproduces the reported defect exactly (both cross-role cases return
  `200` instead of `409`, and the row becomes a self-review); restored.

## Note on #1696

**#1696 (open) also touches `merge/__tests__/route.integration.test.ts`.** The
two sets of cases are independent — whichever lands second resolves the conflict
keep-both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URSrfChi89qKn1hLbjaX3K
