### PR TITLE
feat(membership-ops): remove a background-check attestation with reason + audit (#1456 prerequisite)

### DIFF
--- a/checkin-app/src/__tests__/authzRegistry.test.ts
+++ b/checkin-app/src/__tests__/authzRegistry.test.ts
@@ -97,6 +97,9 @@ const AUTHZ_TESTED = new Set<string>([
     'membership-ops/applications/certify-payment',
     'membership-ops/applications/external',
     'membership-ops/applications/review-override',
+    // 401/403 deny-path in authzRoleRejection.integration.test.ts, incl. a
+    // dedicated board-alone-is-denied case (sysadmin-only, not board).
+    'membership-ops/bg-attestations/[id]',
     // POST deny-path (401 anon / 403 plain / 403 sysadmin-excluded) in
     // membership-ops/contacts/__tests__/route.integration.test.ts.
     'membership-ops/contacts',

--- a/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
+++ b/checkin-app/src/app/__tests__/authzRoleRejection.integration.test.ts
@@ -54,6 +54,7 @@ import { POST as APP_EXTERNAL_POST } from '@/app/api/membership-ops/applications
 import { POST as REVIEW_OVERRIDE_POST } from '@/app/api/membership-ops/applications/review-override/route';
 import { POST as APP_ARCHIVE_POST } from '@/app/api/membership-ops/applications/archive/route';
 import { POST as APP_UNARCHIVE_POST } from '@/app/api/membership-ops/applications/unarchive/route';
+import { DELETE as BG_ATTEST_DELETE } from '@/app/api/membership-ops/bg-attestations/[id]/route';
 import { GET as MOPS_HH_GET, POST as MOPS_HH_POST } from '@/app/api/membership-ops/households/route';
 import { GET as VOL_ROSTER_GET } from '@/app/api/membership-ops/volunteer-memberships/route';
 import { POST as REVIEWS_POST } from '@/app/api/membership/reviews/route';
@@ -201,6 +202,7 @@ describe('Protected-route role rejection', () => {
         { name: 'POST /api/membership-ops/applications/review-override', invoke: () => REVIEW_OVERRIDE_POST(nreq('http://localhost/api/membership-ops/applications/review-override', 'POST', {})) },
         { name: 'POST /api/membership-ops/applications/archive', invoke: () => APP_ARCHIVE_POST(nreq('http://localhost/api/membership-ops/applications/archive', 'POST', {})) },
         { name: 'POST /api/membership-ops/applications/unarchive', invoke: () => APP_UNARCHIVE_POST(nreq('http://localhost/api/membership-ops/applications/unarchive', 'POST', {})) },
+        { name: 'DELETE /api/membership-ops/bg-attestations/[id] (sysadmin-only)', invoke: () => BG_ATTEST_DELETE(nreq('http://localhost/api/membership-ops/bg-attestations/1', 'DELETE', { reason: 'test' }), idCtx(1)) },
         { name: 'GET /api/membership-ops/households (collection)', invoke: () => MOPS_HH_GET(nreq('http://localhost/api/membership-ops/households')) },
         { name: 'POST /api/membership-ops/households (collection)', invoke: () => MOPS_HH_POST(nreq('http://localhost/api/membership-ops/households', 'POST', {})) },
         { name: 'GET /api/membership-ops/volunteer-memberships', invoke: () => VOL_ROSTER_GET(nreq('http://localhost/api/membership-ops/volunteer-memberships')) },
@@ -232,6 +234,17 @@ describe('Protected-route role rejection', () => {
         it('403 for a plain authenticated user (no privileged role)', async () => {
             as(plainId, { householdId: plainHh });
             expect((await invoke()).status).toBe(403);
+        });
+    });
+
+    // ---- bg-attestations DELETE — sysadmin-only, NOT board (#1456 Decision 3) --
+    // Attestations are review artifacts, not a membership decision, so the
+    // board's usual "board OR sysadmin" reach does not extend here.
+    describe('DELETE /api/membership-ops/bg-attestations/[id] — board alone is denied', () => {
+        it('403s a board member who is not also sysadmin', async () => {
+            as(plainId, { householdId: plainHh, isBoardMember: true });
+            const res = await BG_ATTEST_DELETE(nreq('http://localhost/api/membership-ops/bg-attestations/1', 'DELETE', { reason: 'test' }), idCtx(1));
+            expect(res.status).toBe(403);
         });
     });
 

--- a/checkin-app/src/app/api/membership-ops/bg-attestations/[id]/__tests__/route.integration.test.ts
+++ b/checkin-app/src/app/api/membership-ops/bg-attestations/[id]/__tests__/route.integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment node
+ *
+ * Integration tests for DELETE /api/membership-ops/bg-attestations/[id] —
+ * the sysadmin-only cleanup path for a BackgroundCheckAttestation the
+ * participant-merge route refuses to carry forward (#1456 Decision 3).
+ * Real Postgres, INTEGRATION_DB=1.
+ *
+ * 401/403 (incl. board-only) live in authzRoleRejection.integration.test.ts,
+ * the shared table for role-gated routes. This file covers the route's own
+ * behavior: 400 without a reason, 404 on a missing/unknown id, success
+ * (row gone + an audit row carrying the reason and the deleted row's
+ * fields), and the end-to-end case this endpoint exists for — unblocking a
+ * merge the collision check refused.
+ */
+import { DELETE } from '../route';
+import { POST as MERGE_POST } from '@/app/api/membership-ops/participants/merge/route';
+import prisma from '@/lib/prisma';
+import { getServerSession } from 'next-auth/next';
+import { expectAuditRow, auditJson } from '@/test-helpers/expectAuditRow';
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/email', () => ({ runPaced: (tasks: Array<() => Promise<unknown>>) => Promise.all(tasks.map((t) => t())), sendEmail: jest.fn().mockResolvedValue(true) }));
+
+const TAG = 'bg-attestation-remove-test';
+
+function asSysadmin(id: number) {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id, isSysadmin: true } });
+}
+
+function delReq(id: number | string, body?: unknown) {
+    return new Request(`http://localhost/api/membership-ops/bg-attestations/${id}`, {
+        method: 'DELETE',
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    }) as never;
+}
+function ctx(id: number | string) {
+    return { params: Promise.resolve({ id: String(id) }) } as never;
+}
+
+describe('DELETE /api/membership-ops/bg-attestations/[id]', () => {
+    let householdId: number;
+    let reviewerId: number;
+    let sysadminId: number;
+    let processId: number;
+    let attestationId: number;
+    // Ids an individual test creates beyond the base fixture, swept generically
+    // in afterEach (RESTRICT-FK children before their Person rows).
+    let extraPersonIds: number[];
+    let extraHouseholdIds: number[];
+
+    beforeEach(async () => {
+        extraPersonIds = [];
+        extraHouseholdIds = [];
+
+        const hh = await prisma.household.create({ data: { name: `HH ${TAG}` } });
+        householdId = hh.id;
+        reviewerId = (await prisma.person.create({ data: { name: `Reviewer ${TAG}`, householdId } })).id;
+        sysadminId = (await prisma.person.create({ data: { name: `Sysadmin ${TAG}`, isSysadmin: true, householdId } })).id;
+        processId = (await prisma.orgMembershipProcess.create({ data: { kind: 'PERSON_BG', status: 'PENDING_BG_REVIEW' } })).id;
+        attestationId = (await prisma.backgroundCheckAttestation.create({
+            data: { processId, reviewerId, result: 'APPROVE', note: 'looked fine' },
+        })).id;
+        asSysadmin(sysadminId);
+    });
+
+    afterEach(async () => {
+        const personIds = [reviewerId, sysadminId, ...extraPersonIds];
+        await prisma.backgroundCheckAttestation.deleteMany({ where: { OR: [{ processId }, { reviewerId: { in: personIds } }] } });
+        await prisma.auditLog.deleteMany({ where: { OR: [{ affectedEntityId: attestationId, tableName: 'BackgroundCheckAttestation' }, { actorId: { in: personIds } }] } });
+        await prisma.orgMembershipProcess.deleteMany({ where: { id: processId } });
+        await prisma.person.deleteMany({ where: { id: { in: personIds } } });
+        await prisma.orgMembership.deleteMany({ where: { householdId: { in: [householdId, ...extraHouseholdIds] } } });
+        await prisma.household.deleteMany({ where: { id: { in: [householdId, ...extraHouseholdIds] } } });
+    });
+
+    it('400s without a reason, and leaves the row in place', async () => {
+        const res = await DELETE(delReq(attestationId, {}), ctx(attestationId));
+        expect(res.status).toBe(400);
+        expect(await prisma.backgroundCheckAttestation.findUnique({ where: { id: attestationId } })).not.toBeNull();
+    });
+
+    it('400s on a non-numeric id', async () => {
+        const res = await DELETE(delReq('abc', { reason: 'typo id' }), ctx('abc'));
+        expect(res.status).toBe(400);
+    });
+
+    it('404s for an id with no matching row', async () => {
+        const res = await DELETE(delReq(attestationId + 999_000, { reason: 'not real' }), ctx(attestationId + 999_000));
+        expect(res.status).toBe(404);
+    });
+
+    it('deletes the row and writes an audit row carrying the reason', async () => {
+        const res = await DELETE(delReq(attestationId, { reason: 'duplicate identity — reviewed under two accounts' }), ctx(attestationId));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ success: true });
+
+        expect(await prisma.backgroundCheckAttestation.findUnique({ where: { id: attestationId } })).toBeNull();
+
+        const audit = await expectAuditRow(prisma, {
+            action: 'DELETE',
+            tableName: 'BackgroundCheckAttestation',
+            affectedEntityId: attestationId,
+            secondaryAffectedEntity: processId,
+        });
+        expect(audit.actorId).toBe(sysadminId);
+        expect(auditJson(audit.newData)).toEqual({ reason: 'duplicate identity — reviewed under two accounts' });
+        expect(auditJson(audit.oldData)).toMatchObject({ processId, reviewerId, result: 'APPROVE', note: 'looked fine' });
+    });
+
+    // The scenario this endpoint exists for (#1456 Decision 3): the merge route
+    // refuses when both merge subjects attested the same background check, and
+    // deleting one of the two duplicate rows is what turns the refusal into a
+    // mergeable state.
+    it('unblocks a merge the bgAttestation collision check refused', async () => {
+        const otherReviewerId = (await prisma.person.create({ data: { name: `Other Reviewer ${TAG}`, householdId } })).id;
+        const actorHh = (await prisma.household.create({ data: { name: `Actor HH ${TAG}` } })).id;
+        const actorId = (await prisma.person.create({ data: { name: `Merge Actor ${TAG}`, isBoardMember: true, householdId: actorHh } })).id;
+        extraPersonIds.push(otherReviewerId, actorId);
+        extraHouseholdIds.push(actorHh);
+
+        // Both hold an attestation on the SAME process — the collision.
+        const dupeAttestationId = (await prisma.backgroundCheckAttestation.create({
+            data: { processId, reviewerId: otherReviewerId, result: 'APPROVE' },
+        })).id;
+
+        const mergeReq = () => new Request('http://localhost/api/membership-ops/participants/merge', {
+            method: 'POST',
+            body: JSON.stringify({ keepId: reviewerId, mergeId: otherReviewerId, fieldChoices: { name: 'keep' } }),
+        }) as never;
+
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: actorId, isBoardMember: true } });
+        const refused = await MERGE_POST(mergeReq());
+        expect(refused.status).toBe(409);
+        const refusedBody = await refused.json();
+        expect((refusedBody.collisions as { type: string }[]).map((c) => c.type)).toContain('bgAttestation');
+
+        asSysadmin(sysadminId);
+        const cleanup = await DELETE(delReq(dupeAttestationId, { reason: 'duplicate identity, confirmed by board' }), ctx(dupeAttestationId));
+        expect(cleanup.status).toBe(200);
+
+        (getServerSession as jest.Mock).mockResolvedValue({ user: { id: actorId, isBoardMember: true } });
+        const retried = await MERGE_POST(mergeReq());
+        expect(retried.status).toBe(200);
+    });
+});

