### PR TITLE
sec(registry): entry for DELETE bg-attestation (#1456 prerequisite)

### DIFF
--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -359,6 +359,26 @@ defineRoute({
     ],
 });
 
+// Sysadmin-only cleanup path for a BackgroundCheckAttestation the participant-
+// merge route refuses to carry forward: its collision check ("Both attested
+// the same background check", merge/route.ts) means the same human reviewed
+// under two Person identities, and nothing removes the duplicate row today.
+// Sysadmin-only, NOT board — attestations are review artifacts, not a
+// membership decision (#1456 Decision 3). No bag: the response is
+// { success: true }, no model data.
+//
+// Landed registry-first, ahead of the route, per the AGENTS.md boundary-
+// isolation rule: an unused defineRoute is inert, so the grant is reviewable
+// on its own before anything serves it.
+defineRoute({
+    endpoint: 'DELETE /api/membership-ops/bg-attestations/[id]',
+    authorize: { anyRole: ['isSysadmin'] },
+    envelope: null,
+    orderedView: [
+        ['isSysadmin', ['public']],
+    ],
+});
+
 // Background-check reviewers' queue. Reviewers must see applicant parents' names
 // + emails (to look them up on Averity) but NOT internal/personal fields — so the
 // grant is deliberately limited to pii + public. Board members are implicit


### PR DESCRIPTION
## Summary
- Registers `DELETE /api/membership-ops/bg-attestations/[id]` in `src/security/registry.ts`, sysadmin-only (`{ anyRole: ['isSysadmin'] }`), no bag (`envelope: null`).
- Registry-first per the `AGENTS.md` boundary-isolation rule: an unused `defineRoute` is inert, so this widening is reviewable in isolation before anything serves it. Precedent: #1459 (registry-only) unblocking #1387.
- Boundary-only diff — nothing else in this PR. `check-route-coverage --strict` reports the expected `[orphan-registry]` **warning** (not an error — "the register-first state while its route PR is pending") and 0 errors.

## Why
Part of #1456. Decision 3 (owner-accepted default, see the issue's ruling comment): a sysadmin-only endpoint to remove a `BackgroundCheckAttestation` row with a mandatory reason and an audit row, giving the participant-merge route's collision refusal ("Both attested the same background check") an actionable cleanup path. This PR is only the registry entry; the route handler follows in a stacked PR based on this branch.

Part of #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URSrfChi89qKn1hLbjaX3K