### PR TITLE
fix(kiosk): curfew-gate the attendance poller; exempt the supervision confirm from the debounce (#1347 PR-0)

### DIFF
--- a/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -49,6 +49,7 @@ jest.mock('@/lib/scan-service', () => ({
     processCheckout: jest.fn(),
     finalizeFacilityClose: jest.fn().mockResolvedValue(undefined),
     SUPERVISION_CONFIRM_MS: 15_000,
+    SUPERVISION_CONFIRM_DEADFRONT_MS: 1_000,
 }));
 
 describe('POST /api/scan', () => {
@@ -488,20 +489,59 @@ describe('POST /api/scan', () => {
         beforeEach(() => {
             (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'session', user: { id: '1' } });
             (prisma.person.findUnique as jest.Mock).mockResolvedValue({ id: 1, mergedIntoId: null });
-            // Inside the 3s debounce window -- only a fresh supervision stamp gets past it.
+            // Inside the 3s debounce window -- only a stamp past the dead-front floor gets past it.
             (prisma.rawBadgeLog.findFirst as jest.Mock).mockResolvedValue({ timestamp: new Date() });
             (prisma.visit.findFirst as jest.Mock).mockResolvedValue({ id: 7 });
             (processCheckout as jest.Mock).mockResolvedValue(
                 new Response(JSON.stringify({ type: 'checkout' }), { status: 200 }));
         });
 
-        it('exempts a scan 1s after a supervision warning from the debounce, no token needed', async () => {
-            (prisma.visit.count as jest.Mock).mockResolvedValue(1); // a fresh supervisionWarnedAt stamp
+        // Simulates a REAL supervisionWarnedAt of the given age against
+        // whatever [gte, lte] range route.ts actually constructs, instead of
+        // a blanket mockResolvedValue -- a dropped or loosened filter fails
+        // this the same way it would fail against a real database.
+        function mockCountForWarnedAtAge(ageMs: number) {
+            const warnedAt = new Date(Date.now() - ageMs);
+            (prisma.visit.count as jest.Mock).mockImplementation(
+                ({ where }: { where: { supervisionWarnedAt?: { gte: Date; lte?: Date } } }) => {
+                    const range = where.supervisionWarnedAt;
+                    // No lte in the where clause means no upper bound, same as a
+                    // real Prisma query -- so a dropped floor doesn't false-fail
+                    // this helper, only the case it actually breaks (below).
+                    const pastFloor = !range?.lte || warnedAt <= range.lte;
+                    return Promise.resolve(range && warnedAt >= range.gte && pastFloor ? 1 : 0);
+                }
+            );
+        }
+
+        it('exempts a scan 2s after a supervision warning, past the dead-front floor', async () => {
+            mockCountForWarnedAtAge(2000);
 
             const res = await POST(scanReq({ participantId: 1 }));
 
             expect((await res.json()).type).toBe('checkout');
             expect(processCheckout).toHaveBeenCalledWith({ id: 1, mergedIntoId: null }, 7, 'session', expect.anything(), null, expect.any(Date), null);
+            expect(prisma.visit.count).toHaveBeenCalledWith(expect.objectContaining({
+                where: expect.objectContaining({
+                    personId: 1,
+                    departedAt: null,
+                    deletedAt: null,
+                    supervisionWarnedAt: { gte: expect.any(Date), lte: expect.any(Date) },
+                }),
+            }));
+        });
+
+        // Fable review finding (2026-08-21): a USB hardware double-read of the
+        // WARNING scan itself (duplicate keystrokes ~300-800ms apart, no client
+        // dedup) must NOT read as a confirm -- pre-PR-0 it debounced, and the
+        // fix must not regress that into an unacknowledged auto-departure.
+        it('debounces a second badge 500ms after the warning -- a hardware double-read dead front', async () => {
+            mockCountForWarnedAtAge(500);
+
+            const res = await POST(scanReq({ participantId: 1 }));
+
+            expect((await res.json()).type).toBe('ignored_debounce');
+            expect(processCheckout).not.toHaveBeenCalled();
         });
 
         it('still debounces an ordinary double-tap with no fresh stamp and no token', async () => {

--- a/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
+++ b/checkin-app/src/app/api/scan/__tests__/scanRoute.test.ts
@@ -48,6 +48,7 @@ jest.mock('@/lib/scan-service', () => ({
     processCheckin: jest.fn(),
     processCheckout: jest.fn(),
     finalizeFacilityClose: jest.fn().mockResolvedValue(undefined),
+    SUPERVISION_CONFIRM_MS: 15_000,
 }));
 
 describe('POST /api/scan', () => {
@@ -428,10 +429,11 @@ describe('POST /api/scan', () => {
         });
 
         it('treats a non-string token as no token at all', async () => {
+            (prisma.visit.count as jest.Mock).mockResolvedValue(0); // no live token, no fresh supervision stamp either
             const res = await POST(scanReq({ participantId: 1, forceCloseToken: 42 }));
 
             expect((await res.json()).type).toBe('ignored_debounce');
-            expect(prisma.visit.count).not.toHaveBeenCalled();
+            expect(processCheckout).not.toHaveBeenCalled();
         });
 
         // §5.23a: the outbox persists the token with the queued event, so a
@@ -470,6 +472,44 @@ describe('POST /api/scan', () => {
             }));
 
             expect((await res.json()).type).toBe('parked');
+            expect(processCheckout).not.toHaveBeenCalled();
+        });
+    });
+
+    // #1347 PR-0 / Q16 remainder: the supervision confirm inherited the same
+    // debounce swallow the force-close confirm has a token for. The exemption
+    // is tied to a fresh supervisionWarnedAt stamp, no second token minted.
+    describe('supervision confirm exemption from the debounce', () => {
+        const scanReq = (body: Record<string, unknown>) => new Request('http://localhost/api/scan', {
+            method: 'POST',
+            body: JSON.stringify(body),
+        }) as unknown as import('next/server').NextRequest;
+
+        beforeEach(() => {
+            (authenticateRequest as jest.Mock).mockResolvedValue({ type: 'session', user: { id: '1' } });
+            (prisma.person.findUnique as jest.Mock).mockResolvedValue({ id: 1, mergedIntoId: null });
+            // Inside the 3s debounce window -- only a fresh supervision stamp gets past it.
+            (prisma.rawBadgeLog.findFirst as jest.Mock).mockResolvedValue({ timestamp: new Date() });
+            (prisma.visit.findFirst as jest.Mock).mockResolvedValue({ id: 7 });
+            (processCheckout as jest.Mock).mockResolvedValue(
+                new Response(JSON.stringify({ type: 'checkout' }), { status: 200 }));
+        });
+
+        it('exempts a scan 1s after a supervision warning from the debounce, no token needed', async () => {
+            (prisma.visit.count as jest.Mock).mockResolvedValue(1); // a fresh supervisionWarnedAt stamp
+
+            const res = await POST(scanReq({ participantId: 1 }));
+
+            expect((await res.json()).type).toBe('checkout');
+            expect(processCheckout).toHaveBeenCalledWith({ id: 1, mergedIntoId: null }, 7, 'session', expect.anything(), null, expect.any(Date), null);
+        });
+
+        it('still debounces an ordinary double-tap with no fresh stamp and no token', async () => {
+            (prisma.visit.count as jest.Mock).mockResolvedValue(0);
+
+            const res = await POST(scanReq({ participantId: 1 }));
+
+            expect((await res.json()).type).toBe('ignored_debounce');
             expect(processCheckout).not.toHaveBeenCalled();
         });
     });

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -2,7 +2,7 @@ import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { apiError, apiJson } from "@/lib/api-response";
-import { processCheckin, processCheckout, finalizeFacilityClose, SUPERVISION_CONFIRM_MS } from "@/lib/scan-service";
+import { processCheckin, processCheckout, finalizeFacilityClose, SUPERVISION_CONFIRM_MS, SUPERVISION_CONFIRM_DEADFRONT_MS } from "@/lib/scan-service";
 import { config } from "@/lib/config";
 import { withKiosk } from "@/lib/kioskAuth";
 
@@ -179,7 +179,11 @@ export const POST = withKiosk(
             // scan following a fresh supervisionWarnedAt stamp IS the supervision
             // confirm (#1347 PR-0, decision 7) -- both must skip the debounce below.
             // Tied to the warning actually being shown, not badge adjacency; the
-            // token clause is unchanged and stays primary.
+            // token clause is unchanged and stays primary. The stamp side is
+            // floored at SUPERVISION_CONFIRM_DEADFRONT_MS: a USB double-read of
+            // the warning scan itself lands well under that age and must still
+            // debounce, or the room's warning would auto-confirm with no human
+            // acknowledgment at all.
             const isConfirm = (confirmToken !== null && (await tx.visit.count({
                 where: {
                     personId: participant.id,
@@ -192,7 +196,10 @@ export const POST = withKiosk(
                     personId: participant.id,
                     departedAt: null,
                     deletedAt: null,
-                    supervisionWarnedAt: { gte: new Date(Date.now() - SUPERVISION_CONFIRM_MS) },
+                    supervisionWarnedAt: {
+                        gte: new Date(Date.now() - SUPERVISION_CONFIRM_MS),
+                        lte: new Date(Date.now() - SUPERVISION_CONFIRM_DEADFRONT_MS),
+                    },
                 },
             })) > 0;
 

--- a/checkin-app/src/app/api/scan/route.ts
+++ b/checkin-app/src/app/api/scan/route.ts
@@ -2,7 +2,7 @@ import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { logger } from "@/lib/logger";
 import { apiError, apiJson } from "@/lib/api-response";
-import { processCheckin, processCheckout, finalizeFacilityClose } from "@/lib/scan-service";
+import { processCheckin, processCheckout, finalizeFacilityClose, SUPERVISION_CONFIRM_MS } from "@/lib/scan-service";
 import { config } from "@/lib/config";
 import { withKiosk } from "@/lib/kioskAuth";
 
@@ -175,15 +175,24 @@ export const POST = withKiosk(
                 }
             }
 
-            // A scan echoing a live confirm token IS the force-close confirm, so
-            // the debounce must not swallow it (§5.16). Single-use: the confirm
-            // spends the token, so a stray second read debounces as usual.
-            const isConfirm = confirmToken !== null && (await tx.visit.count({
+            // A scan echoing a live confirm token IS the force-close confirm, and a
+            // scan following a fresh supervisionWarnedAt stamp IS the supervision
+            // confirm (#1347 PR-0, decision 7) -- both must skip the debounce below.
+            // Tied to the warning actually being shown, not badge adjacency; the
+            // token clause is unchanged and stays primary.
+            const isConfirm = (confirmToken !== null && (await tx.visit.count({
                 where: {
                     personId: participant.id,
                     departedAt: null,
                     deletedAt: null,
                     forceCloseToken: confirmToken,
+                },
+            })) > 0) || (await tx.visit.count({
+                where: {
+                    personId: participant.id,
+                    departedAt: null,
+                    deletedAt: null,
+                    supervisionWarnedAt: { gte: new Date(Date.now() - SUPERVISION_CONFIRM_MS) },
                 },
             })) > 0;
 

--- a/checkin-app/src/lib/__tests__/scanServiceSupervisionInterrupt.test.ts
+++ b/checkin-app/src/lib/__tests__/scanServiceSupervisionInterrupt.test.ts
@@ -93,7 +93,7 @@ describe("rung 2 — the next supervising adult leaves", () => {
         expect(res.status).toBe(400);
         expect(body.type).toBe("warning");
         expect(body.error).toMatch(/only 1 supervising adult/);
-        expect(body.error).toMatch(/3 to 15 seconds/);
+        expect(body.error).toMatch(/within 15 seconds/);
         expect(update).toHaveBeenCalledWith({
             where: { id: DEPARTING_VISIT },
             data: { supervisionWarnedAt: expect.any(Date) },
@@ -102,6 +102,16 @@ describe("rung 2 — the next supervising adult leaves", () => {
 
     it("lets the checkout through on a scan that follows a fresh stamp", async () => {
         const { res, body } = await checkout([10, 20], new Date(Date.now() - 8_000));
+
+        expect(res.status).toBe(200);
+        expect(body.type).toBe("checkout");
+    });
+
+    it("confirms and departs on a second badge just 1s after the warning (#1347 PR-0)", async () => {
+        // The route's debounce used to swallow exactly this scan; the ladder
+        // itself was never the problem -- it accepts any stamp inside the
+        // window, however close to the warning.
+        const { res, body } = await checkout([10, 20], new Date(Date.now() - 1_000));
 
         expect(res.status).toBe(200);
         expect(body.type).toBe("checkout");

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -19,6 +19,11 @@ export const FORCE_CLOSE_CONFIRM_SECONDS = 15;
  *  full window is usable -- kiosk copy says "within 15 seconds". */
 export const SUPERVISION_CONFIRM_MS = 15_000;
 
+/** Floor on the route's debounce exemption (Fable review, #1347 PR-0): a USB
+ *  hardware double-read of the warning scan lands ~300-800ms later with the
+ *  stamp already fresh. Below this age, treat it as the same physical badge. */
+export const SUPERVISION_CONFIRM_DEADFRONT_MS = 1_000;
+
 /**
  * Process a check-in for a participant who has no active visit.
  *

--- a/checkin-app/src/lib/scan-service.ts
+++ b/checkin-app/src/lib/scan-service.ts
@@ -14,9 +14,10 @@ import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
  *  gate — see the confirm check in processCheckout. */
 export const FORCE_CLOSE_CONFIRM_SECONDS = 15;
 
-/** Countdown on the supervision confirm (#1436). Same 3s debounce eats the front,
- *  so the kiosk copy says "3 to 15 seconds". */
-const SUPERVISION_CONFIRM_MS = 15_000;
+/** Countdown on the supervision confirm (#1436). #1347 PR-0 extended the
+ *  route's debounce exemption to a fresh `supervisionWarnedAt` stamp, so the
+ *  full window is usable -- kiosk copy says "within 15 seconds". */
+export const SUPERVISION_CONFIRM_MS = 15_000;
 
 /**
  * Process a check-in for a participant who has no active visit.
@@ -294,7 +295,7 @@ async function supervisionInterrupt(
     return {
         confirmRequired: true,
         response: apiJson({
-            error: `Warning! Checking out leaves ${left} in the building.\n\nBadge again in 3 to ${SUPERVISION_CONFIRM_MS / 1000} seconds to confirm.`,
+            error: `Warning! Checking out leaves ${left} in the building.\n\nBadge again within ${SUPERVISION_CONFIRM_MS / 1000} seconds to confirm.`,
             type: "warning" as const,
         }, 400),
     };

--- a/client/client.py
+++ b/client/client.py
@@ -23,7 +23,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler, ThreadingHTTPServer
 from nacl.signing import SigningKey
 import requests
 
-from outbox import Outbox, classify_response, replay_drain, new_event_id, now_iso
+from outbox import Outbox, classify_response, replay_drain, new_event_id, now_iso, in_closed_window
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -744,12 +744,16 @@ def handle_scan(backend, state, outbox, participant_id):
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
-def attendance_poller(backend, state, interval=30):
+def attendance_poller(backend, state, interval=30, sleep_fn=time.sleep,
+                       in_closed_window_fn=in_closed_window):
     """Background thread that polls attendance counts periodically.
     Pushes SSE status events when counts change so the blackout
-    logic works on display-only kiosks without a scanner."""
+    logic works on display-only kiosks without a scanner. §3.1/Q17: a
+    24/7 kiosk must not defeat the overnight curfew with signed GETs."""
     while True:
-        time.sleep(interval)
+        sleep_fn(interval)
+        if in_closed_window_fn():
+            continue
         att_data, att_status = backend.get_attendance()
         if att_status == 200 and "counts" in att_data:
             new_counts = att_data["counts"]

--- a/client/client.py
+++ b/client/client.py
@@ -789,7 +789,8 @@ def _should_restart_for_update(remote_head, last_restart_target):
     # never-tried or newly-advanced target.
     return remote_head != last_restart_target
 
-def version_poller(backend, state, interval=60, state_path=SELF_UPDATE_STATE_FILE):
+def version_poller(backend, state, interval=60, state_path=SELF_UPDATE_STATE_FILE,
+                    in_closed_window_fn=in_closed_window):
     """Background thread that checks for client and server version updates."""
     last_restart_target = _read_last_restart_target(state_path)
 
@@ -802,18 +803,21 @@ def version_poller(backend, state, interval=60, state_path=SELF_UPDATE_STATE_FIL
             log.info(f"Initial server version: {initial_server_version}")
             break
         time.sleep(5)
-    
+
     while True:
         time.sleep(interval)
-        
-        # 1. Check Server Version Update
-        if initial_server_version:
+
+        # 1. Check Server Version Update -- skipped during the closed window
+        # (§3.1): this signed GET keep-alives the service same as
+        # attendance_poller's. Self-update below is NOT gated: git pull hits
+        # no server, and overnight is the safe window to restart in.
+        if initial_server_version and not in_closed_window_fn():
             sv, status = backend.get_server_version()
             if status == 200 and sv and sv != initial_server_version:
                 log.info(f"Server version changed from {initial_server_version} to {sv}. Requesting reload.")
                 state.push_event({"reload": True})
                 initial_server_version = sv  # Update to prevent spam
-        
+
         # 2. Check Client Version Update
         try:
             subprocess.run(["git", "fetch", "origin", "main"], capture_output=True, timeout=15)

--- a/client/test_client.py
+++ b/client/test_client.py
@@ -2,6 +2,7 @@ import inspect
 import json
 import os
 import unittest
+from datetime import datetime
 from unittest.mock import MagicMock, Mock, patch
 
 from nacl.signing import SigningKey
@@ -11,10 +12,15 @@ from client import (
     BackendClient,
     DEFAULT_KIOSK_PATH,
     _scan_result_banner_html,
+    attendance_poller,
     handle_scan,
     main,
 )
-from outbox import Outbox
+from outbox import Outbox, in_closed_window
+
+
+class _StopLoop(Exception):
+    """Sentinel to escape attendance_poller's `while True` in tests."""
 
 
 def scan_banner(body, status=200):
@@ -192,6 +198,38 @@ class TestForceCloseConfirm(unittest.TestCase):
         backend.post_scan.assert_not_called()
         queued = [r for r in outbox.pending_rows() if r[0] != "evt-0"]
         self.assertEqual(queued[0][4], "tok-2")
+
+class TestAttendancePollerClosedWindow(unittest.TestCase):
+    """§3.1/Q17: unlike the outbox drain, the poller had no closed-window
+    gate -- a 24/7 kiosk pointed at prod defeats the overnight curfew with
+    signed GETs every 30s."""
+
+    def _run(self, in_closed_window_fn, iterations=2):
+        backend = Mock(attendance_path="/attendance/current")
+        backend.get_attendance.return_value = ({"counts": {"total": 1}}, 200)
+        state = AttendanceState()
+        state.push_event = lambda event: None
+
+        calls = {"n": 0}
+
+        def fake_sleep(secs):
+            calls["n"] += 1
+            if calls["n"] >= iterations:
+                raise _StopLoop()
+
+        with self.assertRaises(_StopLoop):
+            attendance_poller(backend, state, sleep_fn=fake_sleep,
+                               in_closed_window_fn=in_closed_window_fn)
+        return backend
+
+    def test_swallows_the_fetch_at_2330(self):
+        backend = self._run(lambda: in_closed_window(datetime(2026, 8, 18, 23, 30)))
+        backend.get_attendance.assert_not_called()
+
+    def test_polls_at_1200(self):
+        backend = self._run(lambda: in_closed_window(datetime(2026, 8, 18, 12, 0)))
+        backend.get_attendance.assert_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/client/test_self_update_guard.py
+++ b/client/test_self_update_guard.py
@@ -103,5 +103,49 @@ class TestVersionPollerLoopGuard(unittest.TestCase):
         self.assertTrue(any("Not restarting" in m for m in logs.output))
 
 
+class TestVersionPollerClosedWindow(unittest.TestCase):
+    """§3.1: the server-version GET is a keep-alive same as attendance_poller's
+    -- it must not fire during the closed window. Self-update (git, no
+    network to the server) is unaffected: it's meant to run overnight."""
+
+    def _run(self, in_closed_window_fn, iterations=2):
+        backend = MagicMock()
+        backend.get_server_version.return_value = ("v1", 200)
+        state = MagicMock()
+
+        calls = {"n": 0}
+
+        def fake_sleep(_):
+            calls["n"] += 1
+            if calls["n"] >= iterations:
+                raise _StopLoop()
+
+        with tempfile.TemporaryDirectory() as d:
+            state_path = os.path.join(d, "state")
+            with patch("client.subprocess.run") as run_mock, \
+                 patch("client.subprocess.check_output", return_value="same\n"), \
+                 patch("client.time.sleep", side_effect=fake_sleep):
+                with self.assertRaises(_StopLoop):
+                    version_poller(backend, state, interval=0, state_path=state_path,
+                                   in_closed_window_fn=in_closed_window_fn)
+        return backend, run_mock
+
+    def test_swallows_the_version_get_at_2330(self):
+        from datetime import datetime
+        from outbox import in_closed_window
+        backend, run_mock = self._run(lambda: in_closed_window(datetime(2026, 8, 18, 23, 30)))
+        # One call during the initial-version bootstrap loop, none from the
+        # gated recurring check.
+        self.assertEqual(backend.get_server_version.call_count, 1)
+        # Self-update (git fetch) is NOT gated -- overnight is its safe window.
+        run_mock.assert_called()
+
+    def test_polls_the_version_get_at_1200(self):
+        from datetime import datetime
+        from outbox import in_closed_window
+        backend, _ = self._run(lambda: in_closed_window(datetime(2026, 8, 18, 12, 0)))
+        self.assertGreater(backend.get_server_version.call_count, 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two independent, one-line-class defects from the kiosk-resilience epic's PR-0 slice (see #1347's plan comment). They share no files; landed as one PR per the plan's note that they're splittable but fine together.

### 1. `client/client.py` — the poller threads defeat the overnight curfew

The outbox drain already sleeps through the 23:00–06:00 closed window (`in_closed_window()` in `outbox.py`), but two other background threads had no such gate:

- `attendance_poller` — an unconditional signed GET every 30s.
- `version_poller` — an unconditional signed GET to `/api/system-status/kiosk-version` every 60s.

A kiosk pointed at prod 24/7 kept the service warm all night through either one — this is the keep-alive cost shape from the 2026-07-17 overnight incident, possibly leaking money today. Fix: both reuse `in_closed_window()` (imported, not reimplemented) and skip their fetch while closed. `version_poller`'s self-update half (git fetch/rev-parse against `origin/main`, no request to the server) is deliberately left ungated — overnight is the safe restart window, nobody's badging.

### 2. `checkin-app/src/app/api/scan/route.ts` — the supervision confirm inherits the force-close debounce bug

`route.ts`'s debounce exemption (`isConfirm`) keyed only on `forceCloseToken`. The supervision-interrupt confirm (#1436/#1670) mints no token — it accepts a re-scan within `SUPERVISION_CONFIRM_MS` (15s) of `Visit.supervisionWarnedAt` — so a second badge inside the 3s debounce window was silently swallowed before `processCheckout` ever saw it. The working confirm window was really `[3s, 15s]`, and the code said so itself:

```ts
/** Countdown on the supervision confirm (#1436). Same 3s debounce eats the front,
 *  so the kiosk copy says "3 to 15 seconds". */
```

A youth-present room's last-but-one supervising adult double-badging to leave could not check out and got no feedback.

**Decision 7** (ratified in the issue #1347 review): extend the existing debounce exemption to a scan against the person's open Visit whose `supervisionWarnedAt` is fresh, rather than minting a second token. The stamp is only ever written when a warning was actually shown, tying the confirm to that fact the same way the token ties it to force-close. The token clause is unchanged and stays primary; the token machinery is still there to drop in if the stamp-based exemption ever proves too loose.

**Fable cross-check finding (fixed in this PR):** the naive stamp-fresh exemption is not single-use. A USB hardware double-read of the WARNING scan itself (duplicate evdev keystrokes ~300–800ms apart, no client dedup) lands with the stamp already fresh, so the exemption skipped the debounce and `processCheckout` auto-departed the last-but-one adult with zero human acknowledgment — a regression in the very interlock this PR set out to strengthen (pre-PR, that second read debounced and the warning stood). Fixed by flooring the exemption at a new `SUPERVISION_CONFIRM_DEADFRONT_MS` (1s, exported from `scan-service.ts` beside `SUPERVISION_CONFIRM_MS`): the stamp must be `>= 1s` old **and** `<= SUPERVISION_CONFIRM_MS` old. A dead front invisible to a human keyholder; decision 7's semantics are otherwise unchanged, and the "within 15 seconds" copy stays honest since only the window's first second is unusable.

Also: `SUPERVISION_CONFIRM_MS` is now exported from `scan-service.ts` as the single source of truth (route.ts imports it rather than re-deriving the window), and the kiosk copy drops the dead front — "3 to 15 seconds" → "within 15 seconds".

## Tests

- `client/test_client.py`: `attendance_poller` swallows the fetch at 23:30, polls normally at 12:00 (fake-clock idiom mirroring `replay_drain`'s `sleep_fn`/`in_closed_window_fn` injection).
- `client/test_self_update_guard.py`: `version_poller`'s server-version GET is swallowed at 23:30 and runs at 12:00; the self-update `subprocess.run` call still fires during the closed window either way.
- `scanRoute.test.ts`: a stamp 2s old is exempt from the debounce (with the `visit.count` where-clause pinned — `personId`/`departedAt`/`deletedAt`/`gte`/`lte` — so a dropped or loosened filter fails the test instead of passing silently); a stamp 500ms old (the hardware dead-front case) still debounces; still debounces with neither a token nor a fresh stamp. Also fixed a pre-existing assertion (`visit.count` no longer stays uncalled for a tokenless scan, since the supervision check always runs).
- `scanServiceSupervisionInterrupt.test.ts`: a second badge just 1s after the warning confirms and departs (scan-service's own ladder has no floor — only the route's debounce exemption does); updated the "3 to 15 seconds" copy assertion.

**Revert-in-place proofs:**
- Restored the token-only `isConfirm` condition → the new supervision-exemption test failed (`ignored_debounce` instead of `checkout`), all other tests unaffected. Restored.
- Dropped the `lte` dead-front floor → the 500ms test failed (`checkout` instead of `ignored_debounce`, reproducing the auto-departure) and the pinned where-clause assertion failed on the missing `lte`. Restored; all green again.

## Verification

- Python: `python3 -m unittest discover` from `client/` — 55/55 passed.
- `npx tsc --noEmit` — clean.
- `npx eslint` on touched files — clean.
- Full unit tier: `npx jest --ci --maxWorkers=12` — 283 suites / 2886 tests passed.
- Scan integration tier: `INTEGRATION_DB=1 npx jest --ci --maxWorkers=12 --testPathIgnorePatterns=/node_modules/ --testPathPatterns='scan.*\.integration\.test\.ts'` — 5 suites / 28 tests passed.

## Follow-ups (not this PR)

- `Visit.supervisionWarnedAt` is never cleared on departure. Inert today — every lookup filters `departedAt: null` — but it contradicts `processCheckout`'s no-live-state-on-closed-rows principle (the same reasoning that already clears `forceCloseToken`/`forceCloseWarnedAt` on close). Worth folding into the substrate slice.
- A non-departing confirm outcome (e.g. a keyholder warning fires again inside the window) keeps the stamp-based exemption alive for the rest of the window rather than resetting it. Bounded by `SUPERVISION_CONFIRM_MS` either way; noted, not fixed here.

Part of #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URSrfChi89qKn1hLbjaX3K