--- a/checkin-app/src/app/api/membership-ops/bg-attestations/[id]/route.ts
+++ b/checkin-app/src/app/api/membership-ops/bg-attestations/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { withAuth } from "@/lib/auth";
+import { apiError } from "@/lib/api-response";
+import { logBackendError } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+/** Thrown inside the transaction when the id no longer resolves — caught below and mapped to a 404. */
+class NotFoundError extends Error {}
+
+/**
+ * DELETE /api/membership-ops/bg-attestations/[id] — sysadmin-only cleanup for a
+ * BackgroundCheckAttestation the participant-merge route refuses to carry
+ * forward ("Both attested the same background check", merge/route.ts): the
+ * same human reviewed under two Person identities, and nothing else removes
+ * the duplicate. Body: { reason: string } (mandatory, non-empty).
+ *
+ * Leaves OrgMembershipProcess.status untouched — see the PR body for the
+ * process-status coupling this was checked against and why it's a no-op here.
+ */
+export const DELETE = withAuth<{ params: Promise<{ id: string }> }>(
+    { roles: ["isSysadmin"] },
+    async (req, auth, { params }) => {
+        if (auth.type !== "session") return apiError("Unauthorized", 401);
+
+        const id = Number((await params).id);
+        if (!Number.isInteger(id)) return apiError("Invalid attestation id", 400);
+
+        let body: { reason?: unknown };
+        try {
+            body = await req.json();
+        } catch {
+            return apiError("Invalid JSON", 400);
+        }
+        const reason = typeof body.reason === "string" ? body.reason.trim() : "";
+        if (!reason) return apiError("A reason is required", 400);
+
+        try {
+            await prisma.$transaction(async (tx) => {
+                const attestation = await tx.backgroundCheckAttestation.findUnique({ where: { id } });
+                if (!attestation) throw new NotFoundError();
+
+                await tx.backgroundCheckAttestation.delete({ where: { id } });
+                await tx.auditLog.create({
+                    data: {
+                        actorId: auth.user.id,
+                        action: "DELETE",
+                        tableName: "BackgroundCheckAttestation",
+                        affectedEntityId: id,
+                        secondaryAffectedEntity: attestation.processId,
+                        oldData: {
+                            processId: attestation.processId,
+                            reviewerId: attestation.reviewerId,
+                            subjectPersonId: attestation.subjectPersonId,
+                            result: attestation.result,
+                            note: attestation.note,
+                            isMarkedVolunteer: attestation.isMarkedVolunteer,
+                            createdAt: attestation.createdAt,
+                        },
+                        newData: { reason },
+                    },
+                });
+            });
+            return NextResponse.json({ success: true });
+        } catch (error) {
+            if (error instanceof NotFoundError) return apiError("Attestation not found.", 404);
+            await logBackendError(error, "DELETE /api/membership-ops/bg-attestations/[id]");
+            return apiError("Internal Server Error", 500);
+        }
+    }
+);

--- a/checkin-app/src/security/registry.ts
+++ b/checkin-app/src/security/registry.ts
@@ -359,6 +359,26 @@ defineRoute({
     ],
 });
 
+// Sysadmin-only cleanup path for a BackgroundCheckAttestation the participant-
+// merge route refuses to carry forward: its collision check ("Both attested
+// the same background check", merge/route.ts) means the same human reviewed
+// under two Person identities, and nothing removes the duplicate row today.
+// Sysadmin-only, NOT board — attestations are review artifacts, not a
+// membership decision (#1456 Decision 3). No bag: the response is
+// { success: true }, no model data.
+//
+// Landed registry-first, ahead of the route, per the AGENTS.md boundary-
+// isolation rule: an unused defineRoute is inert, so the grant is reviewable
+// on its own before anything serves it.
+defineRoute({
+    endpoint: 'DELETE /api/membership-ops/bg-attestations/[id]',
+    authorize: { anyRole: ['isSysadmin'] },
+    envelope: null,
+    orderedView: [
+        ['isSysadmin', ['public']],
+    ],
+});
+
 // Background-check reviewers' queue. Reviewers must see applicant parents' names
 // + emails (to look them up on Averity) but NOT internal/personal fields — so the
 // grant is deliberately limited to pii + public. Board members are implicit


### PR DESCRIPTION
## Base branch note
This PR is stacked on `sec/bg-attestation-remove-registry` (#1698, the registry-only PR) so its diff is route-only — the registered `defineRoute()` entry it relies on is inert without this handler. **Retarget this PR to `main` once #1698 merges.**

## Purpose
Part of #1456, Decision 3 (owner accepted the default — see the issue's ruling comment). The participant-merge route refuses to carry forward a `BackgroundCheckAttestation` collision with the message "Both attested the same background check" (`merge/route.ts`, `bgAttestation` collision type) — same human reviewed under two `Person` identities. Until now that refusal was a dead end: attestations are deleted only by `overrideBlocked` in `reset`, and only for a `BLOCKED` process. This PR gives it a cleanup path: `DELETE /api/membership-ops/bg-attestations/[id]`, sysadmin-only, requiring a non-empty `reason`, deleting the row and writing an `AuditLog` entry (`oldData` = the deleted row's fields, `newData` = `{ reason }`).

Sysadmin-only rather than board — attestations are review artifacts, not a membership decision, per the plan's Decision 3.

## Process-status coupling — investigated, deliberately left alone
Checked whether removing an attestation needs to touch `OrgMembershipProcess.status` (`src/lib/membership/review.ts`):
- A `REJECT` attestation moves the process to `BLOCKED` (`attest()`). Deleting that attestation via this endpoint does **not** revert the status — the process stays `BLOCKED` with one fewer attestation behind it.
- The 2nd `APPROVE` triggers `clearBackgroundCheck` (stamps `lastBackgroundCheck`, sets `bgClearedAt`, may activate a membership). Deleting an attestation that contributed to an already-cleared process does **not** unwind any of that — the membership stays activated/cleared.

Per the plan: **do not invent a transition here.** Removing the row and leaving status alone, with the audit trail as the record, is the conservative default — a status reversal has its own side effects (re-notifying reviewers, reopening payment, etc.) that a bare row-delete should not trigger silently. If a removed attestation should ever force a status re-evaluation, that's a separate, deliberate design question — flagging it here rather than answering it in this PR.

## Tests
`src/app/api/membership-ops/bg-attestations/[id]/__tests__/route.integration.test.ts` (real Postgres):
- 400 without a `reason` (row untouched)
- 400 on a non-numeric id
- 404 for an id with no matching row
- success: row gone + `AuditLog` row with `actorId`, `oldData` (the deleted row's fields), `newData.reason`
- end-to-end: reproduces the merge's `bgAttestation` collision (409), deletes the duplicate via this endpoint, confirms the merge then succeeds (200) — the actual scenario this endpoint exists for

401/403 (including a board-member-alone case, since this is sysadmin-only NOT board-or-sysadmin) added to the shared `authzRoleRejection.integration.test.ts` table, plus the route added to `authzRegistry.test.ts`'s `AUTHZ_TESTED` drift guard.

Full unit tier (`npx jest --ci --maxWorkers=12`) and the security/authz integration suites pass; `check-route-coverage --strict` is clean (only the expected pre-existing "unmigrated" warning class, matching the sibling `DELETE /api/attendance/manual/[id]` which also uses `withAuth` + a registry entry rather than `handler()`).

Part of #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URSrfChi89qKn1hLbjaX3K